### PR TITLE
Optimization: Resolve React N+1 render and formatting overhead in EventsList

### DIFF
--- a/src/components/EventsList.tsx
+++ b/src/components/EventsList.tsx
@@ -25,14 +25,6 @@ interface EventsListProps {
 // 2. COMPONENT
 // ============================================================================
 
-const formatDate = (date: Date, options: Intl.DateTimeFormatOptions, locale: string) => {
-  return getDateTimeFormatter(locale, options).format(date);
-};
-
-const formatTime = (date: Date, locale: string) => {
-  return getDateTimeFormatter(locale, { hour: '2-digit', minute: '2-digit' }).format(date);
-};
-
 function EventsListInner({ limit = 10, showTitle = true, variant = 'full' }: EventsListProps) {
   const { t, i18n } = useTranslation();
   const currentLocale = i18n.language.startsWith('pt') ? 'pt-BR' : 'en-US';
@@ -43,11 +35,45 @@ function EventsListInner({ limit = 10, showTitle = true, variant = 'full' }: Eve
     mode: 'upcoming',
     limit,
     lang
-  }); // Home page usually non-suspense for better LCP
+  });
 
   if (error) {
     console.error('Error fetching events:', error);
   }
+
+  // Optimization: Pre-process and stabilize event data for rendering
+  const processedEvents = useMemo(() => {
+    if (!events || events.length === 0) return [];
+
+    const timeFormatter = getDateTimeFormatter(currentLocale, { hour: '2-digit', minute: '2-digit' });
+    const monthFormatter = getDateTimeFormatter(currentLocale, { month: 'short' });
+    const eventsDetailRoute = getLocalizedRoute('events-detail', lang);
+
+    const visibleItems = events.slice(0, limit);
+    const results = [];
+
+    for (const event of visibleItems) {
+      const startDate = event.starts_at;
+      const eventDate = new Date(startDate);
+      const loc = event.location;
+
+      const identifier = event.canonical_path
+        ? event.canonical_path.split('/').pop() || event.event_id
+        : event.event_id;
+
+      results.push({
+        ...event,
+        day: eventDate.getDate(),
+        month: monthFormatter.format(eventDate),
+        time: timeFormatter.format(eventDate),
+        locationString: `${loc.city}, ${loc.country || ''}`,
+        detailHref: generatePath(eventsDetailRoute, { id: identifier }),
+        sanitizedTitle: sanitizeHtml(event.title)
+      });
+    }
+
+    return results;
+  }, [events, limit, currentLocale, lang]);
 
   const skeletonElements = useMemo(() => {
     return Array.from({ length: limit }).map((_, i) => {
@@ -63,7 +89,7 @@ function EventsListInner({ limit = 10, showTitle = true, variant = 'full' }: Eve
     });
   }, [limit, variant]);
 
-  // --- Render States (Skeleton Loader for CLS) ---
+  // --- Render States ---
   if (loading) {
     return (
       <div className="w-full">
@@ -77,7 +103,7 @@ function EventsListInner({ limit = 10, showTitle = true, variant = 'full' }: Eve
     );
   }
 
-  if (events.length === 0) {
+  if (processedEvents.length === 0) {
     return (
       <div className="text-center py-12 text-white/60">
         <Calendar size={48} className="mx-auto mb-4 text-white/20" aria-hidden="true" />
@@ -85,8 +111,6 @@ function EventsListInner({ limit = 10, showTitle = true, variant = 'full' }: Eve
       </div>
     );
   }
-  const visibleEvents = events.slice(0, limit);
-
 
   return (
     <div className="w-full">
@@ -97,19 +121,9 @@ function EventsListInner({ limit = 10, showTitle = true, variant = 'full' }: Eve
       )}
 
       <div className={variant === 'compact' ? "space-y-3" : "grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"}>
-        {visibleEvents.map((event) => {
-          const eventDate = new Date(event.starts_at);
+        {processedEvents.map((event) => {
           const loc = event.location;
-          const eventLocation = `${loc.city}, ${loc.country || ''}`;
-
-          const formattedTime = formatTime(eventDate, currentLocale);
-
-          // Canonical Link handling — SINCRONIZADO COM EVENTSPAGE PARA EVITAR 404
-          const identifier = event.canonical_path
-            ? event.canonical_path.split('/').pop() || event.event_id
-            : event.event_id;
-
-          const detailHref = generatePath(getLocalizedRoute('events-detail', lang), { id: identifier });
+          const detailHref = event.detailHref;
 
           // --- COMPACT CARD (used in Home) ---
           if (variant === 'compact') {
@@ -120,11 +134,11 @@ function EventsListInner({ limit = 10, showTitle = true, variant = 'full' }: Eve
               >
                 <Link to={detailHref} className="flex items-start gap-4 p-4">
                   <time dateTime={event.starts_at} className="flex-shrink-0 text-center bg-surface rounded-lg p-3 border border-white/10 min-w-[70px]">
-                    <div className="text-2xl font-bold text-primary">{eventDate.getDate()}</div>
-                    <div className="text-xs uppercase text-white/60">{formatDate(eventDate, { month: 'short' }, currentLocale)}</div>
+                    <div className="text-2xl font-bold text-primary">{event.day}</div>
+                    <div className="text-xs uppercase text-white/60">{event.month}</div>
                   </time>
                   <div className="flex-1 min-w-0">
-                    <h3 className="font-bold text-white mb-1 line-clamp-1 group-hover:text-primary transition-colors text-left" dangerouslySetInnerHTML={{ __html: sanitizeHtml(event.title) }} />
+                    <h3 className="font-bold text-white mb-1 line-clamp-1 group-hover:text-primary transition-colors text-left" dangerouslySetInnerHTML={{ __html: event.sanitizedTitle }} />
                     <div className="space-y-1 text-sm text-white/70 text-left">
                       <div className="flex items-center gap-2">
                         <MapPin size={14} className="flex-shrink-0 text-primary" />
@@ -132,7 +146,7 @@ function EventsListInner({ limit = 10, showTitle = true, variant = 'full' }: Eve
                       </div>
                       <div className="flex items-center gap-2">
                         <Clock size={14} className="flex-shrink-0 text-white/40" />
-                        <span className="truncate">{eventLocation} • {formattedTime}</span>
+                        <span className="truncate">{event.locationString} • {event.time}</span>
                       </div>
                     </div>
                   </div>
@@ -155,11 +169,11 @@ function EventsListInner({ limit = 10, showTitle = true, variant = 'full' }: Eve
                       style={{ backgroundImage: `url(${patternSvg})`, backgroundSize: '30px' }}
                     />
                     <div className="relative z-10 w-full">
-                      <h3 
-                         className="text-2xl font-black uppercase tracking-tighter font-display text-white/90 leading-[0.9] break-words line-clamp-3"
-                         dangerouslySetInnerHTML={{ __html: sanitizeHtml(event.title) }} 
+                      <h3
+                        className="text-2xl font-black uppercase tracking-tighter font-display text-white/90 leading-[0.9] break-words line-clamp-3"
+                        dangerouslySetInnerHTML={{ __html: event.sanitizedTitle }}
                       />
-                       <div className="mt-3 w-8 h-0.5 bg-primary/30 mx-auto rounded-full" />
+                      <div className="mt-3 w-8 h-0.5 bg-primary/30 mx-auto rounded-full" />
                     </div>
                   </div>
                   {/* Overlay Gradient */}
@@ -168,9 +182,9 @@ function EventsListInner({ limit = 10, showTitle = true, variant = 'full' }: Eve
                   {/* Date Badge */}
                   <div className="absolute top-4 left-4">
                     <div className="bg-background/80 backdrop-blur-md border border-white/10 rounded-lg p-2 text-center min-w-[60px]">
-                      <div className="text-xl font-bold text-primary leading-none">{eventDate.getDate()}</div>
+                      <div className="text-xl font-bold text-primary leading-none">{event.day}</div>
                       <div className="text-[10px] uppercase font-semibold text-white/70 mt-1">
-                        {formatDate(eventDate, { month: 'short' }, currentLocale)}
+                        {event.month}
                       </div>
                     </div>
                   </div>
@@ -179,7 +193,7 @@ function EventsListInner({ limit = 10, showTitle = true, variant = 'full' }: Eve
                 <div className="p-6">
                   <h3
                     className="text-xl font-bold mb-3 line-clamp-2 group-hover:text-primary transition-colors h-[3.5rem] flex items-center"
-                    dangerouslySetInnerHTML={{ __html: sanitizeHtml(event.title) }}
+                    dangerouslySetInnerHTML={{ __html: event.sanitizedTitle }}
                   />
 
                   <div className="space-y-3 text-sm text-white/60">
@@ -191,7 +205,7 @@ function EventsListInner({ limit = 10, showTitle = true, variant = 'full' }: Eve
                         <div className="font-semibold text-white">
                           {loc.venue || t('loc_to_be_defined')}
                         </div>
-                        <div className="truncate text-xs">{eventLocation}</div>
+                        <div className="truncate text-xs">{event.locationString}</div>
                       </div>
                     </div>
 
@@ -200,7 +214,7 @@ function EventsListInner({ limit = 10, showTitle = true, variant = 'full' }: Eve
                         <Clock size={14} className="text-white/40" />
                       </div>
                       <div className="text-xs uppercase tracking-wider font-medium text-white/80">
-                        {formattedTime}
+                        {event.time}
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
## Problem
The `EventsList` component was performing expensive operations inside its `map()` loop during the main render cycle. This included multiple date object instantiations, calls to `Intl.DateTimeFormat` (via `getDateTimeFormatter`), route generation, and HTML sanitization for each item. This pattern (an N+1 render bottleneck) caused unnecessary CPU churn on every re-render of the component, even when the underlying data remained the same.

## Solution
1. **Pre-processing (useMemo)**: Introduced a single-pass `useMemo` block that processes the `events` array before rendering.
2. **Single-Pass Formatting**: All date formatting, sanitization, and URL generation are now handled in a single `for...of` loop within `useMemo`.
3. **Stabilized Data**: The components now receive pre-formatted strings (e.g., `event.day`, `event.month`, `event.time`, `event.sanitizedTitle`), eliminating the need for computation during the JSX mapping phase.
4. **Reference Preservation**: By using `useMemo` with minimal dependencies, the processed event objects maintain stable references, allowing `React.memo` inside `EventsListInner` to work effectively.

## Expected Improvements
- **Render Performance**: Faster rendering and re-rendering of the events list, especially on the homepage where multiple `EventsList` components might exist.
- **Improved UX**: Reduced main-thread blocking during complex page transitions or data updates.
- **Code Cleanliness**: Consolidated business logic for formatting into a single, specialized block.

## Risks & Considerations
- **Memory Consumption**: Creates a new array of objects with additional string properties. However, for the typical limits (10-20 events), this is negligible compared to the CPU savings.
- **Locale Sync**: Ensured that `i18n.language` and `currentLocale` are tracked as dependencies to correctly re-format the data if the user switches languages.
- **Sanitization Sync**: Kept the same sanitization logic as before to ensure security and visual consistency.
