### PR TITLE
Sincroniza react-i18next para 16.5.1 e atualiza package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-helmet-async": "^2.0.5",
-        "react-i18next": "^16.4.0",
+        "react-i18next": "^16.5.1",
         "react-router-dom": "^7.0.0",
         "react-youtube": "^10.1.0"
       },
@@ -6225,8 +6225,8 @@
       }
     },
     "node_modules/react-i18next": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.5.0.tgz",
+      "version": "16.5.1",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.5.1.tgz",
       "integrity": "sha512-IMpPTyCTKxEj8klCrLKUTIUa8uYTd851+jcu2fJuUB9Agkk9Qq8asw4omyeHVnOXHrLgQJGTm5zTvn8HpaPiqw==",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-helmet-async": "^2.0.5",
-    "react-i18next": "^16.4.0",
+    "react-i18next": "^16.5.1",
     "react-router-dom": "^7.0.0",
     "react-youtube": "^10.1.0"
   },


### PR DESCRIPTION
### Motivation
- 🔧 Corrigir divergência entre `package.json` e `package-lock.json` após o bump de `react-i18next`, evitando que `npm ci` quebre por versões desalinhadas.

### Description
- ♻️ Atualizados `package.json` (dependência `react-i18next` para `^16.5.1`) e `package-lock.json` (entrada `node_modules/react-i18next` para `16.5.1` e URL resolvida) para manter o manifest e o lockfile sincronizados.

### Testing
- ⚠️ Tentativa de instalar com `npm install react-i18next@16.5.1` falhou com `403 Forbidden` devido a bloqueio de acesso ao registry, então não foi possível executar `npm ci` nem outras validações automáticas no ambiente atual.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69791eb5a008832fb2d9c3d7f7ca8e33)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Dependências do projeto atualizadas para melhorias gerais de compatibilidade e desempenho.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->