### PR TITLE
refactor(zen-bit): centraliza metadados do plugin em config.php

### DIFF
--- a/plugins/zen-bit/config.php
+++ b/plugins/zen-bit/config.php
@@ -1,0 +1,11 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+return [
+    'version' => '3.1.0',
+    'slug' => 'zen-bit',
+];
+

--- a/plugins/zen-bit/zen-bit.php
+++ b/plugins/zen-bit/zen-bit.php
@@ -15,7 +15,17 @@ namespace ZenBit;
 if (!defined('ABSPATH'))
     exit;
 
-define('ZEN_BIT_VERSION', '3.1.0');
+$zen_bit_config = require plugin_dir_path(__FILE__) . 'config.php';
+
+if (!is_array($zen_bit_config)) {
+    $zen_bit_config = [];
+}
+
+$zen_bit_version = isset($zen_bit_config['version']) ? (string) $zen_bit_config['version'] : '3.1.0';
+$zen_bit_slug = isset($zen_bit_config['slug']) ? (string) $zen_bit_config['slug'] : 'zen-bit';
+
+define('ZEN_BIT_VERSION', $zen_bit_version);
+define('ZEN_BIT_SLUG', $zen_bit_slug);
 define('ZEN_BIT_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('ZEN_BIT_PLUGIN_URL', plugin_dir_url(__FILE__));
 
@@ -82,7 +92,7 @@ if (!class_exists('Zen_BIT')) {
 
         public function load_textdomain(): void
         {
-            load_plugin_textdomain('zen-bit', false, dirname(plugin_basename(__FILE__)) . '/languages');
+            load_plugin_textdomain(ZEN_BIT_SLUG, false, dirname(plugin_basename(__FILE__)) . '/languages');
         }
 
         public function register_public_assets(): void


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Este pull request refatora o plugin `zen-bit` para centralizar seus metadados em um arquivo de configuração dedicado.

As principais mudanças incluem:

*   **Criação de `config.php`**: Um novo arquivo `plugins/zen-bit/config.php` foi adicionado para armazenar metadados essenciais do plugin, como `version` e `slug`.
*   **Centralização de Metadados**: A versão (`3.1.0`) e o slug (`zen-bit`) do plugin foram movidos do arquivo principal `zen-bit.php` para o novo `config.php`.
*   **Definição Dinâmica de Constantes**: O arquivo `zen-bit.php` agora lê a versão e o slug do `config.php` para definir as constantes `ZEN_BIT_VERSION` e `ZEN_BIT_SLUG`, com valores de fallback caso as chaves não existam no arquivo de configuração.
*   **Uso Consistente do Slug**: A função `load_plugin_textdomain` foi atualizada para utilizar a constante `ZEN_BIT_SLUG`, garantindo que o domínio de texto seja carregado de forma consistente com a configuração centralizada.

Esta alteração melhora a organização e a manutenção dos metadados do plugin, facilitando futuras atualizações ou modificações.
<!-- kody-pr-summary:end -->