### PR TITLE
⚡ Bolt: Optimize Products API Payload

### DIFF
--- a/inc/api.php
+++ b/inc/api.php
@@ -211,7 +211,8 @@ function djz_get_products($request) {
                 'stock_status' => $product->get_stock_status(),
                 'images' => $images,
                 'short_description' => $product->get_short_description(),
-                'description' => $product->get_description(),
+                // OPTIMIZATION: Only include full description for single product requests
+                'description' => !empty($slug) ? $product->get_description() : '',
                 'permalink' => get_permalink($id),
                 'categories' => array_map(function($term) {
                     return [


### PR DESCRIPTION
Excludes the heavy `description` field from the product list API endpoint (`djzeneyer/v1/products`), returning it only when a specific product `slug` is requested. This reduces payload size for the Shop and Tickets pages which do not use this field. The field is returned as an empty string in list mode to avoid breaking changes to the schema.

---
*PR created automatically by Jules for task [10020850675054208858](https://jules.google.com/task/10020850675054208858) started by @MarceloEyer*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correções de Bugs**
  * Otimização na API de produtos: o campo de descrição agora é incluído apenas ao consultar um produto individual, mantendo vazio em listagens para melhor desempenho.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->