### PR TITLE
Centralizar rotas em SSOT `scripts/routes-config.json` e atualizar prerender/sitemap/CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -126,11 +126,11 @@ jobs:
           echo ""
           echo "📊 Validating prerendered files:"
           
-          # ⚠️ REMOVI O /shop DA LISTA PARA NÃO FALHAR O BUILD
-          ROUTES=("/" "/events" "/music" "/about" "/zentribe")
+          # 🔁 SSOT: carregar rotas do JSON via Node (string com espaços)
+          ROUTES=$(node -p "require('./scripts/routes-config.json').routes.join(' ')")
           FAILED=0
           
-          for route in "${ROUTES[@]}"; do
+          for route in $ROUTES; do
             if [ "$route" = "/" ]; then
               FILE="dist/index.html"
             else

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -13,15 +13,16 @@ const __dirname = path.dirname(__filename);
 
 const BASE_URL = 'https://djzeneyer.com';
 const PUBLIC_DIR = path.resolve(__dirname, '../public');
-const ROUTES_DATA = path.resolve(__dirname, 'routes-data.json');
+const ROUTES_DATA = path.resolve(__dirname, 'routes-config.json');
 
 console.log('🗺️  Sitemap Generator v7.0 - SIMPLIFIED\n');
 
-function buildUrlEntry(enPath, ptPath, date) {
-  const enUrl = enPath === '' ? `${BASE_URL}/` : `${BASE_URL}/${enPath}`;
-  const ptUrl = ptPath === '' ? `${BASE_URL}/pt/` : `${BASE_URL}/pt/${ptPath}`;
+function buildUrlEntry(route, date) {
+  const cleanPath = route === '/' ? '' : route.replace(/^\/+/, '');
+  const enUrl = cleanPath === '' ? `${BASE_URL}/` : `${BASE_URL}/${cleanPath}`;
+  const ptUrl = cleanPath === '' ? `${BASE_URL}/pt/` : `${BASE_URL}/pt/${cleanPath}`;
 
-  const priority = enPath === '' ? '1.0' : '0.8';
+  const priority = cleanPath === '' ? '1.0' : '0.8';
 
   return `
   <url>
@@ -45,7 +46,7 @@ function generateSitemaps() {
     let urlCount = 0;
 
     for (const route of routesData.routes) {
-      pagesXml += buildUrlEntry(route.en, route.pt, date);
+      pagesXml += buildUrlEntry(route, date);
       urlCount++;
     }
 

--- a/scripts/prerender.js
+++ b/scripts/prerender.js
@@ -5,13 +5,16 @@
  */
 
 import { spawn } from 'child_process';
-import { writeFileSync, existsSync, mkdirSync } from 'fs';
+import { writeFileSync, existsSync, mkdirSync, readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import puppeteer from 'puppeteer';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+
+const ROUTES_CONFIG_PATH = join(__dirname, 'routes-config.json');
+const routesConfig = JSON.parse(readFileSync(ROUTES_CONFIG_PATH, 'utf8'));
 
 // =============================
 // CONFIGURAÇÃO
@@ -23,35 +26,8 @@ const CONFIG = {
   timeout: 60000, 
   waitForSelector: '#root',
   
-  // LISTA DE ROTAS ATUALIZADA (Incluindo Music e ZenTribe)
-  routes: [
-    '/',
-    '/about',
-    '/events',
-    '/music',      // <--- ADICIONADO (Essencial para validação)
-    '/zentribe',   // <--- ADICIONADO (Essencial para validação)
-    '/classes',
-    '/shop',
-    '/contact',
-    '/blog',
-    '/login',
-    '/register',
-    '/dashboard',
-    '/workshops',
-    '/private-lessons',
-    '/festival-prep',
-    '/demo-program',
-    '/team',
-    '/media',
-    '/testimonials',
-    '/faq',
-    '/privacy',
-    '/terms',
-    '/sitemap',
-    '/thank-you',
-    '/gamification',
-    '/profile'
-  ]
+  // LISTA DE ROTAS ATUALIZADA (SSOT via JSON)
+  routes: routesConfig.routes
 };
 
 console.log('╔═══════════════════════════════════════════════════════╗');

--- a/scripts/routes-config.json
+++ b/scripts/routes-config.json
@@ -1,0 +1,28 @@
+{
+  "routes": [
+    "/",
+    "/about",
+    "/events",
+    "/music",
+    "/news",
+    "/zentribe",
+    "/tribe",
+    "/zen-tribe",
+    "/work-with-me",
+    "/shop",
+    "/cart",
+    "/checkout",
+    "/tickets",
+    "/tickets-checkout",
+    "/dashboard",
+    "/my-account",
+    "/faq",
+    "/my-philosophy",
+    "/media",
+    "/support-the-artist",
+    "/privacy-policy",
+    "/return-policy",
+    "/terms",
+    "/conduct"
+  ]
+}


### PR DESCRIPTION
### Motivation
- Centralizar a lista de rotas estáticas em um único local para evitar divergência entre prerender, sitemap e validação do CI. 
- Garantir que todos os scripts consumam a mesma fonte de verdade para reduzir erros em build e deploy.

### Description
- Adicionado `scripts/routes-config.json` contendo a lista canônica de rotas estáticas (incluindo `/music`, `/zentribe`, `/shop`, etc.).
- Atualizado `scripts/prerender.js` para carregar as rotas via `readFileSync` do JSON e manter a lógica de polling e estrutura de diretórios existente. 
- Atualizado `scripts/generate-sitemap.js` para ler `scripts/routes-config.json` e adaptar a geração de URLs para os caminhos do JSON. 
- Atualizado `.github/workflows/deploy.yml` na etapa de validação para usar a one-liner Node `ROUTES=$(node -p "require('./scripts/routes-config.json').routes.join(' ')")` e iterar em Bash com `for route in $ROUTES; do` em vez de arrays hardcoded.

### Testing
- Nenhum teste automatizado foi executado como parte deste PR; recomenda-se executar o job de CI (incluindo a etapa `🎨 Prerender pages (SSG)`) para validar a integração completa entre prerender, sitemap e validação do deploy.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697aac6fb418832f86cf8d7595f014c4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Tarefas**
  * Otimização da configuração de rotas: as rotas agora são carregadas dinamicamente de um arquivo de configuração centralizado, em vez de estarem codificadas em múltiplos locais. Esta mudança melhora a manutenibilidade e facilita atualizações futuras.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->