### PR TITLE
⚡ Bolt: Optimize redundant product image ID calculations in API

### DIFF
--- a/inc/api.php
+++ b/inc/api.php
@@ -302,6 +302,7 @@ function djz_query_products(array $options = [])
         $product_objects = [];
         $product_ids = [];
         $all_img_ids = [];
+        $product_images_map = [];
 
         while ($query->have_posts()) {
             $query->the_post();
@@ -318,6 +319,10 @@ function djz_query_products(array $options = [])
             $product_ids[] = $product->get_id();
 
             $img_ids = djz_get_product_image_ids($product, empty($slug));
+
+            // ⚡ Bolt: Cache product image IDs to avoid redundant calls to djz_get_product_image_ids in the formatting loop
+            $product_images_map[$product->get_id()] = $img_ids;
+
             if (!empty($img_ids)) {
                 $all_img_ids = array_merge($all_img_ids, $img_ids);
             }
@@ -333,7 +338,7 @@ function djz_query_products(array $options = [])
 
         foreach ($product_objects as $product) {
             $images = [];
-            $img_ids = djz_get_product_image_ids($product, empty($slug));
+            $img_ids = $product_images_map[$product->get_id()] ?? [];
 
             foreach ($img_ids as $img_id) {
                 $src = wp_get_attachment_url($img_id);


### PR DESCRIPTION
💡 What: Caches the output of `djz_get_product_image_ids` in a map (`$product_images_map`) during the initial product query loop to prevent recalculating image IDs in the formatting loop.
🎯 Why: `djz_get_product_image_ids` executes array manipulation logic (e.g., `array_unshift`) and is called redundantly for each product in `djz_query_products`. This solves an N+1 calculation bottleneck for the shop's API responses.
📊 Impact: Reduces redundant function calls by N (where N is the number of queried products), yielding measurable processing efficiency for shop endpoint data formatting without architectural changes.
🔬 Measurement: Verify by executing backend benchmarks for `/djzeneyer/v1/shop/page` or product list endpoints to observe the minimized response processing time.

---
*PR created automatically by Jules for task [12391088286839657805](https://jules.google.com/task/12391088286839657805) started by @MarceloEyer*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Bug Fixes**
  * Melhorado o desempenho ao carregar imagens de produtos, reduzindo chamadas desnecessárias ao sistema e otimizando o tempo de resposta.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->