### PR TITLE
fix: pass defaultImage as fallback to safeUrl for og:image

### DIFF
--- a/src/components/HeadlessSEO.tsx
+++ b/src/components/HeadlessSEO.tsx
@@ -135,7 +135,7 @@ export const HeadlessSEO: React.FC<HeadlessSEOProps> = ({
 
   // FIX: Imagem padrão robusta se nada for passado
   const defaultImage = `${baseUrl}/images/zen-eyer-og-image.png`;
-  const finalImage = safeUrl(ensureAbsoluteUrl(data?.image || image || defaultImage, baseUrl));
+  const finalImage = safeUrl(ensureAbsoluteUrl(data?.image || image || defaultImage, baseUrl), defaultImage);
 
   const shouldNoIndex = data?.noindex || noindex;
 


### PR DESCRIPTION
## **User description**
Modifies HeadlessSEO.tsx to explicitly pass `defaultImage` as the fallback to `safeUrl`. This ensures that even if `safeUrl` rejects the resulting URL or the provided image is empty, the robust `zen-eyer-og-image.png` is always used as a fallback rather than `#`.

---
*PR created automatically by Jules for task [15289237926188672922](https://jules.google.com/task/15289237926188672922) started by @MarceloEyer*


___

## **CodeAnt-AI Description**
Pass robust default image as fallback for og:image in HeadlessSEO

### What Changed
- The Open Graph image now always falls back to the site default image (zen-eyer-og-image.png) when no image is provided or the resolved URL is rejected
- Prevents the og:image from becoming an invalid placeholder when inputs are empty or invalid

### Impact
`✅ Clearer social link previews`
`✅ Fewer broken or missing og:image tags`
`✅ Consistent share images across pages`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Correções de Bugs**
  * Melhorada a manipulação de imagens de SEO com fallback para imagem padrão quando a URL resolvida é inválida.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->