### PR TITLE
Atualiza título do herói para 'Zen Eyer' em cor primária

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -265,7 +265,7 @@ const HomePage: React.FC = () => {
             </motion.div>
 
             <motion.h1 variants={ITEM_VARIANTS} className="text-5xl md:text-7xl lg:text-8xl font-bold font-display text-primary mb-4 tracking-tight">
-              Zen Eyer
+              {ARTIST.identity.displayTitle}
             </motion.h1>
 
             <motion.p variants={ITEM_VARIANTS} className="text-xl md:text-2xl text-white/90 mb-2 font-light">

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -264,8 +264,8 @@ const HomePage: React.FC = () => {
               </div>
             </motion.div>
 
-            <motion.h1 variants={ITEM_VARIANTS} className="text-5xl md:text-7xl lg:text-8xl font-bold font-display text-white mb-4 tracking-tight">
-              DJ Zen Eyer
+            <motion.h1 variants={ITEM_VARIANTS} className="text-5xl md:text-7xl lg:text-8xl font-bold font-display text-primary mb-4 tracking-tight">
+              Zen Eyer
             </motion.h1>
 
             <motion.p variants={ITEM_VARIANTS} className="text-xl md:text-2xl text-white/90 mb-2 font-light">


### PR DESCRIPTION
### Motivation
- Alinhar a identidade visual do site removendo o prefixo “DJ” no título principal da home e aplicando a cor primária (azul) usada no restante do site. 🎨

### Description
- Substitui o `h1` do herói de `DJ Zen Eyer` para `Zen Eyer` e altera a classe `text-white` para `text-primary` em `src/pages/HomePage.tsx` para usar o azul padrão do tema.

### Testing
- Rodei o servidor de desenvolvimento com `npm run dev` e capturei uma verificação visual com Playwright (screenshot), ambos executaram com sucesso e confirmaram a alteração visual no herói.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987667f54c0832fbeb0696f2884ac82)