### PR TITLE
Atualizar i18n do hero da HomePage

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -125,9 +125,11 @@
   "hero_cta": "Listen Now",
   "hero_cta_secondary": "View Events",
 
-  "home_hero_badge": "2× World Champion - Brazilian Zouk World Championships",
+  "home_hero_badge": "2× World Champion - Zouk World Championships",
   "home_hero_title": "DJ Zen Eyer",
   "home_hero_subtitle": "2× World Champion Brazilian Zouk DJ & Producer",
+  "home_hero_slogan": "Haste is the enemy of creaminess ™",
+  "home_hero_cta_text": "Full sets and exclusive remixes. Check <0>Events</0> for schedule. Head to <1>Work With Me</1> for bookings.",
   "home_stat_champion": "World Champion",
   "home_stat_countries": "Countries",
   "home_stat_events": "Events",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -130,9 +130,11 @@
   "hero_cta": "Ouvir Agora",
   "hero_cta_secondary": "Ver Eventos",
 
-  "home_hero_badge": "2× Campeão Mundial - Brazilian Zouk World Championships",
+  "home_hero_badge": "Bicampeão Mundial - Zouk World Championships",
   "home_hero_title": "DJ Zen Eyer",
   "home_hero_subtitle": "Bicampeão Mundial de Zouk Brasileiro",
+  "home_hero_slogan": "A pressa é inimiga da cremosidade ™",
+  "home_hero_cta_text": "Sets completos e remixes exclusivos. Para agenda, vá para <0>Eventos</0>. Para bookings, acesse <1>Trabalhe Comigo</1>.",
   "home_stat_champion": "Campeão Mundial",
   "home_stat_countries": "Países",
   "home_stat_events": "Eventos",

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -4,7 +4,7 @@
 import React, { useMemo, useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { motion, Variants } from 'framer-motion';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import {
   PlayCircle, Calendar, Users, Music, Award, Trophy,
   Globe, Mail, ExternalLink, Sparkles, Download
@@ -258,7 +258,7 @@ const HomePage: React.FC = () => {
             <motion.div variants={ITEM_VARIANTS} className="mb-6">
               <div className="inline-flex items-center gap-2 px-4 py-2 bg-primary/20 border border-primary/30 rounded-full text-primary text-sm font-medium backdrop-blur-sm">
                 <Trophy size={16} />
-                <span className="font-semibold">2× World Champion - Zouk World Championships</span>
+                <span className="font-semibold">{t('home_hero_badge')}</span>
               </div>
             </motion.div>
 
@@ -267,11 +267,11 @@ const HomePage: React.FC = () => {
             </motion.h1>
 
             <motion.p variants={ITEM_VARIANTS} className="text-xl md:text-2xl text-white/90 mb-2 font-light">
-              {isPortuguese ? 'Bicampeão Mundial de Zouk Brasileiro' : '2× World Champion Brazilian Zouk DJ & Producer'}
+              {t('home_hero_subtitle')}
             </motion.p>
 
             <motion.p variants={ITEM_VARIANTS} className="text-lg md:text-xl italic text-primary/90 mb-8">
-              "{ARTIST.philosophy.slogan}" ™
+              "{t('home_hero_slogan')}"
             </motion.p>
 
             <motion.div variants={ITEM_VARIANTS} className="grid grid-cols-1 md:grid-cols-3 gap-4 max-w-xl mx-auto mb-10">
@@ -287,7 +287,7 @@ const HomePage: React.FC = () => {
                 aria-label="Listen to DJ Zen Eyer on SoundCloud"
               >
                 <PlayCircle size={22} />
-                <span>{isPortuguese ? 'Ouvir no SoundCloud' : 'Listen on SoundCloud'}</span>
+                <span>{t('home_cta_soundcloud')}</span>
               </a>
               <Link
                 to={isPortuguese ? '/pt/contrate' : '/work-with-me'}
@@ -295,14 +295,18 @@ const HomePage: React.FC = () => {
                 aria-label="Book DJ Zen Eyer or Get Press Kit"
               >
                 <Mail size={22} />
-                <span>{isPortuguese ? 'Contrate / Press Kit' : 'Booking / Press Kit'}</span>
+                <span>{t('home_cta_booking')}</span>
               </Link>
             </motion.div>
 
             <motion.p variants={ITEM_VARIANTS} className="text-sm md:text-base text-white/60 max-w-2xl mx-auto leading-relaxed">
-              {isPortuguese
-                ? 'Sets completos e remixes exclusivos. Para agenda, vá para Events. Para bookings, acesse Work With Me.'
-                : 'Full sets and exclusive remixes. Check Events for schedule. Head to Work With Me for bookings.'}
+              <Trans
+                i18nKey="home_hero_cta_text"
+                components={[
+                  <Link key="events-link" to="/events/" className="text-primary hover:text-primary/80 underline underline-offset-4" />,
+                  <Link key="work-with-me-link" to={isPortuguese ? '/pt/contrate' : '/work-with-me'} className="text-primary hover:text-primary/80 underline underline-offset-4" />
+                ]}
+              />
             </motion.p>
           </motion.div>
         </div>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -303,7 +303,11 @@ const HomePage: React.FC = () => {
               <Trans
                 i18nKey="home_hero_cta_text"
                 components={[
-                  <Link key="events-link" to="/events/" className="text-primary hover:text-primary/80 underline underline-offset-4" />,
+                  <Link
+                    key="events-link"
+                    to={isPortuguese ? '/pt/eventos/' : '/events/'}
+                    className="text-primary hover:text-primary/80 underline underline-offset-4"
+                  />,
                   <Link key="work-with-me-link" to={isPortuguese ? '/pt/contrate' : '/work-with-me'} className="text-primary hover:text-primary/80 underline underline-offset-4" />
                 ]}
               />


### PR DESCRIPTION
### Motivation
- Corrigir strings do hero que estavam fixas em inglês ou com tradução faltante (slogan, badge, subtítulo e CTAs) para suportar PT/EN via i18n.
- Localizar links e textos do CTA para que apareçam como "Eventos" / "Trabalhe Comigo" em PT e mantenham os termos aceitos em BR (como "Sets" e "Press Kit").

### Description
- Substituído texto hard-coded no `src/pages/HomePage.tsx` por chamadas i18n: `t('home_hero_badge')`, `t('home_hero_subtitle')`, `t('home_cta_soundcloud')`, `t('home_cta_booking')` e uso de `Trans` para o parágrafo com links localizados.
- Importado `Trans` de `react-i18next` e ajustados os links para usar o `isPortuguese` para gerar a rota correta (`/pt/contrate` vs `/work-with-me`).
- Adicionadas/atualizadas chaves de tradução em `src/locales/en/translation.json` e `src/locales/pt/translation.json`: `home_hero_slogan`, `home_hero_cta_text`, e ajustes em `home_hero_badge`/`home_hero_subtitle` conforme solicitado.
- Mantidas as expressões solicitadas (por exemplo, manter "Sets" e "Press Kit") e aplicado `Trans` para renderizar os links estilizados dentro da string localizada.

### Testing
- Subiu o servidor de desenvolvimento com `npm run dev` e o servidor respondeu com sucesso (Vite ready and listening).
- Captura de tela do hero foi gerada via um script Playwright usando Firefox com sucesso e o artefato foi produzido (`artifacts/homepage-hero.png`).
- Tentativa de executar Playwright com Chromium falhou devido a crash do binário do navegador, portanto esse run específico falhou com erro de processo (não blocking para as mudanças de i18n).
- Não foram executados testes unitários automatizados adicionais para este ajuste de conteúdo/i18n.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b586d42fc832fba2dfceb4295eeb6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localização**
  * Atualizados textos do selo de campeão em inglês e português.
  * Adicionados novo slogan e texto de chamada para ação na seção inicial, com suporte a links embutidos.
* **Interface**
  * Centralização das strings da hero para i18n, permitindo composição de CTA com elementos inline.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->