### PR TITLE
⚡ Bolt: Optimize Shop API image lookup

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -45,3 +45,7 @@
 ## 2026-03-08 - UseMemo on Array Data
 **Learning:** Found that large data object definitions utilizing `t` were being recreated every render cycle in `ZenTribePage.tsx`. Attempting to micro-optimize tiny array traversals (like `find` + `filter` -> `for` loops) proved detrimental due to dependency complexities triggering unnecessary renders, and violating micro-optimization guidelines.
 **Action:** When implementing static array mapping and data definitions that rely on React contexts such as translations (`useTranslation()`), apply `useMemo` and attach `t` as a dependency to avoid re-rendering heavy allocations without sacrificing maintainability for imperceptible loop improvements.
+
+## 2026-03-09 - Map pattern to avoid redundant function calls in REST API
+**Learning:** In `djz_get_shop_page` inside `inc/api.php`, `djz_get_product_image_ids` was being called during the initial query loop to collect image IDs for cache priming, and then called *again* for the exact same products in the subsequent formatting loop. This caused N redundant calculations per shop section.
+**Action:** When deriving data in one loop that will be needed in a subsequent loop (especially for the same collection of items), cache the intermediate result in an associative array keyed by item ID (e.g., `$product_images_map[$id] = $img_ids`). Then perform an O(1) lookup in the second loop instead of recalculating.

--- a/inc/api.php
+++ b/inc/api.php
@@ -616,6 +616,8 @@ function djz_get_shop_page($request)
             $product_objects = [];
             $product_ids = [];
             $all_img_ids = [];
+            // ⚡ Bolt: Cache product image IDs to avoid redundant calls to djz_get_product_image_ids in the formatting loop
+            $product_images_map = [];
 
             while ($query->have_posts()) {
                 $query->the_post();
@@ -628,6 +630,8 @@ function djz_get_shop_page($request)
                 $product_ids[] = $product->get_id();
 
                 $img_ids = djz_get_product_image_ids($product, true); // true = list view
+                $product_images_map[$product->get_id()] = $img_ids;
+
                 if (!empty($img_ids))
                     $all_img_ids = array_merge($all_img_ids, $img_ids);
             }
@@ -638,7 +642,8 @@ function djz_get_shop_page($request)
                 update_object_term_cache($product_ids, 'product');
 
             foreach ($product_objects as $product) {
-                $img_ids = djz_get_product_image_ids($product, true);
+                // ⚡ Bolt: Retrieve image IDs from our pre-computed map in O(1) time
+                $img_ids = $product_images_map[$product->get_id()] ?? [];
                 $images = [];
                 foreach ($img_ids as $img_id) {
                     $src = wp_get_attachment_url($img_id);


### PR DESCRIPTION
## **User description**
⚡ Bolt: Optimize Shop API image lookup

💡 What: Implemented a map pattern to cache image IDs in `inc/api.php` `djz_get_shop_page`.
🎯 Why: Prevents N redundant calls to `djz_get_product_image_ids` per section format.
📊 Impact: Reduces CPU and database overhead for the backend shop page endpoint by caching derived arrays instead of repeating identical iterations.
🔬 Measurement: Verify API response times for `/djzeneyer/v1/shop/page`.

---
*PR created automatically by Jules for task [11817329674756247752](https://jules.google.com/task/11817329674756247752) started by @MarceloEyer*


___

## **CodeAnt-AI Description**
**Bolt: Cache product image IDs to speed up shop page API responses**

### What Changed
- The shop page REST endpoint now caches each product's image ID list during the initial query and reuses it when formatting responses, avoiding recalculating the same image lists twice.
- The endpoint primes thumbnail caches and builds product lists using the cached image IDs, preserving the same response structure and image data.
- No functional change to returned product fields; the change reduces redundant work during request processing.

### Impact
`✅ Faster shop page API responses`
`✅ Lower CPU and database work during shop page requests`
`✅ Fewer redundant image ID calculations per section`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Melhorias de Desempenho**
  * Otimizado o carregamento das páginas da loja com implementação de cache para imagens de produtos, reduzindo consultas redundantes e melhorando significativamente a velocidade de processamento.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->