### PR TITLE
ci: corrigir flag inválida do Composer no workflow de deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -119,12 +119,14 @@ jobs:
             for dir in plugins/*/; do
               if [ -f "$dir/composer.json" ]; then
                 cd "$dir"
-                # ⚠️ CI hardening note:
-                # Composer 2.9+ now blocks packages flagged by Packagist security advisories.
+                # ⚠️ CI hardening note (do not "optimize" this without validation):
+                # Composer 2.9+ can block packages flagged by Packagist security advisories.
                 # Our auth plugin depends on firebase/php-jwt and Packagist currently marks all 6.x
                 # as blocked (PKSA-y2cr-5h3j-g3ys), which would break every deploy even when app build passes.
-                # Keep --no-security-blocking and --no-audit in CI until upstream advisory constraints are fixed.
-                composer install --no-dev --optimize-autoloader --ignore-platform-reqs --no-interaction --no-security-blocking --no-audit
+                # IMPORTANT: keep --no-security-blocking until the advisory constraints are fixed.
+                # IMPORTANT: NEVER add --no-audit here; this option is not available in composer install
+                # and causes the pipeline to fail with: "The \"--no-audit\" option does not exist."
+                composer install --no-dev --optimize-autoloader --ignore-platform-reqs --no-interaction --no-security-blocking
                 rm -rf tests/ .git/ .github/ .gitignore
                 cd - > /dev/null
               fi


### PR DESCRIPTION
## **User description**
### Motivation
- Corrigir falha no CI causada pela opção inválida `--no-audit` passada para `composer install`, que interrompia a etapa de build de plugins.

### Description
- Removida a flag `--no-audit` em `.github/workflows/deploy.yml` e adicionados comentários explicativos fortes para evitar que a opção seja reintroduzida; `--no-security-blocking` foi mantida conforme contexto do advisory.

### Testing
- Verificações automáticas realizadas: `rg -n "no-audit|Building plugins|composer install" .github -S`, `nl -ba .github/workflows/deploy.yml | sed -n '116,132p'` e `git diff -- .github/workflows/deploy.yml`, todas confirmaram a remoção de `--no-audit` e a presença dos comentários e flags esperadas (sucesso).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996c9ad3da0832fa0cb9e1d622aef88)


___

## **CodeAnt-AI Description**
Fix deploy CI: remove invalid Composer flag and clarify plugin build behavior

### What Changed
- Removed the invalid Composer option that caused the deploy pipeline to fail; plugin builds now use a valid install command.
- Kept the non-blocking security flag so plugin installation continues when Packagist advisories are present, preventing spurious build breaks.
- Added clear comments in the deploy workflow explaining why the flags are set and warning not to reintroduce the removed option.

### Impact
`✅ Prevent CI deploy failures caused by invalid Composer flags`
`✅ Fewer broken deployments when Packagist advisories exist`
`✅ Clearer deploy workflow guidance for maintainers`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
