### PR TITLE
fix(security): remove chave embutida e endurece acesso ao debug Bandsintown

### DIFF
--- a/debug-bit.php
+++ b/debug-bit.php
@@ -6,7 +6,8 @@
 
 require_once('wp-load.php');
 
-if (!current_user_can('manage_options') && !isset($_GET['force'])) {
+if (!is_user_logged_in() || !current_user_can('manage_options')) {
+    status_header(403);
     die('Unauthorized');
 }
 
@@ -16,11 +17,16 @@ echo "=== Bandsintown Debug ===\n";
 
 $artist_id = get_option('zen_bit_artist_id', '15619775');
 $artist_name = get_option('zen_bit_artist_name', '');
-$app_id = get_option('zen_bit_api_key', 'f8f1216ea03be95a3ea91c7ebe7117e7');
+$app_id = get_option('zen_bit_api_key', '');
 
 echo "Artist ID: $artist_id\n";
 echo "Artist Name: $artist_name\n";
-echo "App ID: $app_id\n";
+echo "App ID configured: " . ($app_id !== '' ? 'yes' : 'no') . "\n";
+
+if ($app_id === '') {
+    echo "Missing API key in zen_bit_api_key option.\n";
+    exit;
+}
 
 $ident = $artist_name !== '' ? urlencode($artist_name) : 'id_' . $artist_id;
 $url = sprintf(

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -47,7 +47,7 @@ function buildUrlEntry(url, date, priority = '0.8', ptUrl = null, imageUrl = nul
 }
 
 const BANDSINTOWN_ARTIST_ID = process.env.BANDSINTOWN_ARTIST_ID || 'id_15619775';
-const BANDSINTOWN_APP_ID = process.env.BANDSINTOWN_APP_ID || 'f8f1216ea03be95a3ea91c7ebe7117e7';
+const BANDSINTOWN_APP_ID = process.env.BANDSINTOWN_APP_ID || '';
 
 async function fetchEvents() {
   let raw = null;
@@ -70,7 +70,7 @@ async function fetchEvents() {
   }
 
   // 2. Fallback: Bandsintown Direto
-  if (!raw) {
+  if (!raw && BANDSINTOWN_APP_ID) {
     try {
       const BIT_API_URL = `https://rest.bandsintown.com/artists/${BANDSINTOWN_ARTIST_ID}/events?app_id=${BANDSINTOWN_APP_ID}&date=upcoming`;
       console.log(`📡 Fetching events from ${BIT_API_URL}...`);
@@ -91,6 +91,10 @@ async function fetchEvents() {
     } catch (error) {
       console.warn('\n❌ SITEMAP ERROR: Could not fetch events:', error.message);
     }
+  }
+
+  if (!raw && !BANDSINTOWN_APP_ID) {
+    console.warn('ℹ️ Bandsintown fallback desativado (defina BANDSINTOWN_APP_ID para ativar).');
   }
 
   if (!raw || !Array.isArray(raw)) return [];

--- a/scripts/prerender.js
+++ b/scripts/prerender.js
@@ -7,13 +7,20 @@ import puppeteer from 'puppeteer';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const BANDSINTOWN_ARTIST_ID = process.env.BANDSINTOWN_ARTIST_ID || 'id_15619775';
-const BANDSINTOWN_APP_ID = process.env.BANDSINTOWN_APP_ID || 'f8f1216ea03be95a3ea91c7ebe7117e7';
+const BANDSINTOWN_APP_ID = process.env.BANDSINTOWN_APP_ID || '';
 const SITE_BASE_URL = process.env.SITE_BASE_URL || 'https://djzeneyer.com';
 const INTERNAL_API_EVENTS = `${SITE_BASE_URL}/wp-json/zen-bit/v2/events?mode=upcoming&days=365`;
 const EVENTS_ROUTE_EN = '/zouk-events';
 const EVENTS_ROUTE_PT = '/pt/eventos-zouk';
-const bandsintownArtistEndpoint = `https://rest.bandsintown.com/artists/${BANDSINTOWN_ARTIST_ID}/events?app_id=${BANDSINTOWN_APP_ID}&date=upcoming`;
-console.log(`📡 Bandsintown Endpoint (Fallback): ${bandsintownArtistEndpoint}`);
+const bandsintownArtistEndpoint = BANDSINTOWN_APP_ID
+  ? `https://rest.bandsintown.com/artists/${BANDSINTOWN_ARTIST_ID}/events?app_id=${BANDSINTOWN_APP_ID}&date=upcoming`
+  : null;
+
+if (bandsintownArtistEndpoint) {
+  console.log(`📡 Bandsintown Endpoint (Fallback): ${bandsintownArtistEndpoint}`);
+} else {
+  console.log('ℹ️ Bandsintown fallback desativado (defina BANDSINTOWN_APP_ID para ativar).');
+}
 console.log(`📡 Internal API Endpoint: ${INTERNAL_API_EVENTS}`);
 
 // 1. Carregar Rotas (SSOT — src/config/routes-slugs.json)
@@ -143,7 +150,7 @@ async function fetchEvents() {
   }
 
   // 2. Fallback: Bandsintown Direto
-  if (!raw) {
+  if (!raw && bandsintownArtistEndpoint) {
     try {
       const res = await fetch(bandsintownArtistEndpoint, {
         headers: { 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
As alterações implementadas visam aprimorar a segurança e a robustez da aplicação, focando na gestão da chave de API do Bandsintown e no controle de acesso a um script de depuração.

As principais mudanças são:

*   **Endurecimento do Acesso ao Script de Depuração (`debug-bit.php`):**
    *   O acesso ao script `debug-bit.php` agora exige que o usuário esteja logado e possua a capacidade `manage_options`.
    *   A opção de bypass via parâmetro `$_GET['force']` foi removida.
    *   Em caso de acesso não autorizado, um cabeçalho de status `403 Forbidden` é retornado.
*   **Remoção da Chave de API do Bandsintown Embutida:**
    *   A chave de API do Bandsintown que estava embutida no código (`f8f1216ea03be95a3ea91c7ebe7117e7`) foi removida de `debug-bit.php`, `scripts/generate-sitemap.js` e `scripts/prerender.js`.
    *   A chave agora deve ser configurada explicitamente, seja através da opção do WordPress `zen_bit_api_key` ou da variável de ambiente `BANDSINTOWN_APP_ID`.
*   **Fallback Condicional do Bandsintown:**
    *   O mecanismo de fallback para buscar eventos do Bandsintown nos scripts de geração de sitemap (`generate-sitemap.js`) e pré-renderização (`prerender.js`) agora só é ativado se a `BANDSINTOWN_APP_ID` estiver configurada.
    *   Mensagens informativas são exibidas no console quando o fallback do Bandsintown é desativado devido à ausência da chave de API.
*   **Tratamento Explícito de Chave de API Ausente:**
    *   O script `debug-bit.php` agora verifica explicitamente se a chave de API do Bandsintown está ausente e, nesse caso, exibe uma mensagem de erro e encerra a execução.
<!-- kody-pr-summary:end -->