### PR TITLE
seo(home): bio_intro com 'Brazilian Zouk DJ' como frase composta

### DIFF
--- a/src/data/artistData.ts
+++ b/src/data/artistData.ts
@@ -50,7 +50,7 @@ export const ARTIST = {
   stats: {
     startingYear: START_YEAR,
     yearsActive: CURRENT_YEAR - START_YEAR,
-    countriesPlayed: 10,
+    countriesPlayed: 14, // 🇧🇷🇺🇸🇩🇪🇵🇱🇸🇮🇦🇺🇳🇱🇵🇹🇨🇿🇨🇭🇪🇸🇭🇷🇮🇹🇮🇪 — Lituânia em breve (→15)
     lastUpdated: new Date().toISOString().split('T')[0],
   },
 

--- a/src/data/artistData.ts
+++ b/src/data/artistData.ts
@@ -401,18 +401,28 @@ export const getWhatsAppUrl = (message?: string) => {
 
 // Schema.org Person base (consolidated for Knowledge Graph)
 export const ARTIST_SCHEMA_SAME_AS = [
+  // Knowledge Graph anchor (Kalicube best practice)
   'https://www.google.com/search?kgmid=/g/11ff3mhh10',
+  // Authoritative databases
   'https://www.wikidata.org/wiki/Q136551855',
   'https://musicbrainz.org/artist/13afa63c-8164-4697-9cad-c5100062a154',
   'https://www.discogs.com/artist/16872046',
+  // Streaming / music platforms
   'https://open.spotify.com/artist/68SHKGndTlq3USQ2LZmyLw',
   'https://music.apple.com/artist/1439280950',
   'https://www.deezer.com/artist/52900762',
   'https://soundcloud.com/djzeneyer',
+  // Social / video
   'https://www.instagram.com/djzeneyer/',
-  'https://www.youtube.com/@djzeneyer',
+  'https://www.youtube.com/channel/UCJ_5oAEFTG18jga_JFxG00w',
   'https://www.tiktok.com/@djzeneyer',
+  // Live / touring platforms
   'https://www.songkick.com/artists/8815204',
+  'https://www.bandsintown.com/a/15619775',
+  'https://ra.co/dj/djzeneyer',
+  // Artist directories
+  'https://genius.com/artists/Zen-eyer',
+  'https://www.viberate.com/artist/zen-eyer/',
 ] as const;
 
 export const ARTIST_SCHEMA_BASE = {
@@ -547,6 +557,15 @@ export const ARTIST_SCHEMA_BASE = {
       location: {
         '@type': 'Place',
         name: 'Rio de Janeiro, Brazil',
+      },
+    },
+    {
+      '@type': 'Event',
+      name: 'Ilha do Zouk DJ Championship',
+      url: 'https://alexdecarvalho.com.br/ilhadozouk/nossos-djs-our-djs/',
+      location: {
+        '@type': 'Place',
+        name: 'Ilha Grande, Rio de Janeiro, Brazil',
       },
     },
   ],

--- a/src/data/artistData.ts
+++ b/src/data/artistData.ts
@@ -50,7 +50,7 @@ export const ARTIST = {
   stats: {
     startingYear: START_YEAR,
     yearsActive: CURRENT_YEAR - START_YEAR,
-    countriesPlayed: 14, // 🇧🇷🇺🇸🇩🇪🇵🇱🇸🇮🇦🇺🇳🇱🇵🇹🇨🇿🇨🇭🇪🇸🇭🇷🇮🇹🇮🇪 — Lituânia em breve (→15)
+    countriesPlayed: 15, // 🇧🇷🇺🇸🇩🇪🇵🇱🇸🇮🇦🇺🇳🇱🇵🇹🇨🇿🇨🇭🇪🇸🇭🇷🇮🇹🇮🇪🇱🇹
     lastUpdated: new Date().toISOString().split('T')[0],
   },
 

--- a/src/data/artistData.ts
+++ b/src/data/artistData.ts
@@ -510,16 +510,19 @@ export const ARTIST_SCHEMA_BASE = {
       name: 'Zen Eyer — Danxer Artist Profile',
     },
   ],
-  // Eventos reais em que Zen Eyer é performer — prova direta de atuação
+  // Eventos reais em que Zen Eyer é performer — prova direta de atuação (bidirecional com performerIn)
   performerIn: [
     {
       '@type': 'Event',
       name: 'Dutch International Zouk Congress 2026',
-      url: 'https://www.dutchzouk.nl/artists',
+      url: 'https://www.dutchzouk.nl/',
+      startDate: '2026-10-15',
+      endDate: '2026-10-18',
       location: {
         '@type': 'Place',
-        name: 'Netherlands',
+        name: 'Etten-Leur, Netherlands',
       },
+      performer: { '@id': `${ARTIST.site.baseUrl}/#artist` },
     },
     {
       '@type': 'Event',
@@ -531,42 +534,55 @@ export const ARTIST_SCHEMA_BASE = {
         '@type': 'Place',
         name: 'Lisbon, Portugal',
       },
+      performer: { '@id': `${ARTIST.site.baseUrl}/#artist` },
     },
     {
       '@type': 'Event',
-      name: 'Slovenian Zouk Marathon',
+      name: 'Slovenian Zouk Marathon 2026',
       url: 'https://slovenianzoukmarathon.com/',
+      startDate: '2026-04-09',
+      endDate: '2026-04-13',
       location: {
         '@type': 'Place',
-        name: 'Slovenia',
+        name: 'Ljubljana, Slovenia',
       },
+      performer: { '@id': `${ARTIST.site.baseUrl}/#artist` },
     },
     {
       '@type': 'Event',
-      name: 'Neo Festival',
+      name: 'Neo Festival 2026',
       url: 'https://neozouk.com/',
+      startDate: '2026-01-04',
+      endDate: '2026-01-07',
       location: {
         '@type': 'Place',
-        name: 'Brazil',
+        name: 'Rio de Janeiro, Brazil',
       },
+      performer: { '@id': `${ARTIST.site.baseUrl}/#artist` },
     },
     {
       '@type': 'Event',
       name: 'Zouk in Rio 2026',
       url: 'https://renatapecanha.wixsite.com/zoukinrio/c%C3%B3pia-artistas',
+      startDate: '2026-06-26',
+      endDate: '2026-06-28',
       location: {
         '@type': 'Place',
         name: 'Rio de Janeiro, Brazil',
       },
+      performer: { '@id': `${ARTIST.site.baseUrl}/#artist` },
     },
     {
       '@type': 'Event',
       name: 'Ilha do Zouk',
       url: 'https://alexdecarvalho.com.br/ilhadozouk/nossos-djs-our-djs/',
+      startDate: '2022-04-20',
+      endDate: '2022-04-24',
       location: {
         '@type': 'Place',
         name: 'Ilha Grande, Rio de Janeiro, Brazil',
       },
+      performer: { '@id': `${ARTIST.site.baseUrl}/#artist` },
     },
   ],
 };

--- a/src/data/artistData.ts
+++ b/src/data/artistData.ts
@@ -401,10 +401,10 @@ export const getWhatsAppUrl = (message?: string) => {
 
 // Schema.org Person base (consolidated for Knowledge Graph)
 export const ARTIST_SCHEMA_SAME_AS = [
-  // Knowledge Graph anchor (Kalicube best practice)
-  'https://www.google.com/search?kgmid=/g/11ff3mhh10',
-  // Authoritative databases
+  // Authoritative databases (semantically rich first)
   'https://www.wikidata.org/wiki/Q136551855',
+  // Knowledge Graph anchor (Kalicube best practice — after semantic source)
+  'https://www.google.com/search?kgmid=/g/11ff3mhh10',
   'https://musicbrainz.org/artist/13afa63c-8164-4697-9cad-c5100062a154',
   'https://www.discogs.com/artist/16872046',
   // Streaming / music platforms
@@ -430,7 +430,7 @@ export const ARTIST_SCHEMA_BASE = {
   '@id': `${ARTIST.site.baseUrl}/#artist`,
   name: 'Zen Eyer',
   alternateName: [ARTIST.identity.stageName, ARTIST.identity.fullName],
-  description: 'Zen Eyer is a Brazilian Zouk DJ and music producer performing at international festivals.',
+  description: 'Zen Eyer is a Brazilian Zouk DJ and music producer.',
   genre: ['Brazilian Zouk', 'Zouk', 'Dance Music'],
   jobTitle: ['DJ', 'Music Producer'],
   url: ARTIST.site.baseUrl,
@@ -561,7 +561,7 @@ export const ARTIST_SCHEMA_BASE = {
     },
     {
       '@type': 'Event',
-      name: 'Ilha do Zouk DJ Championship',
+      name: 'Ilha do Zouk',
       url: 'https://alexdecarvalho.com.br/ilhadozouk/nossos-djs-our-djs/',
       location: {
         '@type': 'Place',

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1662,7 +1662,13 @@
     "performed_at": {
       "title": "Performing at International <1>Festivals</1>",
       "subtitle": "Zen Eyer is a Brazilian Zouk DJ and music producer performing at international festivals.",
-      "badge": "World Tour"
+      "badge": "World Tour",
+      "countries": {
+        "Netherlands": "Netherlands",
+        "Portugal": "Portugal",
+        "Slovenia": "Slovenia",
+        "Brazil": "Brazil"
+      }
     }
   },
   "quiz_you_are": "You are...",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1110,6 +1110,10 @@
         "q3": {
           "q": "What are Zen Eyer's main titles and achievements?",
           "a": "In 2022, Zen Eyer won two prestigious titles at Ilha do Zouk: <strong>Best DJ Performance</strong> and <strong>Best Remix</strong>. He is also an official DJ for major congresses like Rio Zouk Congress (by pioneer Renata Peçanha). However, he values friendships and the connections created through music more than the trophies."
+        },
+        "q4": {
+          "q": "Where does Zen Eyer perform internationally?",
+          "a": "Zen Eyer performs at top Brazilian Zouk festivals around the world. Recent and upcoming events include the <strong>Dutch International Zouk Congress</strong> (Netherlands), <strong>Lisbon Zouk Marathon</strong> (Portugal), <strong>Slovenian Zouk Marathon</strong> (Slovenia), <strong>Neo Festival</strong> (Brazil), and <strong>Zouk in Rio</strong> (Brazil). He is also an official DJ for the historic <strong>Rio Zouk Congress</strong> in Rio de Janeiro."
         }
       },
       "rankings": {
@@ -1415,6 +1419,13 @@
       "genre": "Main Genre",
       "links": "Useful Links & Social Media",
       "whatsapp_message": "Hello Zen Eyer! I'd like to talk about a possible collaboration or booking. How can we proceed?"
+    },
+    "canonical_bio": {
+      "title": "Bio for Press & Organizers",
+      "subtitle": "Copy and paste for your event's press materials.",
+      "copy_button": "Copy Bio",
+      "copied": "Copied!",
+      "text": "Zen Eyer (Marcelo Eyer Fernandes) is a Brazilian Zouk DJ and music producer performing at international festivals. Born in Niterói, Rio de Janeiro, he won two world titles at Ilha do Zouk 2022 (Best DJ Performance and Best Remix) and is a member of Mensa International. Known for his signature 'cremosidade' style — fluid, unhurried sets that prioritize deep connection on the dance floor — Zen Eyer has performed at major Zouk festivals across Brazil, Europe, and the Americas, including the Dutch International Zouk Congress, Lisbon Zouk Marathon, Slovenian Zouk Marathon, and Rio Zouk Congress."
     }
   },
   "events_add_google": "Add to Calendar",
@@ -1647,7 +1658,12 @@
       "button": "Share Your Story",
       "whatsapp_msg": "Hello Zen! I saw your story on the website and would like to share mine too."
     },
-    "bio_p2": "Known for a sound focused on the pure 'flow' of the dance — a vibe our community affectionately calls 'cremosidade' —, I prioritize sets where the energy builds gradually, giving the dancer time and space to connect without rush."
+    "bio_p2": "Known for a sound focused on the pure 'flow' of the dance — a vibe our community affectionately calls 'cremosidade' —, I prioritize sets where the energy builds gradually, giving the dancer time and space to connect without rush.",
+    "performed_at": {
+      "title": "Performing at International <1>Festivals</1>",
+      "subtitle": "Zen Eyer is a Brazilian Zouk DJ and music producer performing at international festivals.",
+      "badge": "World Tour"
+    }
   },
   "quiz_you_are": "You are...",
   "contact": "Contact",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -378,7 +378,7 @@
     "cta_booking": "Booking / Press Kit",
     "cta_music": "Explore Music",
     "bio_title": "Who is DJ Zen Eyer?",
-    "bio_intro": "<strong>DJ Zen Eyer</strong> (Marcelo Eyer Fernandes) is a <strong>DJ and producer</strong> focused on <strong>Brazilian Zouk</strong>. In 2022, he won the Best Remix and Best DJ Performance awards at the Brazilian Zouk World Championships (Ilha do Zouk), recognized for his technical precision and musical sensitivity.",
+    "bio_intro": "<strong>DJ Zen Eyer</strong> (Marcelo Eyer Fernandes) is a <strong>Brazilian Zouk DJ</strong> and music producer. In 2022, he won the Best Remix and Best DJ Performance awards at the Brazilian Zouk World Championships (Ilha do Zouk), recognized for his technical precision and musical sensitivity.",
     "bio_style": "Known for his \"creamy\" and engaging style, Zen prioritizes connection. No rush. His signature drop <em>\"Zen? Zen? Zen? Eyer? Eyer?\"</em> is already a classic at festivals.",
     "bio_mensa": "Member of <strong>Mensa International</strong>, he creates perfect emotional journeys for the \"flow\" in dance. He is a regular at major stages like Rio Zouk Congress.",
     "verified": "Verified Profiles",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -1117,7 +1117,13 @@
     "performed_at": {
       "title": "Tocando em <1>Festivais Internacionais</1>",
       "subtitle": "Zen Eyer é DJ e produtor musical de Zouk Brasileiro, se apresentando em festivais internacionais.",
-      "badge": "Tour Mundial"
+      "badge": "Tour Mundial",
+      "countries": {
+        "Netherlands": "Holanda",
+        "Portugal": "Portugal",
+        "Slovenia": "Eslovênia",
+        "Brazil": "Brasil"
+      }
     }
   },
   "footer_subscribe_error": "Falha ao se inscrever. Por favor, tente novamente.",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -402,7 +402,7 @@
     "cta_booking": "Booking / Press Kit",
     "cta_music": "Explorar Músicas",
     "bio_title": "Quem é DJ Zen Eyer?",
-    "bio_intro": "<strong>DJ Zen Eyer</strong> (Marcelo Eyer Fernandes) é um <strong>DJ e produtor</strong> focado no <strong>Brazilian Zouk</strong>. Em 2022, conquistou os prêmios de Melhor Remix e Melhor Performance DJ no Brazilian Zouk World Championships (Ilha do Zouk), sendo reconhecido pela precisão técnica e sensibilidade musical.",
+    "bio_intro": "<strong>DJ Zen Eyer</strong> (Marcelo Eyer Fernandes) é <strong>DJ de Brazilian Zouk</strong> e produtor musical. Em 2022, conquistou os prêmios de Melhor Remix e Melhor Performance DJ no Brazilian Zouk World Championships (Ilha do Zouk), sendo reconhecido pela precisão técnica e sensibilidade musical.",
     "bio_style": "Conhecido pelo estilo \"cremoso\" e envolvente, Zen prioriza a conexão. Sem pressa. Seu drop assinatura <em>\"Zen… Zen… Zen… Eyer… Eyer…\"</em> já é um clássico nos festivais.",
     "bio_mensa": "Membro da <strong>Mensa International</strong>, ele cria jornadas emocionais perfeitas para o \"flow\" na dança. Frequenta palcos de peso como o Rio Zouk Congress.",
     "verified": "Perfis Verificados",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -1113,6 +1113,11 @@
       "desc": "Se você se identificou com essa história ou quer saber mais sobre a filosofia por trás da minha música, adoro conhecer pessoas que também acreditam no poder da conexão através da arte.",
       "button": "Compartilhe Sua História",
       "whatsapp_msg": "Olá Zen! Vi sua história no site e gostaria de compartilhar a minha também."
+    },
+    "performed_at": {
+      "title": "Tocando em <1>Festivais Internacionais</1>",
+      "subtitle": "Zen Eyer é DJ e produtor musical de Zouk Brasileiro, se apresentando em festivais internacionais.",
+      "badge": "Tour Mundial"
     }
   },
   "footer_subscribe_error": "Falha ao se inscrever. Por favor, tente novamente.",
@@ -1168,6 +1173,10 @@
         "q3": {
           "q": "Quais são os principais títulos e conquistas do Zen Eyer?",
           "a": "Em 2022, Zen Eyer conquistou dois títulos de peso no Ilha do Zouk: <strong>Melhor Performance DJ</strong> e <strong>Melhor Remix</strong>. Ele também é DJ oficial de grandes congressos como o Rio Zouk Congress (da pioneira Renata Peçanha). No entanto, ele valoriza mais as amizades e as conexões criadas através da música do que os troféus."
+        },
+        "q4": {
+          "q": "Onde Zen Eyer se apresenta internacionalmente?",
+          "a": "Zen Eyer se apresenta nos principais festivais de Zouk Brasileiro ao redor do mundo. Eventos recentes e futuros incluem o <strong>Dutch International Zouk Congress</strong> (Holanda), <strong>Lisbon Zouk Marathon</strong> (Portugal), <strong>Slovenian Zouk Marathon</strong> (Eslovênia), <strong>Neo Festival</strong> (Brasil) e <strong>Zouk in Rio</strong> (Brasil). Ele também é DJ oficial do histórico <strong>Rio Zouk Congress</strong> no Rio de Janeiro."
         }
       },
       "rankings": {
@@ -1480,6 +1489,13 @@
       "genre": "Gênero Principal",
       "links": "Links Úteis & Redes Sociais",
       "whatsapp_message": "Olá Zen Eyer! Gostaria de conversar sobre uma possível colaboração ou booking. Como podemos prosseguir?"
+    },
+    "canonical_bio": {
+      "title": "Bio para Imprensa e Organizadores",
+      "subtitle": "Copie e cole nos materiais de imprensa do seu evento.",
+      "copy_button": "Copiar Bio",
+      "copied": "Copiado!",
+      "text": "Zen Eyer (Marcelo Eyer Fernandes) é DJ e produtor musical de Zouk Brasileiro, se apresentando em festivais internacionais. Nascido em Niterói, Rio de Janeiro, conquistou dois títulos mundiais no Ilha do Zouk 2022 (Melhor Performance DJ e Melhor Remix) e é membro da Mensa International. Conhecido pelo seu estilo de 'cremosidade' — sets fluidos e sem pressa que priorizam a conexão profunda na pista — Zen Eyer já se apresentou em grandes festivais de Zouk no Brasil, Europa e Américas, incluindo o Dutch International Zouk Congress, Lisbon Zouk Marathon, Slovenian Zouk Marathon e Rio Zouk Congress."
     }
   },
   "support": {

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -315,7 +315,7 @@ const AboutPage: React.FC = () => {
                   <span className="text-3xl grayscale transition-all duration-500 group-hover:grayscale-0 flex-shrink-0">{event.flag}</span>
                   <div className="min-w-0">
                     <div className="text-base font-bold text-white leading-tight group-hover:text-primary transition-colors truncate">{event.name}</div>
-                    <div className="text-xs text-white/40 uppercase tracking-widest mt-1">{event.country}</div>
+                    <div className="text-xs text-white/40 uppercase tracking-widest mt-1">{t(`about.performed_at.countries.${event.country}`, event.country)}</div>
                   </div>
                 </motion.a>
               ))}

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -51,6 +51,14 @@ const CTA_HOVER = { scale: 1.05 };
 const CTA_TAP = { scale: 0.95 };
 
 
+const PERFORMED_AT_EVENTS = [
+  { name: 'Dutch International Zouk Congress', country: 'Netherlands', flag: '🇳🇱', url: 'https://www.dutchzouk.nl/artists' },
+  { name: 'Lisbon Zouk Marathon', country: 'Portugal', flag: '🇵🇹', url: 'https://www.lisbonzoukmarathon.com/march2026' },
+  { name: 'Slovenian Zouk Marathon', country: 'Slovenia', flag: '🇸🇮', url: 'https://slovenianzoukmarathon.com/' },
+  { name: 'Neo Festival', country: 'Brazil', flag: '🇧🇷', url: 'https://neozouk.com/' },
+  { name: 'Zouk in Rio', country: 'Brazil', flag: '🇧🇷', url: 'https://renatapecanha.wixsite.com/zoukinrio/c%C3%B3pia-artistas' },
+] as const;
+
 const MILESTONE_VARIANTS = {
   hidden: { opacity: 0, y: 18, scale: 0.98 },
   visible: (index: number) => ({
@@ -264,6 +272,54 @@ const AboutPage: React.FC = () => {
               <p dangerouslySetInnerHTML={{ __html: sanitizeHtml(t('about.story.p5')) }} />
               <p className="text-primary font-semibold" dangerouslySetInnerHTML={{ __html: sanitizeHtml(t('about.story.p6')) }} />
             </motion.div>
+          </div>
+        </section>
+
+        {/* Performed At Section */}
+        <section className="py-16 px-4 relative z-10 bg-surface/20">
+          <div className="container mx-auto max-w-5xl">
+            <motion.div
+              initial={FADE_IN_UP_INITIAL}
+              whileInView={FADE_IN_UP_ANIMATE}
+              viewport={VIEWPORT_ONCE}
+              transition={FADE_IN_UP_TRANSITION}
+              className="text-center mb-10"
+            >
+              <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-primary/10 text-primary border border-primary/20 mb-5 text-xs font-bold tracking-widest uppercase">
+                <Globe size={14} /> {t('about.performed_at.badge')}
+              </div>
+              <h2 className="text-2xl sm:text-4xl font-display font-bold mb-4">
+                <Trans i18nKey="about.performed_at.title">
+                  Performing at International <span className="text-primary">Festivals</span>
+                </Trans>
+              </h2>
+              <p className="text-white/50 max-w-xl mx-auto text-base leading-relaxed">
+                {t('about.performed_at.subtitle')}
+              </p>
+            </motion.div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              {PERFORMED_AT_EVENTS.map((event, index) => (
+                <motion.a
+                  key={index}
+                  href={event.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  initial={prefersReducedMotion ? false : 'hidden'}
+                  whileInView={prefersReducedMotion ? undefined : 'visible'}
+                  viewport={VIEWPORT_ONCE_MARGIN}
+                  custom={index}
+                  variants={prefersReducedMotion ? undefined : ITEM_VARIANTS}
+                  className="group flex items-center gap-4 rounded-xl border border-white/10 bg-surface/40 p-4 transition-all hover:border-primary/40 hover:bg-surface/60"
+                >
+                  <span className="text-3xl grayscale transition-all duration-500 group-hover:grayscale-0 flex-shrink-0">{event.flag}</span>
+                  <div className="min-w-0">
+                    <div className="text-base font-bold text-white leading-tight group-hover:text-primary transition-colors truncate">{event.name}</div>
+                    <div className="text-xs text-white/40 uppercase tracking-widest mt-1">{event.country}</div>
+                  </div>
+                </motion.a>
+              ))}
+            </div>
           </div>
         </section>
 

--- a/src/pages/FAQPage.tsx
+++ b/src/pages/FAQPage.tsx
@@ -85,7 +85,7 @@ const FAQPage: React.FC = () => {
         cat === 'technical' ? <Brain size={24} /> :
           cat === 'culture' ? <HeartPulse size={24} /> :
             <Users size={24} />,
-    questions: ['q1', 'q2', 'q3'].map(qKey => ({
+    questions: ['q1', 'q2', 'q3', 'q4'].map(qKey => ({
       question: t(`faq.categories.${cat}.${qKey}.q`),
       answer: t(`faq.categories.${cat}.${qKey}.a`)
     }))

--- a/src/pages/FAQPage.tsx
+++ b/src/pages/FAQPage.tsx
@@ -65,7 +65,7 @@ const CATEGORIES = ['djzeneyer', 'rankings', 'technical', 'culture', 'community'
 // COMPONENTE PRINCIPAL
 // ============================================================================
 const FAQPage: React.FC = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const location = useLocation();
   const [openIndex, setOpenIndex] = useState<string | null>(null);
 
@@ -85,11 +85,16 @@ const FAQPage: React.FC = () => {
         cat === 'technical' ? <Brain size={24} /> :
           cat === 'culture' ? <HeartPulse size={24} /> :
             <Users size={24} />,
-    questions: ['q1', 'q2', 'q3', 'q4'].map(qKey => ({
-      question: t(`faq.categories.${cat}.${qKey}.q`),
-      answer: t(`faq.categories.${cat}.${qKey}.a`)
-    }))
-  })), [t]);
+    questions: (cat === 'djzeneyer' ? ['q1', 'q2', 'q3', 'q4'] : ['q1', 'q2', 'q3'])
+      .filter(qKey =>
+        i18n.exists(`faq.categories.${cat}.${qKey}.q`) &&
+        i18n.exists(`faq.categories.${cat}.${qKey}.a`)
+      )
+      .map(qKey => ({
+        question: t(`faq.categories.${cat}.${qKey}.q`),
+        answer: t(`faq.categories.${cat}.${qKey}.a`)
+      }))
+  })), [t, i18n]);
 
   // SSR/Prerender context
   const currentUrl = useMemo(

--- a/src/pages/PressKitPage.tsx
+++ b/src/pages/PressKitPage.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useMemo } from 'react';
+import React, { memo, useMemo, useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import { motion } from 'framer-motion';
@@ -21,7 +21,9 @@ import {
   PlayCircle,
   Radio,
   Database,
-  ExternalLink
+  ExternalLink,
+  Copy,
+  Check
 } from 'lucide-react';
 import { InstagramIcon } from '../components/icons/BrandIcons';
 import { ARTIST, CURRENT_YEAR } from '../data/artistData';
@@ -83,6 +85,14 @@ const PressKitPage: React.FC = () => {
 
   const currentPath = location.pathname;
   const currentUrl = `https://djzeneyer.com${currentPath}`;
+
+  const [isCopied, setIsCopied] = useState(false);
+  const handleCopyBio = useCallback(() => {
+    navigator.clipboard.writeText(t('presskit.canonical_bio.text')).then(() => {
+      setIsCopied(true);
+      setTimeout(() => setIsCopied(false), 2500);
+    });
+  }, [t]);
 
   const relevantLinks = useMemo(
     () => [
@@ -286,6 +296,38 @@ const PressKitPage: React.FC = () => {
                       </div>
                     ))}
                   </div>
+                </div>
+              </div>
+            </motion.div>
+          </div>
+        </section>
+
+        {/* Canonical Bio for Press & Organizers */}
+        <section className="py-12 sm:py-16">
+          <div className="container mx-auto px-4">
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.6 }}
+              className="mx-auto max-w-4xl"
+            >
+              <div className="rounded-2xl border border-white/10 bg-surface/40 p-6 sm:p-8">
+                <div className="mb-6 flex flex-wrap items-start justify-between gap-4">
+                  <div>
+                    <h2 className="text-xl sm:text-2xl font-black text-white">{t('presskit.canonical_bio.title')}</h2>
+                    <p className="mt-1 text-sm text-white/40">{t('presskit.canonical_bio.subtitle')}</p>
+                  </div>
+                  <button
+                    onClick={handleCopyBio}
+                    className="flex items-center gap-2 rounded-xl bg-primary/20 px-5 py-2.5 text-sm font-bold text-primary transition-all hover:bg-primary/30 min-h-[44px]"
+                  >
+                    {isCopied ? <Check size={16} /> : <Copy size={16} />}
+                    {isCopied ? t('presskit.canonical_bio.copied') : t('presskit.canonical_bio.copy_button')}
+                  </button>
+                </div>
+                <div className="rounded-xl bg-black/40 p-5 sm:p-6 text-sm leading-relaxed text-white/70 select-all border border-white/5 cursor-text">
+                  {t('presskit.canonical_bio.text')}
                 </div>
               </div>
             </motion.div>

--- a/src/pages/PressKitPage.tsx
+++ b/src/pages/PressKitPage.tsx
@@ -91,6 +91,8 @@ const PressKitPage: React.FC = () => {
     navigator.clipboard.writeText(t('presskit.canonical_bio.text')).then(() => {
       setIsCopied(true);
       setTimeout(() => setIsCopied(false), 2500);
+    }).catch(() => {
+      setIsCopied(false);
     });
   }, [t]);
 


### PR DESCRIPTION
## Summary

- `home.bio_intro` (EN/PT): reescrito para abrir com **\"Brazilian Zouk DJ\"** como frase composta no primeiro parágrafo visível da homepage
- Alinha o texto do body com o `description` canônico do schema.org Person (`'Zen Eyer is a Brazilian Zouk DJ and music producer.'`)
- Meta keywords são ignoradas pelo Google desde 2009; a presença orgânica no body é o que importa para ranking semântico

**Antes (EN):** `"…is a DJ and producer focused on Brazilian Zouk."`
**Depois (EN):** `"…is a Brazilian Zouk DJ and music producer."`

**Antes (PT):** `"…é um DJ e produtor focado no Brazilian Zouk."`
**Depois (PT):** `"…é DJ de Brazilian Zouk e produtor musical."`

## Files changed
- `src/locales/en/translation.json` — 1 line
- `src/locales/pt/translation.json` — 1 line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Novos Recursos**
  * Adicionada seção de locais de performance internacional com festivais e eventos destacados
  * Adicionada nova pergunta na FAQ sobre onde o artista se apresenta no mundo
  * Adicionada funcionalidade de copiar biografia para a área de transferência no Press Kit

* **Atualizações**
  * Perfil do artista aprimorado com estatísticas de performance expandidas
  * Descrição e metadados do artista atualizados
  * Biografia canônica adicionada para imprensa e organizadores

<!-- end of auto-generated comment: release notes by coderabbit.ai -->