### PR TITLE
feat(ui): redesenhar PhilosophyPage + mover Código de Conduta para rodapé

### DIFF
--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -2,7 +2,7 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { Music, Music2, MessageCircle, SendHorizontal } from 'lucide-react';
+import { Music, Music2, MessageCircle, SendHorizontal, Heart } from 'lucide-react';
 import { FacebookIcon, InstagramIcon, YoutubeIcon } from '../icons/BrandIcons';
 import { ARTIST, CURRENT_YEAR } from '../../data/artistData';
 import { getLocalizedRoute, normalizeLanguage } from '../../config/routes';
@@ -91,6 +91,12 @@ const Footer: React.FC = () => {
               <li><Link to={getLocalizedRoute('shop', currentLang)} className="text-white/70 hover:text-primary transition-colors">{t('nav.shop')}</Link></li>
               <li><Link to={getLocalizedRoute('zentribe', currentLang)} className="text-white/70 hover:text-primary transition-colors">{t('nav.tribe')}</Link></li>
               <li><Link to={getLocalizedRoute('booking', currentLang)} className="text-white/70 hover:text-primary transition-colors">{t('nav.booking')}</Link></li>
+              <li className="pt-1">
+                <Link to={getLocalizedRoute('support', currentLang)} className="inline-flex items-center gap-1.5 text-primary hover:text-primary/80 transition-colors font-semibold">
+                  <Heart size={13} />
+                  {t('footer_support_artist')}
+                </Link>
+              </li>
             </ul>
           </div>
 

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -152,6 +152,8 @@ const Footer: React.FC = () => {
           <div className="flex justify-center gap-4 mt-2 text-xs uppercase tracking-wider">
             <Link to={getLocalizedRoute('privacy', currentLang)} className="hover:text-primary transition-colors">{t('common.footer_privacy')}</Link>
             <span>&bull;</span>
+            <Link to={getLocalizedRoute('terms', currentLang)} className="hover:text-primary transition-colors">{t('common.footer_terms')}</Link>
+            <span>&bull;</span>
             <Link to={getLocalizedRoute('conduct', currentLang)} className="hover:text-primary transition-colors">{t('common.footer_conduct')}</Link>
           </div>
 

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -103,7 +103,6 @@ const Footer: React.FC = () => {
               <li><Link to={getLocalizedRoute('philosophy', currentLang)} className="text-white/70 hover:text-primary transition-colors">{t('philosophy.page_title')}</Link></li>
               <li><Link to={getLocalizedRoute('media', currentLang)} className="text-white/70 hover:text-primary transition-colors">{t('nav.media')}</Link></li>
               <li><Link to={getLocalizedRoute('faq', currentLang)} className="text-white/70 hover:text-primary transition-colors">FAQ</Link></li>
-              <li><Link to={getLocalizedRoute('conduct', currentLang)} className="text-white/70 hover:text-primary transition-colors">{t('conduct_page.title')}</Link></li>
             </ul>
           </div>
 
@@ -147,7 +146,7 @@ const Footer: React.FC = () => {
           <div className="flex justify-center gap-4 mt-2 text-xs uppercase tracking-wider">
             <Link to={getLocalizedRoute('privacy', currentLang)} className="hover:text-primary transition-colors">{t('common.footer_privacy')}</Link>
             <span>&bull;</span>
-            <Link to={getLocalizedRoute('terms', currentLang)} className="hover:text-primary transition-colors">{t('common.footer_terms')}</Link>
+            <Link to={getLocalizedRoute('conduct', currentLang)} className="hover:text-primary transition-colors">{t('common.footer_conduct')}</Link>
           </div>
 
           <div className="mt-4 text-xs opacity-30 flex justify-center gap-4">

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -696,6 +696,7 @@
   },
   "philosophy": {
     "page_title": "Artistic Philosophy",
+    "hero_title_rich": "Artistic <1>Philosophy</1>",
     "style_title": "The Style",
     "mission_title": "Mission",
     "coming_soon_title": "Vision",
@@ -1470,7 +1471,7 @@
       "keywords": "support artist, hire dj, payment methods, international payments, brazilian zouk dj"
     },
     "header": {
-      "title": "Support the <0>Music</0>",
+      "title": "Support the <1>Music</1>",
       "description": "Your support helps create new music, educational content, and build the Brazilian Zouk community worldwide. Whether you're hiring for an event or making a donation, every contribution makes a difference."
     },
     "payment": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -702,7 +702,10 @@
     "coming_soon_desc": "Complete artistic manifesto of {{name}} is being updated for the 2026 world tour."
   },
   "philosophy_page": {
+    "manifesto_badge": "Artistic Manifesto",
+    "hero_subtitle": "The philosophy behind every beat, every transition, every moment on the dance floor.",
     "style_title": "The Style",
+    "style_desc": "The unmistakable sonic signature — deep bass, smooth transitions and an energy that transforms any dance floor into an experience.",
     "connection": "Real Connection",
     "connection_desc": "Music as a bridge between two souls, creating a moment of absolute presence.",
     "flow": "State of Flow",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -702,7 +702,10 @@
     "coming_soon_desc": "O manifesto artístico completo de {{name}} está sendo atualizado para a tour mundial de 2026."
   },
   "philosophy_page": {
+    "manifesto_badge": "Manifesto Artístico",
+    "hero_subtitle": "A filosofia por trás de cada batida, cada transição, cada momento na pista.",
     "style_title": "O Estilo",
+    "style_desc": "A assinatura sonora inconfundível — graves profundos, transições suaves e uma energia que transforma qualquer pista em experiência.",
     "connection": "Conexão Real",
     "connection_desc": "A música como ponte entre duas almas, criando um momento de presença absoluta.",
     "flow": "Estado de Flow",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -696,6 +696,7 @@
   },
   "philosophy": {
     "page_title": "Filosofia Artística",
+    "hero_title_rich": "Filosofia <1>Artística</1>",
     "style_title": "O Estilo",
     "mission_title": "Missão",
     "coming_soon_title": "Visão",
@@ -1534,7 +1535,7 @@
       "keywords": "apoiar artista, contratar dj, métodos de pagamento, pagamentos internacionais, brazilian zouk dj"
     },
     "header": {
-      "title": "Apoie a <0>Música</0>",
+      "title": "Apoie a <1>Música</1>",
       "description": "Seu apoio ajuda a criar novas músicas, conteúdo educacional e a fortalecer a comunidade de Brazilian Zouk em todo o mundo. Seja contratando para um evento ou fazendo uma doação, cada contribuição faz a diferença."
     },
     "payment": {

--- a/src/pages/PhilosophyPage.tsx
+++ b/src/pages/PhilosophyPage.tsx
@@ -6,6 +6,36 @@ import { ARTIST } from '../data/artistData';
 import { useTranslation } from 'react-i18next';
 import { getLocalizedRoute, normalizeLanguage } from '../config/routes';
 
+// ─── Framer Motion — module-level constants ───────────────────────────────────
+const HERO_VARIANTS = {
+  hidden: { opacity: 0, y: 30 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.8 } },
+};
+
+const FADE_UP_VARIANTS = {
+  hidden: { opacity: 0, y: 20 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.6 } },
+};
+
+const QUOTE_VARIANTS = {
+  hidden: { opacity: 0, scale: 0.97 },
+  visible: { opacity: 1, scale: 1, transition: { duration: 0.7 } },
+};
+
+const CARDS_CONTAINER_VARIANTS = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.12 } },
+};
+
+const CARD_ITEM_VARIANTS = {
+  hidden: { opacity: 0, y: 28 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.5 } },
+};
+
+const CARD_HOVER = { y: -8 };
+const VIEWPORT_ONCE = { once: true, amount: 0.15 };
+
+// ─── Component ────────────────────────────────────────────────────────────────
 const PhilosophyPage: React.FC = () => {
   const { t, i18n } = useTranslation();
   const currentLang = useMemo(() => normalizeLanguage(i18n.language), [i18n.language]);
@@ -31,8 +61,7 @@ const PhilosophyPage: React.FC = () => {
           name: ARTIST.identity.stageName,
         },
         about: [
-          // TODO: move description to i18n key 'philosophy.cremosidade_desc' for full bilingual JSON-LD
-          { '@type': 'Thing', name: 'Cremosidade', description: t('philosophy.coming_soon_desc', { name: ARTIST.identity.stageName }) },
+          { '@type': 'Thing', name: 'Cremosidade', description: t('philosophy_page.cremosidade_desc') },
           { '@type': 'MusicGenre', name: 'Brazilian Zouk' },
         ],
         isPartOf: { '@id': `${ARTIST.site.baseUrl}/#website` },
@@ -54,103 +83,199 @@ const PhilosophyPage: React.FC = () => {
         description={t('philosophy.coming_soon_desc', { name: ARTIST.identity.stageName })}
         url={pageUrl}
         schema={philosophySchema}
-        leadAnswer={t('philosophy.coming_soon_desc', { name: ARTIST.identity.stageName })}
+        leadAnswer={t('philosophy_page.cremosidade_desc')}
       />
 
-      <div className="min-h-screen pt-24 pb-16 px-4 bg-background text-white">
-        <div className="container mx-auto max-w-4xl text-center">
+      <div className="min-h-screen bg-background text-white">
+
+        {/* ── HERO ─────────────────────────────────────────────────────── */}
+        <section className="relative min-h-[55vh] flex items-center justify-center pt-24 pb-16 px-4 overflow-hidden">
+          <div className="absolute inset-0 pointer-events-none" aria-hidden>
+            <div className="absolute top-1/3 left-1/4 w-[480px] h-[480px] bg-primary/15 rounded-full blur-[160px] -translate-x-1/2 -translate-y-1/2" />
+            <div className="absolute bottom-0 right-1/4 w-72 h-72 bg-accent/10 rounded-full blur-[120px]" />
+          </div>
+
           <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.8 }}
+            className="relative z-10 text-center max-w-3xl mx-auto"
+            initial="hidden"
+            animate="visible"
+            variants={HERO_VARIANTS}
           >
-            <Sparkles className="w-16 h-16 mx-auto mb-6 text-primary" />
-            <h1 className="text-4xl md:text-6xl font-black font-display mb-8">
+            <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-primary/15 border border-primary/30 text-primary text-xs font-bold uppercase tracking-[0.2em] mb-8">
+              <Sparkles className="w-3.5 h-3.5" />
+              {t('philosophy_page.manifesto_badge')}
+            </div>
+
+            <h1 className="text-5xl sm:text-6xl md:text-7xl font-black font-display mb-6 leading-none tracking-tight">
               {t('philosophy.page_title')}
             </h1>
 
-            <div className="grid md:grid-cols-3 gap-8 mb-16 text-left">
-              <motion.div 
-                whileHover={{ y: -5 }}
-                className="card p-8 bg-surface/50 border border-white/10 hover:border-primary/50 transition-all rounded-3xl"
+            <p className="text-base sm:text-lg md:text-xl text-white/60 max-w-2xl mx-auto leading-relaxed">
+              {t('philosophy_page.hero_subtitle')}
+            </p>
+          </motion.div>
+        </section>
+
+        {/* ── QUOTE ────────────────────────────────────────────────────── */}
+        <section className="py-16 sm:py-20 px-4 bg-surface/30 border-y border-white/5">
+          <motion.div
+            className="max-w-3xl mx-auto text-center"
+            initial="hidden"
+            whileInView="visible"
+            viewport={VIEWPORT_ONCE}
+            variants={QUOTE_VARIANTS}
+          >
+            <div className="text-7xl sm:text-8xl text-primary/20 font-display leading-none mb-2 select-none" aria-hidden>
+              &ldquo;
+            </div>
+            <blockquote className="text-lg sm:text-xl md:text-2xl text-white/80 leading-relaxed italic font-light -mt-4">
+              {t('about.philosophy.quote')}
+            </blockquote>
+            <div className="mt-6 text-sm text-white/40 font-bold uppercase tracking-[0.2em]">
+              &mdash; {ARTIST.identity.stageName}
+            </div>
+          </motion.div>
+        </section>
+
+        {/* ── 3 PRINCÍPIOS ─────────────────────────────────────────────── */}
+        <section className="py-16 sm:py-24 px-4">
+          <div className="container mx-auto max-w-5xl">
+            <motion.div
+              className="grid grid-cols-1 sm:grid-cols-3 gap-6"
+              initial="hidden"
+              whileInView="visible"
+              viewport={VIEWPORT_ONCE}
+              variants={CARDS_CONTAINER_VARIANTS}
+            >
+              {/* 01 — O Estilo */}
+              <motion.div
+                variants={CARD_ITEM_VARIANTS}
+                whileHover={CARD_HOVER}
+                className="group card p-6 sm:p-8 bg-surface/50 border border-white/10 hover:border-primary/50 transition-colors duration-300 rounded-3xl"
               >
-                <Music2 className="w-10 h-10 text-primary mb-6" />
-                <h2 className="text-xl font-black mb-4 uppercase tracking-[0.2em] text-primary">
+                <div className="w-12 h-12 rounded-2xl bg-primary/15 flex items-center justify-center mb-6 group-hover:bg-primary/25 transition-colors duration-300">
+                  <Music2 className="w-6 h-6 text-primary" />
+                </div>
+                <div className="text-xs font-bold text-primary/50 uppercase tracking-[0.3em] mb-2">01</div>
+                <h2 className="text-xl font-black uppercase tracking-[0.15em] text-white mb-4">
                   {t('philosophy_page.style_title')}
                 </h2>
-                <p className="text-white/80 leading-relaxed italic text-lg">
-                  "{t('about.philosophy.quote')}"
+                <p className="text-white/70 leading-relaxed text-sm sm:text-base">
+                  {t('philosophy_page.style_desc')}
                 </p>
-                <div className="mt-6 flex items-center justify-between">
-                    <span className="text-white/40 text-sm font-bold uppercase tracking-widest">{t('music.listen_now')}</span>
-                    <div className="text-xs text-white/30 font-bold uppercase tracking-widest">— {ARTIST.identity.stageName}</div>
-                </div>
               </motion.div>
 
-              <motion.div 
-                whileHover={{ y: -5 }}
-                className="card p-8 bg-surface/50 border border-white/10 hover:border-accent/50 transition-all rounded-3xl"
+              {/* 02 — Conexão Real */}
+              <motion.div
+                variants={CARD_ITEM_VARIANTS}
+                whileHover={CARD_HOVER}
+                className="group card p-6 sm:p-8 bg-surface/50 border border-white/10 hover:border-accent/50 transition-colors duration-300 rounded-3xl"
               >
-                <Heart className="w-10 h-10 text-accent mb-6" />
-                <h2 className="text-xl font-black mb-4 uppercase tracking-[0.2em] text-accent">
+                <div className="w-12 h-12 rounded-2xl bg-accent/15 flex items-center justify-center mb-6 group-hover:bg-accent/25 transition-colors duration-300">
+                  <Heart className="w-6 h-6 text-accent" />
+                </div>
+                <div className="text-xs font-bold text-accent/50 uppercase tracking-[0.3em] mb-2">02</div>
+                <h2 className="text-xl font-black uppercase tracking-[0.15em] text-white mb-4">
                   {t('philosophy_page.connection')}
                 </h2>
-                <p className="text-white/70 leading-relaxed">
+                <p className="text-white/70 leading-relaxed text-sm sm:text-base">
                   {t('philosophy_page.connection_desc')}
                 </p>
               </motion.div>
 
-              <motion.div 
-                whileHover={{ y: -5 }}
-                className="card p-8 bg-surface/50 border border-white/10 hover:border-cyan-500/50 transition-all rounded-3xl"
+              {/* 03 — Estado de Flow */}
+              <motion.div
+                variants={CARD_ITEM_VARIANTS}
+                whileHover={CARD_HOVER}
+                className="group card p-6 sm:p-8 bg-surface/50 border border-white/10 hover:border-cyan-500/50 transition-colors duration-300 rounded-3xl"
               >
-                <Sparkles className="w-10 h-10 text-cyan-500 mb-6" />
-                <h2 className="text-xl font-black mb-4 uppercase tracking-[0.2em] text-cyan-500">
+                <div className="w-12 h-12 rounded-2xl bg-cyan-500/15 flex items-center justify-center mb-6 group-hover:bg-cyan-500/25 transition-colors duration-300">
+                  <Sparkles className="w-6 h-6 text-cyan-500" />
+                </div>
+                <div className="text-xs font-bold text-cyan-500/50 uppercase tracking-[0.3em] mb-2">03</div>
+                <h2 className="text-xl font-black uppercase tracking-[0.15em] text-white mb-4">
                   {t('philosophy_page.flow')}
                 </h2>
-                <p className="text-white/70 leading-relaxed">
+                <p className="text-white/70 leading-relaxed text-sm sm:text-base">
                   {t('philosophy_page.flow_desc')}
                 </p>
               </motion.div>
-            </div>
+            </motion.div>
+          </div>
+        </section>
 
-            {/* Expanded Content Sections */}
-            <div className="space-y-12 mb-20 text-left">
-              <section className="relative p-10 md:p-16 rounded-[3rem] bg-gradient-to-br from-primary/10 to-transparent border border-white/5 overflow-hidden">
-                <div className="absolute top-0 right-0 w-64 h-64 bg-primary/20 blur-[100px] -mr-32 -mt-32" />
+        {/* ── CREMOSIDADE ──────────────────────────────────────────────── */}
+        <section className="pb-6 px-4 sm:px-6">
+          <div className="container mx-auto max-w-5xl">
+            <motion.div
+              className="relative p-8 sm:p-12 md:p-16 rounded-[2rem] sm:rounded-[3rem] bg-gradient-to-br from-primary/10 to-transparent border border-white/5 overflow-hidden"
+              initial="hidden"
+              whileInView="visible"
+              viewport={VIEWPORT_ONCE}
+              variants={FADE_UP_VARIANTS}
+            >
+              <div className="absolute top-0 right-0 w-64 h-64 bg-primary/20 blur-[100px] -mr-32 -mt-32 pointer-events-none" aria-hidden />
+              <div className="relative z-10">
+                <h3 className="text-3xl sm:text-4xl md:text-5xl font-black font-display mb-4 tracking-tighter uppercase italic">
+                  {t('philosophy_page.cremosidade_title')}
+                </h3>
+                <div className="h-1 w-16 sm:w-20 bg-primary mb-6 sm:mb-8" />
+                <p className="text-lg sm:text-xl md:text-2xl text-white/80 leading-relaxed max-w-3xl">
+                  {t('philosophy_page.cremosidade_desc')}
+                </p>
+              </div>
+            </motion.div>
+          </div>
+        </section>
+
+        {/* ── FONTE + VISÃO ─────────────────────────────────────────────── */}
+        <section className="py-16 sm:py-24 px-4">
+          <div className="container mx-auto max-w-5xl">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-8 sm:gap-12">
+
+              {/* A Fonte */}
+              <motion.div
+                className="space-y-4"
+                initial="hidden"
+                whileInView="visible"
+                viewport={VIEWPORT_ONCE}
+                variants={FADE_UP_VARIANTS}
+              >
+                <h4 className="text-2xl sm:text-3xl font-black font-display uppercase tracking-widest text-white/90">
+                  {t('philosophy_page.the_source')}
+                </h4>
+                <div className="h-0.5 w-12 bg-primary/50" />
+                <p className="text-base sm:text-lg text-white/60 leading-relaxed">
+                  {t('philosophy_page.the_source_desc')}
+                </p>
+              </motion.div>
+
+              {/* Manifesto 2026 */}
+              <motion.div
+                className="relative p-6 sm:p-8 rounded-2xl sm:rounded-3xl bg-gradient-to-br from-white/5 to-transparent border border-white/10 overflow-hidden"
+                initial="hidden"
+                whileInView="visible"
+                viewport={VIEWPORT_ONCE}
+                variants={FADE_UP_VARIANTS}
+              >
+                <div className="absolute top-0 right-0 w-32 h-32 bg-accent/10 blur-[60px] pointer-events-none" aria-hidden />
                 <div className="relative z-10">
-                  <h3 className="text-3xl md:text-5xl font-black font-display mb-6 tracking-tighter uppercase italic">
-                    {t('philosophy_page.cremosidade_title')}
-                  </h3>
-                  <div className="h-1 w-20 bg-primary mb-8" />
-                  <p className="text-xl md:text-2xl text-white/80 leading-relaxed max-w-3xl">
-                    {t('philosophy_page.cremosidade_desc')}
-                  </p>
-                </div>
-              </section>
-
-              <div className="grid md:grid-cols-2 gap-12">
-                <div className="space-y-6">
-                  <h4 className="text-2xl font-black font-display uppercase tracking-widest text-white/90">
-                    {t('philosophy_page.the_source')}
-                  </h4>
-                  <p className="text-lg text-white/50 leading-relaxed">
-                    {t('philosophy_page.the_source_desc')}
-                  </p>
-                </div>
-                <div className="p-8 bg-white/5 rounded-3xl border border-dashed border-white/10">
-                  <h4 className="text-xl font-bold mb-4 flex items-center gap-3">
-                    <span className="w-2 h-2 rounded-full bg-primary animate-pulse" />
-                    {t('philosophy_page.coming_soon_title')}
-                  </h4>
-                  <p className="text-white/40 italic">
+                  <div className="flex items-center gap-3 mb-4">
+                    <span className="w-2.5 h-2.5 rounded-full bg-primary animate-pulse" />
+                    <span className="text-xs font-bold text-primary uppercase tracking-[0.25em]">
+                      {t('philosophy_page.coming_soon_title')}
+                    </span>
+                  </div>
+                  <p className="text-white/60 leading-relaxed text-sm sm:text-base">
                     {t('philosophy_page.coming_soon_desc')}
                   </p>
                 </div>
-              </div>
+              </motion.div>
+
             </div>
-          </motion.div>
-        </div>
+          </div>
+        </section>
+
       </div>
     </>
   );

--- a/src/pages/PhilosophyPage.tsx
+++ b/src/pages/PhilosophyPage.tsx
@@ -3,7 +3,7 @@ import { motion } from 'framer-motion';
 import { HeadlessSEO } from '../components/HeadlessSEO';
 import { Heart, Music2, Sparkles } from 'lucide-react';
 import { ARTIST } from '../data/artistData';
-import { useTranslation } from 'react-i18next';
+import { useTranslation, Trans } from 'react-i18next';
 import { getLocalizedRoute, normalizeLanguage } from '../config/routes';
 
 // ─── Framer Motion — module-level constants ───────────────────────────────────
@@ -107,7 +107,9 @@ const PhilosophyPage: React.FC = () => {
             </div>
 
             <h1 className="text-5xl sm:text-6xl md:text-7xl font-black font-display mb-6 leading-none tracking-tight">
-              {t('philosophy.page_title')}
+              <Trans i18nKey="philosophy.hero_title_rich">
+                Filosofia <span className="text-primary">Artística</span>
+              </Trans>
             </h1>
 
             <p className="text-base sm:text-lg md:text-xl text-white/60 max-w-2xl mx-auto leading-relaxed">


### PR DESCRIPTION
## PhilosophyPage — Redesign completo

### Estrutura nova
- **Hero cinematic**: badge `MANIFESTO ARTÍSTICO`, H1 grande, subtítulo, orbs de gradiente no fundo
- **Seção Quote**: a frase filosófica pessoal em destaque (grande, itálico, centralizada) com atribuição
- **3 Princípios — cards consistentes**: ícone em container arredondado, número `01/02/03`, título, descrição uniforme
- **Cremosidade**: seção existente polida (padding responsivo `p-8 sm:p-12 md:p-16`, `rounded-[2rem] sm:rounded-[3rem]`)
- **Fonte + Visão**: 2 colunas limpas, sem borda tracejada de placeholder — caixa de Visão com gradiente sutil

### Qualidade técnica
- Framer Motion variants extraídos para escopo de módulo (`HERO_VARIANTS`, `FADE_UP_VARIANTS`, `QUOTE_VARIANTS`, `CARDS_CONTAINER_VARIANTS`, `CARD_ITEM_VARIANTS`, `CARD_HOVER`)
- Stagger nos 3 cards (`staggerChildren: 0.12`)
- Mobile-first: `grid-cols-1 sm:grid-cols-3`, `text-5xl sm:text-6xl md:text-7xl`, paddings `sm:` em todos os elementos críticos
- 3 novas chaves i18n (PT + EN): `manifesto_badge`, `hero_subtitle`, `style_desc`
- TODO de Schema.org resolvido: Cremosidade description agora usa `philosophy_page.cremosidade_desc`

## Footer

- **Rodapé inferior**: link `Termos de Uso` substituído por `Código de Conduta` (`conduct` route, `t('common.footer_conduct')`)
- **Menu Descubra Mais**: link de Código de Conduta removido (agora está só no rodapé inferior)

## Checklist
- [x] `npm run lint` — passou (0 erros)
- [x] `npm run build` — passou (tsc + vite + prerender)
- [x] i18n: PT e EN atualizados
- [x] Sem strings hardcoded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Novas Funcionalidades**
  * Página de Filosofia redesenhada com novo layout multi-seção, conteúdo atualizado e animações de entrada e hover aprimoradas.

* **Chores**
  * Reorganização do rodapé: adicionada entrada "Suporte" em links rápidos e realocada a "Conduta" para a barra inferior.

* **Localização**
  * Atualizações de textos em inglês e português com novas chaves e ajustes em marcação rica para a página de Filosofia e telas de suporte.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->