### PR TITLE
⚡ Bolt: Optimize News API Query

### DIFF
--- a/inc/cpt.php
+++ b/inc/cpt.php
@@ -89,7 +89,8 @@ add_action('rest_api_init', function() {
     register_rest_field('remixes', 'type_name', ['get_callback' => $get_type_callback]);
     register_rest_field('remixes', 'category_name', ['get_callback' => $get_type_callback]);
 
-    register_rest_field('remixes', 'featured_image_src', [
+    // Optimized Image Fields (Shared by remixes and post)
+    register_rest_field(['remixes', 'post'], 'featured_image_src', [
         'get_callback' => function($object) {
             $img_id = get_post_thumbnail_id($object['id']);
             if (!$img_id) return null;
@@ -98,17 +99,24 @@ add_action('rest_api_init', function() {
         },
     ]);
 
-    register_rest_field('remixes', 'featured_image_src_full', [
+    register_rest_field(['remixes', 'post'], 'featured_image_src_full', [
         'get_callback' => function($object) {
             $img_id = get_post_thumbnail_id($object['id']);
             return $img_id ? wp_get_attachment_url($img_id) : null;
+        },
+    ]);
+
+    // Author Name (Optimized for post)
+    register_rest_field('post', 'author_name', [
+        'get_callback' => function($object) {
+            return get_the_author_meta('display_name', $object['author']);
         },
     ]);
 });
 
 /**
  * Optimization: Batch prime attachment caches for REST API
- * Resolves N+1 query issue when fetching 'remixes' with 'featured_image_src'
+ * Resolves N+1 query issue when fetching 'remixes' or 'post' with 'featured_image_src'
  */
 add_filter('the_posts', function($posts, $query) {
     // 1. Ensure it's the main query and we have results
@@ -118,11 +126,16 @@ add_filter('the_posts', function($posts, $query) {
 
     // 2. Robust and strict post_type validation (handles arrays)
     $post_type = $query->get('post_type');
-    $is_remixes = is_array($post_type) 
-        ? in_array('remixes', $post_type, true) 
-        : 'remixes' === $post_type;
+    $valid_types = ['remixes', 'post'];
 
-    if (!$is_remixes) {
+    $is_valid = false;
+    if (is_array($post_type)) {
+        $is_valid = !empty(array_intersect($post_type, $valid_types));
+    } else {
+        $is_valid = in_array($post_type, $valid_types, true);
+    }
+
+    if (!$is_valid) {
         return $posts;
     }
 

--- a/src/hooks/useQueries.ts
+++ b/src/hooks/useQueries.ts
@@ -68,6 +68,9 @@ export interface WPPost {
   title: { rendered: string };
   excerpt: { rendered: string };
   content?: { rendered: string };
+  featured_image_src?: string | null;
+  featured_image_src_full?: string | null;
+  author_name?: string | null;
   _embedded?: {
     'wp:featuredmedia'?: Array<{ source_url: string }>;
     author?: Array<{ name: string }>;
@@ -168,7 +171,8 @@ export const useNewsQuery = (options: { enabled?: boolean } = {}) => {
     queryKey: QUERY_KEYS.posts.list(),
     queryFn: async (): Promise<WPPost[]> => {
       const apiUrl = buildApiUrl('wp/v2/posts', {
-        _embed: 'true',
+        // OPTIMIZATION: Use _fields instead of _embed to reduce payload and backend processing
+        _fields: 'id,date,slug,title,excerpt,featured_image_src,featured_image_src_full,author_name',
         per_page: '10',
       });
       const res = await fetch(apiUrl);
@@ -188,7 +192,8 @@ export const useNewsBySlug = (slug?: string) => {
       if (!slug) return null;
       const apiUrl = buildApiUrl('wp/v2/posts', {
         slug,
-        _embed: 'true',
+        // OPTIMIZATION: Use _fields instead of _embed to reduce payload and backend processing
+        _fields: 'id,date,slug,title,content,excerpt,featured_image_src_full,author_name',
       });
       const res = await fetch(apiUrl);
       if (!res.ok) throw new Error('Failed to fetch individual news post');

--- a/src/pages/NewsPage.tsx
+++ b/src/pages/NewsPage.tsx
@@ -63,14 +63,14 @@ const NewsPage: React.FC = () => {
                 <div className="flex items-center justify-center gap-4 text-white/50 text-sm mb-4 font-mono uppercase tracking-widest">
                   <span className="flex items-center gap-1.5"><Calendar size={14} /> {formatDate(singlePost.date)}</span>
                   <span>•</span>
-                  <span>{t('news.by')} {singlePost._embedded?.author?.[0]?.name || 'Zen Eyer'}</span>
+                  <span>{t('news.by')} {singlePost.author_name || singlePost._embedded?.author?.[0]?.name || 'Zen Eyer'}</span>
                 </div>
                 <h1 className="text-4xl md:text-6xl font-black font-display leading-tight mb-8" dangerouslySetInnerHTML={{ __html: singlePost.title.rendered }} />
 
-                {singlePost._embedded?.['wp:featuredmedia']?.[0]?.source_url && (
+                {(singlePost.featured_image_src_full || singlePost._embedded?.['wp:featuredmedia']?.[0]?.source_url) && (
                   <div className="rounded-3xl overflow-hidden border border-white/10 shadow-2xl h-[40vh] md:h-[60vh]">
                     <img
-                      src={singlePost._embedded['wp:featuredmedia'][0].source_url}
+                      src={singlePost.featured_image_src_full || singlePost._embedded?.['wp:featuredmedia']?.[0]?.source_url || ''}
                       className="w-full h-full object-cover"
                       alt={singlePost.title.rendered}
                     />
@@ -142,7 +142,7 @@ const NewsPage: React.FC = () => {
                   <Link to={`${getRouteForKey('news')}/${featuredPost.slug}`}>
                     <div className="relative h-[60vh] md:h-[70vh] w-full overflow-hidden rounded-3xl border border-white/10 shadow-2xl">
                       <img
-                        src={featuredPost._embedded?.['wp:featuredmedia']?.[0]?.source_url || '/images/hero-background.webp'}
+                        src={featuredPost.featured_image_src_full || featuredPost._embedded?.['wp:featuredmedia']?.[0]?.source_url || '/images/hero-background.webp'}
                         alt={featuredPost.title.rendered}
                         className="absolute inset-0 w-full h-full object-cover transition-transform duration-1000 group-hover:scale-105"
                         loading="eager"
@@ -194,7 +194,7 @@ const NewsPage: React.FC = () => {
                   >
                     <Link to={`${getRouteForKey('news')}/${post.slug}`} className="block h-56 overflow-hidden relative">
                       <img
-                        src={post._embedded?.['wp:featuredmedia']?.[0]?.source_url || '/images/hero-background.webp'}
+                        src={post.featured_image_src || post._embedded?.['wp:featuredmedia']?.[0]?.source_url || '/images/hero-background.webp'}
                         alt={post.title.rendered}
                         className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110"
                         loading="lazy"


### PR DESCRIPTION
## **User description**
⚡ **Bolt Optimization**

**What:**
Replaced the expensive `_embed=true` parameter in `useNewsQuery` with a specific list of `_fields` and custom REST fields.

**Why:**
`_embed` forces WordPress to fetch and process all related resources (comments, terms, author full profile, all media sizes) for every post in the list. This causes significant backend overhead and large payload sizes, especially for list views.

**Impact:**
- Reduces API response size by ~80% (estimated).
- Eliminates N+1 queries for fetching featured images and authors on the backend.
- Improves TTFB for the News page.

**Measurement:**
Verified via Playwright script mocking the optimized API response to ensuring frontend renders correctly with the new data structure. Validated backend logic via code review.

---
*PR created automatically by Jules for task [17546315048683983117](https://jules.google.com/task/17546315048683983117) started by @MarceloEyer*


___

## **CodeAnt-AI Description**
Use trimmed REST fields for News to reduce payload and reliably show images and author

### What Changed
- News list and article requests now return only the fields the frontend needs, shrinking network payloads and backend work (images, author name, title, excerpt, content).
- News pages and cards read new lightweight image and author fields first and fall back to existing embedded data when those fields are missing, preserving current visuals and author display.
- Server now exposes compact image URLs and author name for posts and primes attachment caches for list queries to eliminate repeated image lookups on the backend.

### Impact
`✅ Faster News page load`
`✅ Smaller network payloads for News list and article requests`
`✅ Fewer backend image queries (resolves N+1 for News and remixes)`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Adicionado nome do autor nas páginas de notícias com fallbacks inteligentes.
  * Campos de imagem em destaque agora disponíveis para posts e remixes.

* **Refactor**
  * Otimizado carregamento de dados da API com requisições mais eficientes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->