### PR TITLE
⚡ Bolt: Optimize MusicPage data fetching and fix field access

### DIFF
--- a/inc/cpt.php
+++ b/inc/cpt.php
@@ -97,4 +97,11 @@ add_action('rest_api_init', function() {
             return $src ? $src[0] : wp_get_attachment_url($img_id);
         },
     ]);
+
+    register_rest_field('remixes', 'featured_image_src_full', [
+        'get_callback' => function($object) {
+            $img_id = get_post_thumbnail_id($object['id']);
+            return $img_id ? wp_get_attachment_url($img_id) : null;
+        },
+    ]);
 });

--- a/src/hooks/useQueries.ts
+++ b/src/hooks/useQueries.ts
@@ -55,7 +55,10 @@ export interface MusicTrack {
     youtube: string;
   };
   featured_image_src?: string | null;
-    slug: string;
+  featured_image_src_full?: string | null;
+  slug: string;
+  content?: { rendered: string };
+  excerpt?: { rendered: string };
 }
 
 // ============================================================================
@@ -100,14 +103,14 @@ export const useEventsQuery = (limit = 10) => {
 // TRACKS QUERY (PÚBLICO)
 // ============================================================================
 
-export const useTracksQuery = () => {
+export const useTracksQuery = (options: { enabled?: boolean } = {}) => {
   return useQuery({
     queryKey: QUERY_KEYS.tracks.list(),
     queryFn: async (): Promise<MusicTrack[]> => {
       const apiUrl = buildApiUrl('wp/v2/remixes', {
         per_page: '100',
         // OPTIMIZATION: Limit fields to reduce payload size
-        _fields: 'id,title,category_name,tag_names,links,featured_image_src',
+        _fields: 'id,title,category_name,tag_names,links,featured_image_src,slug',
       });
       const res = await fetch(apiUrl);
       if (!res.ok) throw new Error('Failed to fetch tracks');
@@ -116,6 +119,26 @@ export const useTracksQuery = () => {
     },
     staleTime: STALE_TIME.TRACKS,
     gcTime: 15 * 60 * 1000,
+    ...options,
+  });
+};
+
+export const useTrackBySlug = (slug?: string) => {
+  return useQuery({
+    queryKey: ['tracks', slug],
+    queryFn: async (): Promise<MusicTrack | null> => {
+      if (!slug) return null;
+      const apiUrl = buildApiUrl('wp/v2/remixes', {
+        slug,
+        _fields: 'id,title,content,excerpt,links,featured_image_src_full,slug',
+      });
+      const res = await fetch(apiUrl);
+      if (!res.ok) throw new Error('Failed to fetch track');
+      const data = await res.json();
+      return Array.isArray(data) && data.length > 0 ? data[0] : null;
+    },
+    enabled: !!slug,
+    staleTime: STALE_TIME.TRACKS,
   });
 };
 

--- a/src/hooks/useQueries.ts
+++ b/src/hooks/useQueries.ts
@@ -125,7 +125,7 @@ export const useTracksQuery = (options: { enabled?: boolean } = {}) => {
 
 export const useTrackBySlug = (slug?: string) => {
   return useQuery({
-    queryKey: ['tracks', slug],
+    queryKey: ['tracks', 'detail', slug],
     queryFn: async (): Promise<MusicTrack | null> => {
       if (!slug) return null;
       const apiUrl = buildApiUrl('wp/v2/remixes', {

--- a/src/pages/MusicPage.tsx
+++ b/src/pages/MusicPage.tsx
@@ -94,8 +94,8 @@ const MusicPage: React.FC = () => {
   }
 
   // --- RENDERIZAÇÃO DA LISTA (Original logic maintained with i18n links) ---
-  const tags = ['Todos', ...new Set(listTracks.flatMap((t: any) => t.tag_names || []))];
-  const filteredTracks = listTracks.filter((track: any) => {
+  const tags = ['Todos', ...new Set(listTracks.flatMap((t: MusicTrack) => t.tag_names || []))];
+  const filteredTracks = listTracks.filter((track: MusicTrack) => {
     const matchesTag = activeTag === 'Todos' || track.tag_names?.includes(activeTag);
     const matchesSearch = track.title.rendered.toLowerCase().includes(searchQuery.toLowerCase());
     return matchesTag && matchesSearch;


### PR DESCRIPTION
*   💡 What:
    *   Added `featured_image_src_full` to `inc/cpt.php`.
    *   Updated `useTracksQuery` to include `slug` and allow conditional fetching.
    *   Added `useTrackBySlug` hook.
    *   Refactored `MusicPage.tsx` to use conditional fetching (split query) and correct field names.
*   🎯 Why: To prevent over-fetching list data when viewing a single track, avoid `_embed` overhead, and fix broken images/links due to missing fields.
*   📊 Impact: Reduces payload size for detail views significantly (O(1) vs O(N)) and fixes broken UI.
*   🔬 Measurement: Check network tab on detail view; should only fetch one track. Check list view images; should be visible.

---
*PR created automatically by Jules for task [14339064086741827863](https://jules.google.com/task/14339064086741827863) started by @MarceloEyer*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notas de Lançamento

* **New Features**
  * Imagens das faixas disponíveis em tamanho completo.
  * Pesquisa/visualização de faixa por identificador (slug) para exibir detalhes individuais.
  * Exibição de conteúdo completo e resumo das faixas.
  * Botões/links do SoundCloud exibidos quando presentes.

* **Chores**
  * Melhoria no carregamento condicional entre lista e detalhe para respostas mais rápidas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->