### PR TITLE
chore: Remove resolved default image fallback comment

### DIFF
--- a/src/components/HeadlessSEO.tsx
+++ b/src/components/HeadlessSEO.tsx
@@ -160,7 +160,6 @@ export const HeadlessSEO = React.memo<HeadlessSEOProps>(({
   const absoluteUrl = ensureAbsoluteUrl(finalUrlRaw, baseUrl);
   const finalUrl = safeUrl(ensureTrailingSlash(absoluteUrl));
 
-  // FIX: Imagem padrão robusta se nada for passado
   const defaultImage = `${baseUrl}/images/zen-eyer-og-image.png`;
   const finalImage = safeUrl(ensureAbsoluteUrl(data?.image || image || defaultImage, baseUrl), defaultImage);
 


### PR DESCRIPTION
## **User description**
Removed the `// FIX:` comment for the default image fallback logic in `src/components/HeadlessSEO.tsx`. The implemented fix was already evident and functionally sound, leaving the code clean. Validated that builds and lints pass correctly.

---
*PR created automatically by Jules for task [9253493811131266485](https://jules.google.com/task/9253493811131266485) started by @MarceloEyer*


___

## **CodeAnt-AI Description**
**Remove resolved comment about default image fallback in HeadlessSEO**

### What Changed
- Deleted a resolved developer comment related to the default Open Graph image in the HeadlessSEO component.
- Default image fallback behavior remains unchanged: pages still use the configured image, the provided image prop, or the site's default image in that order.
- Builds and lints continue to pass; no runtime or user-facing behavior was modified.

### Impact
`✅ Clearer code comments for maintainers`
`✅ No change to Open Graph image behavior`
`✅ No impact on builds or runtime`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
