### PR TITLE
⚡ Optimize user events term fetching to eliminate N+1 query

### DIFF
--- a/inc/api.php
+++ b/inc/api.php
@@ -481,6 +481,20 @@ function djz_get_user_events_attended($user_id) {
     $target_slugs = ['events', 'tickets', 'congressos', 'workshops', 'social', 'festivais', 'pass'];
 
     if ($orders) {
+        // OPTIMIZATION: Batch prime term cache to avoid N+1 queries
+        $product_ids = [];
+        foreach ($orders as $order) {
+            foreach ($order->get_items() as $item) {
+                if ($pid = $item->get_product_id()) {
+                    $product_ids[] = $pid;
+                }
+            }
+        }
+        if (!empty($product_ids)) {
+            $product_ids = array_unique($product_ids);
+            update_object_term_cache($product_ids, 'product');
+        }
+
         foreach ($orders as $order) {
             foreach ($order->get_items() as $item) {
                 $product_id = $item->get_product_id();

--- a/scripts/optimize_api.py
+++ b/scripts/optimize_api.py
@@ -1,0 +1,53 @@
+import sys
+
+with open('inc/api.php', 'r') as f:
+    lines = f.readlines()
+
+found = False
+for i, line in enumerate(lines):
+    # Check if this is the target line
+    if 'if ($orders) {' in line and 'foreach' not in line:
+        # Check context: verify we are in the right function (djz_get_user_events_attended)
+        # We can check previous lines for target_slugs definition which is unique enough here
+        context_check = False
+        for offset in range(1, 5):
+            if i - offset >= 0 and 'target_slugs' in lines[i - offset]:
+                context_check = True
+                break
+
+        if context_check:
+            print(f"Found target at line {i+1}")
+            indent = line[:line.find('if')]
+
+            optimization_code = [
+                f"{indent}    // OPTIMIZATION: Batch prime term cache to avoid N+1 queries\n",
+                f"{indent}    $product_ids = [];\n",
+                f"{indent}    foreach ($orders as $order) {{\n",
+                f"{indent}        foreach ($order->get_items() as $item) {{\n",
+                f"{indent}            if ($pid = $item->get_product_id()) {{\n",
+                f"{indent}                $product_ids[] = $pid;\n",
+                f"{indent}            }}\n",
+                f"{indent}        }}\n",
+                f"{indent}    }}\n",
+                f"{indent}    if (!empty($product_ids)) {{\n",
+                f"{indent}        $product_ids = array_unique($product_ids);\n",
+                f"{indent}        update_object_term_cache($product_ids, 'product');\n",
+                f"{indent}    }}\n",
+                f"\n"
+            ]
+
+            # Insert AFTER the if ($orders) { line
+            # So insert at i + 1
+            for code in reversed(optimization_code):
+                lines.insert(i + 1, code)
+
+            found = True
+            break
+
+if found:
+    with open('inc/api.php', 'w') as f:
+        f.writelines(lines)
+    print("Successfully optimized inc/api.php")
+else:
+    print("Could not find the target code block in inc/api.php")
+    sys.exit(1)

--- a/verification/benchmark_user_events_v2.php
+++ b/verification/benchmark_user_events_v2.php
@@ -1,0 +1,194 @@
+<?php
+
+// Mocking the environment
+$db_queries = 0;
+$term_cache = [];
+
+function get_transient($key) { return false; }
+function set_transient($key, $val, $exp) {}
+function is_wp_error($thing) { return false; }
+
+function get_the_terms($post_id, $taxonomy) {
+    global $db_queries, $term_cache;
+    if (isset($term_cache[$post_id])) {
+        return $term_cache[$post_id];
+    }
+    $db_queries++;
+    usleep(100); // Simulate DB latency per query
+    // Return mock terms
+    if ($post_id % 2 == 0) { // Simulate some matching products
+        return [(object)['slug' => 'events'], (object)['slug' => 'other']];
+    }
+    return [(object)['slug' => 'clothing']];
+}
+
+function update_object_term_cache($object_ids, $object_type) {
+    global $db_queries, $term_cache;
+    $db_queries++; // One batch query
+    usleep(200); // Slightly heavier but single query
+    foreach ($object_ids as $id) {
+        if ($id % 2 == 0) {
+            $term_cache[$id] = [(object)['slug' => 'events'], (object)['slug' => 'other']];
+        } else {
+            $term_cache[$id] = [(object)['slug' => 'clothing']];
+        }
+    }
+}
+
+class MockItem {
+    public $product_id;
+    public $quantity;
+    public function __construct($pid, $qty) {
+        $this->product_id = $pid;
+        $this->quantity = $qty;
+    }
+    public function get_product_id() { return $this->product_id; }
+    public function get_quantity() { return $this->quantity; }
+}
+
+class MockOrder {
+    public $items = [];
+    public function __construct($items) {
+        $this->items = $items;
+    }
+    public function get_items() { return $this->items; }
+}
+
+function wc_get_orders($args) {
+    // Generate 50 orders
+    $orders = [];
+    for ($i=0; $i<50; $i++) {
+        // Each order has 2 items
+        $items = [
+            new MockItem($i * 10 + 1, 1),
+            new MockItem($i * 10 + 2, 2)
+        ];
+        $orders[] = new MockOrder($items);
+    }
+    return $orders;
+}
+
+// ---------------------------------------------------------
+// Original Logic
+// ---------------------------------------------------------
+function original_logic() {
+    global $db_queries, $term_cache;
+    $db_queries = 0;
+    $term_cache = []; // Clear cache
+
+    $user_id = 123;
+    $args = [
+        'customer_id' => $user_id,
+        'limit' => -1,
+        'status' => ['completed', 'processing'],
+        'type' => 'shop_order',
+    ];
+
+    $orders = wc_get_orders($args);
+    $count = 0;
+    $target_slugs = ['events', 'tickets', 'congressos', 'workshops', 'social', 'festivais', 'pass'];
+
+    if ($orders) {
+        foreach ($orders as $order) {
+            foreach ($order->get_items() as $item) {
+                $product_id = $item->get_product_id();
+                if ($product_id) {
+                    $terms = get_the_terms($product_id, 'product_cat');
+                    if ($terms && !is_wp_error($terms)) {
+                        foreach ($terms as $term) {
+                            if (in_array($term->slug, $target_slugs)) {
+                                $count += $item->get_quantity();
+                                break 2;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return $count;
+}
+
+// ---------------------------------------------------------
+// Optimized Logic
+// ---------------------------------------------------------
+function optimized_logic() {
+    global $db_queries, $term_cache;
+    $db_queries = 0;
+    $term_cache = []; // Clear cache
+
+    $user_id = 123;
+    $args = [
+        'customer_id' => $user_id,
+        'limit' => -1,
+        'status' => ['completed', 'processing'],
+        'type' => 'shop_order',
+    ];
+
+    $orders = wc_get_orders($args);
+    $count = 0;
+    $target_slugs = ['events', 'tickets', 'congressos', 'workshops', 'social', 'festivais', 'pass'];
+
+    if ($orders) {
+        // Collect all product IDs first
+        $product_ids = [];
+        foreach ($orders as $order) {
+            foreach ($order->get_items() as $item) {
+                $pid = $item->get_product_id();
+                if ($pid) {
+                    $product_ids[] = $pid;
+                }
+            }
+        }
+
+        // Batch prime cache
+        if (!empty($product_ids)) {
+            $product_ids = array_unique($product_ids);
+            update_object_term_cache($product_ids, 'product');
+        }
+
+        // Original loop logic
+        foreach ($orders as $order) {
+            foreach ($order->get_items() as $item) {
+                $product_id = $item->get_product_id();
+                if ($product_id) {
+                    $terms = get_the_terms($product_id, 'product_cat'); // Now cached
+                    if ($terms && !is_wp_error($terms)) {
+                        foreach ($terms as $term) {
+                            if (in_array($term->slug, $target_slugs)) {
+                                $count += $item->get_quantity();
+                                break 2;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return $count;
+}
+
+echo "Running Benchmark...\n";
+
+// Run Original
+$start = microtime(true);
+$res1 = original_logic();
+$time1 = microtime(true) - $start;
+$queries1 = $db_queries;
+echo "Original: Count=$res1, Queries=$queries1, Time=" . number_format($time1, 4) . "s\n";
+
+// Run Optimized
+$start = microtime(true);
+$res2 = optimized_logic();
+$time2 = microtime(true) - $start;
+$queries2 = $db_queries;
+echo "Optimized: Count=$res2, Queries=$queries2, Time=" . number_format($time2, 4) . "s\n";
+
+if ($res1 !== $res2) {
+    echo "ERROR: Results differ! Original: $res1, Optimized: $res2\n";
+    exit(1);
+}
+
+echo "Improvement: " . ($queries1 - $queries2) . " fewer queries.\n";
+
+?>


### PR DESCRIPTION
## **User description**
* 💡 **What:** Implemented batch term cache priming for order items in `djz_get_user_events_attended`.
* 🎯 **Why:** Eliminated N+1 queries when iterating through order items to check product categories.
* 📊 **Measured Improvement:** Benchmark shows reduction from ~100 queries to ~1 query for 50 orders (100 items). Execution time reduced significantly (simulated).

---
*PR created automatically by Jules for task [2398375897853608836](https://jules.google.com/task/2398375897853608836) started by @MarceloEyer*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Melhorias de Performance**
  * Otimização de cache implementada para reduzir consultas ao banco de dados durante o processamento de eventos do usuário. O sistema agora pré-carrega dados de produtos em lote único, em vez de múltiplas consultas individuais, resultando em melhor velocidade de resposta da aplicação.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Speed up user event attendance counting by batching product term lookups

### What Changed
- When counting events a user attended, product category data is loaded once in bulk before inspecting order items instead of querying categories per item.
- The bulk loading reduces database queries and wall-clock time for the user-events calculation while returning the same attendance totals.
- A small benchmark script and a file that verifies the optimized behavior were added to demonstrate the query and time improvement.

### Impact
`✅ Fewer DB queries when calculating user event attendance`
`✅ Faster user events count responses`
`✅ Consistent event attendance totals`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
