### PR TITLE
feat(api): adicionar endpoint REST /stats no namespace djzeneyer/v1

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -14,6 +14,7 @@ Base REST: `https://djzeneyer.com/wp-json`
 - `GET /shop/page`
 - `GET /products`
 - `GET /products/collections`
+- `GET /stats`
 - `POST /subscribe`
 - `POST /user/update-profile`
 
@@ -63,4 +64,3 @@ Rotas completas tambem suportadas:
 2. Evitar over-fetch; usar campos necessarios sempre que houver suporte
 3. `zen-ra` foi removido do projeto e nao deve aparecer em rotas, exemplos ou integracoes
 4. Em caso de duvida, validar no codigo com `register_rest_route`
-

--- a/inc/api.php
+++ b/inc/api.php
@@ -37,6 +37,12 @@ add_action('rest_api_init', function () {
         'permission_callback' => '__return_true',
     ]);
 
+    register_rest_route($ns, '/stats', [
+        'methods' => 'GET',
+        'callback' => 'djz_get_stats',
+        'permission_callback' => '__return_true',
+    ]);
+
     register_rest_route($ns, '/subscribe', [
         'methods' => 'POST',
         'callback' => 'djz_subscribe_newsletter',
@@ -219,6 +225,45 @@ function djz_get_product_collections($request)
     set_transient($cache_key, $response, DJZ_CACHE_PRODUCTS);
 
     return rest_ensure_response($response);
+}
+
+/**
+ * Site Stats Endpoint (Cached 15min)
+ *
+ * Endpoint REST moderno para consumo no frontend SPA em substituicao
+ * de fluxos legados baseados em admin-ajax.
+ */
+function djz_get_stats($request)
+{
+    $cache_key = 'djz_site_stats_v1';
+    $cached = get_transient($cache_key);
+
+    if ($cached) {
+        return rest_ensure_response($cached);
+    }
+
+    $published_posts = wp_count_posts('post')->publish ?? 0;
+    $published_pages = wp_count_posts('page')->publish ?? 0;
+    $published_products = post_type_exists('product')
+        ? (wp_count_posts('product')->publish ?? 0)
+        : 0;
+
+    $stats = [
+        'content' => [
+            'posts' => (int) $published_posts,
+            'pages' => (int) $published_pages,
+            'products' => (int) $published_products,
+        ],
+        'system' => [
+            'wp_version' => get_bloginfo('version'),
+            'php_version' => phpversion(),
+            'timestamp' => current_time('mysql', true),
+        ],
+    ];
+
+    set_transient($cache_key, $stats, MINUTE_IN_SECONDS * 15);
+
+    return rest_ensure_response($stats);
 }
 
 function djz_query_products(array $options = [])


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Adiciona o endpoint REST `GET /stats` à documentação da API. Este novo endpoint permite a recuperação de estatísticas e está listado sob a base REST `https://djzeneyer.com/wp-json`.
<!-- kody-pr-summary:end -->