### PR TITLE
feat: Implement EventSeries schema for multiple events in HeadlessSEO

### DIFF
--- a/src/components/HeadlessSEO.tsx
+++ b/src/components/HeadlessSEO.tsx
@@ -252,8 +252,9 @@ export const HeadlessSEO = React.memo<HeadlessSEOProps>(({
 
     // 4.3 Event Schema (If on events page or specific event)
     if (events && events.length > 0) {
-      events.forEach((event) => {
+      const musicEvents = events.map((event) => {
         const eventTitle = event.title?.rendered || event.title || event.name || 'Zouk Event';
+        const canonicalUrl = event.canonical_url || event.url || undefined;
         const startDate = event.starts_at || event.event_date || event.start_date;
         const endDate = event.ends_at || event.end_date;
 
@@ -273,9 +274,10 @@ export const HeadlessSEO = React.memo<HeadlessSEOProps>(({
           };
         }
 
-        graph.push({
-          '@type': 'Event',
+        return {
+          '@type': 'MusicEvent',
           name: eventTitle,
+          ...(canonicalUrl ? { url: canonicalUrl } : {}),
           startDate: startDate,
           ...(endDate ? { endDate } : {}),
           eventStatus: 'https://schema.org/EventScheduled',
@@ -295,13 +297,31 @@ export const HeadlessSEO = React.memo<HeadlessSEOProps>(({
           image: event.image || finalImage,
           description: (event.description || event.desc || '').replace(/<[^>]*>?/gm, '').substring(0, 300),
           performer: {
-            '@type': 'Person',
+            '@type': 'MusicGroup',
             name: ARTIST.identity.stageName,
-            sameAs: ARTIST.social.instagram
+            sameAs: ARTIST.social.instagram.url || ARTIST.social.instagram
           },
           ...(eventOffers ? { offers: eventOffers } : {}),
+        };
+      }).filter(e => !!e.startDate); // Ensure required startDate
+
+      if (musicEvents.length > 1) {
+        graph.push({
+          '@type': 'EventSeries',
+          name: `${ARTIST.identity.stageName} World Tour`,
+          url: finalUrl,
+          description: `Official tour dates and upcoming performances for ${ARTIST.identity.stageName}.`,
+          performer: {
+            '@type': 'MusicGroup',
+            name: ARTIST.identity.stageName,
+            url: ARTIST.site.baseUrl,
+            sameAs: ARTIST.social.instagram.url || ARTIST.social.instagram
+          },
+          subEvent: musicEvents
         });
-      });
+      } else if (musicEvents.length === 1) {
+        graph.push(musicEvents[0]);
+      }
     }
 
     // Combine with WebPage base


### PR DESCRIPTION
## **User description**
Modifies the `HeadlessSEO` component to output Google's `EventSeries` structured data schema when multiple events are present. This groups the individual `MusicEvent` representations within a `subEvent` array, fulfilling Google's E-E-A-T rich snippet guidelines for tour dates and event series. Also ensures correct handling of a single `MusicEvent` without the wrapper.

---
*PR created automatically by Jules for task [11500578481376121007](https://jules.google.com/task/11500578481376121007) started by @MarceloEyer*


___

## **CodeAnt-AI Description**
**Implement EventSeries structured data for multiple events**

### What Changed
- When multiple events are present, the page now emits a single EventSeries schema that groups individual events as subEvent entries so search engines see them as a tour/series.
- Individual events are emitted as MusicEvent entries with performer set as a MusicGroup and include the event start/end dates, image, description, offers (ticket URL), and canonical event URL when available.
- Events without a start date are excluded; when only one valid event exists, that single MusicEvent is emitted instead of an EventSeries.

### Impact
`✅ Better indexing of tour dates`
`✅ Clearer event structured data for multiple events`
`✅ Correct handling of single-event pages`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Melhorias**
  * Aprimorado o tratamento de dados de eventos com suporte expandido para séries de eventos e tours
  * Implementada extração automática de URLs canônicas para eventos
  * Otimizado o processamento de metadados de eventos para melhor qualidade de informações

<!-- end of auto-generated comment: release notes by coderabbit.ai -->