### PR TITLE
Robustecer normalizeLanguage para rotas localizadas

### DIFF
--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Music, Instagram, Youtube, Music2, MessageCircle, Send } from 'lucide-react';
 import { ARTIST, getWhatsAppUrl } from '../../data/artistData';
-import { buildFullPath, ROUTES_CONFIG, getLocalizedPaths } from '../../config/routes';
+import { buildFullPath, ROUTES_CONFIG, getLocalizedPaths, normalizeLanguage } from '../../config/routes';
 
 declare global {
   interface Window {
@@ -49,8 +49,9 @@ const Footer: React.FC = () => {
       return pathEn === key;
     });
     if (!route) return `/${key}`;
-    const localizedPath = getLocalizedPaths(route, i18n.language as 'en' | 'pt')[0];
-    return buildFullPath(localizedPath, i18n.language as 'en' | 'pt');
+    const normalizedLanguage = normalizeLanguage(i18n.language);
+    const localizedPath = getLocalizedPaths(route, normalizedLanguage)[0];
+    return buildFullPath(localizedPath, normalizedLanguage);
   };
 
   const handleSubscribe = async (e: React.FormEvent) => {
@@ -101,7 +102,7 @@ const Footer: React.FC = () => {
           
           {/* 1. Logo, Bio & Social Icons */}
           <div className="lg:col-span-1">
-            <Link to={buildFullPath('', i18n.language as 'en' | 'pt')} className="flex items-center space-x-2 mb-4 hover:opacity-80 transition-opacity" aria-label="Voltar para Home">
+            <Link to={buildFullPath('', normalizeLanguage(i18n.language))} className="flex items-center space-x-2 mb-4 hover:opacity-80 transition-opacity" aria-label="Voltar para Home">
               <div className="h-10 w-10 flex items-center justify-center rounded-full bg-primary/20">
                 <Music size={20} className="text-primary" />
               </div>

--- a/src/components/common/UserMenu.tsx
+++ b/src/components/common/UserMenu.tsx
@@ -14,7 +14,7 @@ import {
 } from 'lucide-react';
 import { useUser } from '../../contexts/UserContext';
 import { useTranslation } from 'react-i18next';
-import { buildFullPath, ROUTES_CONFIG, getLocalizedPaths } from '../../config/routes';
+import { buildFullPath, ROUTES_CONFIG, getLocalizedPaths, normalizeLanguage } from '../../config/routes';
 
 interface UserMenuProps {
   orientation?: 'horizontal' | 'vertical';
@@ -35,8 +35,9 @@ const UserMenu: React.FC<UserMenuProps> = ({ orientation = 'horizontal' }) => {
       return pathEn === key;
     });
     if (!route) return `/${key}`;
-    const localizedPath = getLocalizedPaths(route, i18n.language as 'en' | 'pt')[0];
-    return buildFullPath(localizedPath, i18n.language as 'en' | 'pt');
+    const normalizedLanguage = normalizeLanguage(i18n.language);
+    const localizedPath = getLocalizedPaths(route, normalizedLanguage)[0];
+    return buildFullPath(localizedPath, normalizedLanguage);
   };
 
   // ✅ FIX 1: O segredo para não travar. 

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -22,6 +22,11 @@ import { matchPath, generatePath } from 'react-router-dom';
 
 export type Language = 'en' | 'pt';
 
+export const normalizeLanguage = (lang: string): Language => {
+  const normalized = lang.trim().toLowerCase();
+  return normalized.startsWith('pt') ? 'pt' : 'en';
+};
+
 export interface RouteConfig {
   /** Componente da página (lazy loaded) */
   component: ComponentType;

--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -10,7 +10,7 @@ import { ARTIST, getWhatsAppUrl } from '../data/artistData';
 import { Event, Testimonial, FlyerData } from '../types';
 import { EventsList } from '../components/EventsList';
 import { useParams, Link } from 'react-router-dom';
-import { buildFullPath, ROUTES_CONFIG, getLocalizedPaths } from '../config/routes';
+import { buildFullPath, ROUTES_CONFIG, getLocalizedPaths, normalizeLanguage } from '../config/routes';
 import { 
   Calendar as CalendarIcon,
   MapPin,
@@ -42,7 +42,8 @@ const EventsPage: React.FC = () => {
   const getRouteForKey = (key: string): string => {
     const route = ROUTES_CONFIG.find(r => getLocalizedPaths(r, 'en')[0] === key);
     if (!route) return `/${key}`;
-    return buildFullPath(getLocalizedPaths(route, i18n.language as 'en' | 'pt')[0], i18n.language as 'en' | 'pt');
+    const normalizedLanguage = normalizeLanguage(i18n.language);
+    return buildFullPath(getLocalizedPaths(route, normalizedLanguage)[0], normalizedLanguage);
   };
 
   useEffect(() => {

--- a/src/pages/MusicPage.tsx
+++ b/src/pages/MusicPage.tsx
@@ -7,7 +7,7 @@ import { getHreflangUrls } from '../utils/seo';
 import { Download, Music2, Filter, Youtube, Cloud, Play, ArrowLeft } from 'lucide-react';
 import { useTracksQuery } from '../hooks/useQueries';
 import { useParams, Link } from 'react-router-dom';
-import { buildFullPath, ROUTES_CONFIG, getLocalizedPaths } from '../config/routes';
+import { buildFullPath, ROUTES_CONFIG, getLocalizedPaths, normalizeLanguage } from '../config/routes';
 
 const MusicPage: React.FC = () => {
   const { slug } = useParams<{ slug?: string }>();
@@ -20,7 +20,8 @@ const MusicPage: React.FC = () => {
   const getRouteForKey = (key: string): string => {
     const route = ROUTES_CONFIG.find(r => getLocalizedPaths(r, 'en')[0] === key);
     if (!route) return `/${key}`;
-    return buildFullPath(getLocalizedPaths(route, i18n.language as 'en' | 'pt')[0], i18n.language as 'en' | 'pt');
+    const normalizedLanguage = normalizeLanguage(i18n.language);
+    return buildFullPath(getLocalizedPaths(route, normalizedLanguage)[0], normalizedLanguage);
   };
 
   // Encontra faixa específica se houver slug

--- a/src/pages/NewsPage.tsx
+++ b/src/pages/NewsPage.tsx
@@ -4,7 +4,7 @@ import { HeadlessSEO } from '../components/HeadlessSEO';
 import { Calendar, Clock, ArrowRight, TrendingUp, Hash, ArrowLeft } from 'lucide-react';
 import { Link, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { buildFullPath, ROUTES_CONFIG, getLocalizedPaths } from '../config/routes';
+import { buildFullPath, ROUTES_CONFIG, getLocalizedPaths, normalizeLanguage } from '../config/routes';
 
 // ============================================================================
 // TYPES
@@ -52,7 +52,8 @@ const NewsPage: React.FC = () => {
   const getRouteForKey = (key: string): string => {
     const route = ROUTES_CONFIG.find(r => getLocalizedPaths(r, 'en')[0] === key);
     if (!route) return `/${key}`;
-    return buildFullPath(getLocalizedPaths(route, i18n.language as 'en' | 'pt')[0], i18n.language as 'en' | 'pt');
+    const normalizedLanguage = normalizeLanguage(i18n.language);
+    return buildFullPath(getLocalizedPaths(route, normalizedLanguage)[0], normalizedLanguage);
   };
 
   // Busca conteúdo (lista ou post único)


### PR DESCRIPTION
### Motivation
- `i18n.language` pode vir com tags regionais, espaços ou variação de caixa (ex.: `pt-BR`, ` PT-br `), o que quebrava a inferência direta para `'en' | 'pt'`. 
- Centralizar e endurecer a normalização reduz risco de rotas quebradas e duplicação de lógica pela app. 
- É necessário garantir que todas as helpers que constroem URLs usem a versão normalizada para comportamento consistente. 

### Description
- Atualiza `normalizeLanguage` em `src/config/routes.ts` para usar `lang.trim().toLowerCase()` e então decidir entre `'pt'` ou `'en'`. 
- Substitui castings diretos de `i18n.language as 'en' | 'pt'` por `normalizeLanguage(i18n.language)` nos helpers de rota em `Footer.tsx`, `UserMenu.tsx`, `EventsPage.tsx`, `MusicPage.tsx` e `NewsPage.tsx`. 
- Ajusta o `Link` de Home no `Footer` para usar `buildFullPath('', normalizeLanguage(i18n.language))` garantindo que o root respeite a linguagem normalizada. 
- Mudanças focadas apenas na lógica de normalização e uso uniforme do helper exportado. 

### Testing
- Nenhum teste automatizado foi executado como parte dessa alteração.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69787caa0504832f836b0a43a4a24a2f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Melhorada a normalização de idioma ao resolver rotas para localização, garantindo consistência no tratamento de valores de idioma em todo o aplicativo.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->