### PR TITLE
feat: Fix FAQPage structured data implementation using HeadlessSEO

### DIFF
--- a/src/pages/FAQPage.tsx
+++ b/src/pages/FAQPage.tsx
@@ -95,44 +95,15 @@ const FAQPage: React.FC = () => {
     [location.pathname]
   );
 
-  // FAQ Schema JSON-LD
-  const faqSchema = useMemo(() => ({
-    "@context": "https://schema.org",
-    "@graph": [
-      {
-        "@type": "FAQPage",
-        "@id": `${currentUrl}#faqpage`,
-        "mainEntity": faqData.flatMap(category =>
-          category.questions.map(q => ({
-            "@type": "Question",
-            "name": q.question,
-            "acceptedAnswer": {
-              "@type": "Answer",
-              "text": q.answer.replace(/<[^>]*>/g, '') // Texto limpo para robots/LLMs
-            }
-          }))
-        )
-      },
-      {
-        "@type": "BreadcrumbList",
-        "@id": `${currentUrl}#breadcrumb`,
-        "itemListElement": [
-          {
-            "@type": "ListItem",
-            "position": 1,
-            "name": "Home",
-            "item": ARTIST.site.baseUrl
-          },
-          {
-            "@type": "ListItem",
-            "position": 2,
-            "name": "FAQ",
-            "item": currentUrl
-          }
-        ]
-      }
-    ]
-  }), [currentUrl, faqData]);
+  // Extract FAQs for the HeadlessSEO component to generate the FAQPage schema
+  const faqList = useMemo(() => {
+    return faqData.flatMap(category =>
+      category.questions.map(q => ({
+        q: q.question,
+        a: q.answer.replace(/<[^>]*>/g, '') // Clean text for robots/LLMs
+      }))
+    );
+  }, [faqData]);
 
   return (
     <div className="min-h-screen bg-background text-white pt-24 pb-20">
@@ -140,7 +111,7 @@ const FAQPage: React.FC = () => {
         title={t('faq.title')}
         description={t('faq.subtitle')}
         url={safeUrl(currentUrl, ARTIST.site.baseUrl)}
-        schema={faqSchema}
+        faqs={faqList}
         keywords={t('faq.seo.keywords')}
         leadAnswer={t('faq.seo.lead_answer')}
       />


### PR DESCRIPTION
## **User description**
This pull request resolves an issue with the \`FAQPage\` where the search engine structured data schema (JSON-LD) completely replaced the standard page-level \`HeadlessSEO\` config. 

Instead of creating a local schema override from scratch, \`FAQPage.tsx\` has been refactored to parse the translated items into a clean array and pass it via the existing \`faqs\` prop of \`HeadlessSEO\`, seamlessly unlocking dropdown questions/answers rich snippets in search results while retaining default OpenGraph tags and metadata.

---
*PR created automatically by Jules for task [13291607908507949467](https://jules.google.com/task/13291607908507949467) started by @MarceloEyer*


___

## **CodeAnt-AI Description**
Use HeadlessSEO's FAQ prop so FAQ structured data no longer replaces page metadata

### What Changed
- The page no longer injects a standalone FAQ JSON-LD; it sends a cleaned list of FAQs to HeadlessSEO so the component generates FAQ structured data
- FAQ answers are stripped of HTML before being passed, ensuring plain text for search engines and language models
- Default page metadata (OpenGraph tags, description, keywords, lead answer) is preserved and not overwritten by the FAQ schema

### Impact
`✅ FAQ rich snippets in search results`
`✅ Retain OpenGraph and page metadata`
`✅ Cleaner FAQ text for search engines`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Chores**
  * Otimização do processamento de dados de perguntas frequentes para melhor desempenho em buscas e compatibilidade com sistemas de inteligência artificial.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->