### PR TITLE
⚡ Bolt: Fix N+1 queries in Gamipress user data endpoint

### DIFF
--- a/inc/api.php
+++ b/inc/api.php
@@ -376,23 +376,30 @@ function djz_get_gamipress_user_data($request) {
 
                 // Batch prime caches for achievement images to prevent N+1 queries
                 $all_img_ids = [];
+                $post_thumbnail_map = [];
+
                 foreach ($posts as $post) {
-                    $tid = get_post_thumbnail_id($post->ID);
-                    if ($tid) {
-                        $all_img_ids[] = $tid;
+                    $thumbnail_id = get_post_thumbnail_id($post->ID);
+                    if ($thumbnail_id) {
+                        $all_img_ids[] = $thumbnail_id;
+                        $post_thumbnail_map[$post->ID] = $thumbnail_id;
                     }
                 }
 
                 if (!empty($all_img_ids)) {
                     $all_img_ids = array_unique($all_img_ids);
                     update_meta_cache('post', $all_img_ids);
+                    // _prime_post_caches is an internal WP function (since 3.4) that efficiently
+                    // primes the object cache for a list of post IDs. We use it here to avoid
+                    // N+1 queries when wp_get_attachment_url() requests the attachment post object.
+                    // If it's not available (highly unlikely in WP), we simply skip this optimization step.
                     if (function_exists('_prime_post_caches')) {
                         _prime_post_caches($all_img_ids, false, false);
                     }
                 }
 
                 foreach ($posts as $post) {
-                    $img_id = get_post_thumbnail_id($post->ID);
+                    $img_id = $post_thumbnail_map[$post->ID] ?? 0;
                     $img_url = $img_id ? wp_get_attachment_url($img_id) : '';
 
                     // Cleanup content

--- a/inc/api.php
+++ b/inc/api.php
@@ -374,6 +374,23 @@ function djz_get_gamipress_user_data($request) {
                     'numberposts' => -1,
                 ]);
 
+                // Batch prime caches for achievement images to prevent N+1 queries
+                $all_img_ids = [];
+                foreach ($posts as $post) {
+                    $tid = get_post_thumbnail_id($post->ID);
+                    if ($tid) {
+                        $all_img_ids[] = $tid;
+                    }
+                }
+
+                if (!empty($all_img_ids)) {
+                    $all_img_ids = array_unique($all_img_ids);
+                    update_meta_cache('post', $all_img_ids);
+                    if (function_exists('_prime_post_caches')) {
+                        _prime_post_caches($all_img_ids, false, false);
+                    }
+                }
+
                 foreach ($posts as $post) {
                     $img_id = get_post_thumbnail_id($post->ID);
                     $img_url = $img_id ? wp_get_attachment_url($img_id) : '';


### PR DESCRIPTION
💡 What: Added batch cache priming for achievement images in `djz_get_gamipress_user_data` (inc/api.php).
🎯 Why: The previous implementation triggered a separate database query (`wp_get_attachment_url`) for every achievement's image, causing an N+1 performance bottleneck.
📊 Impact: Reduces database queries for image retrieval from N (number of achievements) to 1 constant query, significantly improving response time for users with many achievements.
🔬 Measurement: Verify by inspecting `inc/api.php` and confirming the batch priming logic exists before the loop.

---
*PR created automatically by Jules for task [11556420065647731534](https://jules.google.com/task/11556420065647731534) started by @MarceloEyer*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Melhorias de Performance**
  * Otimização do cache de imagens de conquistas: carregamento em lote e eliminação de buscas redundantes, resultando em carregamento mais rápido das páginas de conquistas e menor latência na exibição de miniaturas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->