### PR TITLE
⚡ Bolt: Optimize Product API Payload & Fix Loop Bug

### DIFF
--- a/inc/api.php
+++ b/inc/api.php
@@ -163,6 +163,7 @@ function djz_get_products($request) {
         }
 
         foreach ($product_objects as $product) {
+            $id = $product->get_id(); // Fix: Update ID for current loop iteration
             $images = [];
             $img_ids = $product->get_gallery_image_ids();
             
@@ -211,7 +212,7 @@ function djz_get_products($request) {
                 'stock_status' => $product->get_stock_status(),
                 'images' => $images,
                 'short_description' => $product->get_short_description(),
-                'description' => $product->get_description(),
+                'description' => !empty($slug) ? $product->get_description() : '', // Optimization: Only return description for single view
                 'permalink' => get_permalink($id),
                 'categories' => array_map(function($term) {
                     return [


### PR DESCRIPTION
This PR addresses a critical correctness bug and a performance optimization in the `djz_get_products` REST API endpoint (`inc/api.php`).

### 🐛 Bug Fix: Variable Scoping
In the original code, the `$id` variable was defined in a preceding `while` loop but was reused in a subsequent `foreach` loop without being updated. In PHP, variables leak from loop scopes. This caused the `foreach` loop to use the stale `$id` (from the last iteration of the `while` loop) for all products when calling `wp_get_post_terms($id)` and `get_permalink($id)`.
**Fix:** Explicitly updated `$id = $product->get_id()` at the start of the `foreach` loop.

### ⚡ Performance: Payload Optimization
The `description` field contains the full HTML description of a product. Previously, this was returned for every product in the list view (e.g., 100 items), significantly inflating the JSON payload size.
**Optimization:** Wrapped the `description` assignment in a conditional check `!empty($slug)`.
- **List View:** `description` is returned as an empty string.
- **Single Product View:** (identified by the presence of a slug) `description` is fully populated.

### 🔬 Verification
- **Correctness:** Created a reproduction script `verification/verify_api_logic.php` which confirmed the variable leakage behavior in the original code and verified the fix.
- **Scoping:** Verified via `verification/verify_scope.php` that `$slug` (function argument) is correctly visible inside the loop scope in PHP, addressing review concerns.
- **Syntax:** Ran `php -l inc/api.php` to ensure no syntax errors were introduced.

---
*PR created automatically by Jules for task [6249367356408966367](https://jules.google.com/task/6249367356408966367) started by @MarceloEyer*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Correções de Erros**
  * Corrigida a captura de identificadores ao processar múltiplos produtos para garantir que o ID atual seja usado.
  * Ajustado o campo de descrição na API: mostra a descrição completa ao visualizar um produto individual (slug presente) e retorna vazio ao listar produtos.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->