### PR TITLE
Corrige recuperacao de chunks lazy no deploy

### DIFF
--- a/.agents/skills/djzeneyer-context/SKILL.md
+++ b/.agents/skills/djzeneyer-context/SKILL.md
@@ -273,6 +273,17 @@ export const useEventsList = (status?: string) => {
 **Causa:** Node `spawn` no Windows requer `.cmd` e `shell: true`.
 **Solução:** Use `process.platform === 'win32'` para ajustar o comando de `npx` para `npx.cmd` no script `prerender.js`.
 
+### Erro ao clicar em links apos deploy (`ChunkLoadError`)
+
+**Sintoma:** Navegacao client-side mostra `Something went wrong` no primeiro clique, mas a mesma URL abre depois de atualizar a pagina.
+**Causa:** A aba ainda esta executando o bundle Vite anterior ou recebeu HTML cacheado. Ao clicar numa rota lazy, o app tenta baixar um chunk hashado antigo que foi removido de `dist/assets`.
+**Solucao:**
+
+1. Manter `src/utils/lazyWithRetry.ts` e `src/utils/chunkRecovery.ts` nas rotas lazy.
+2. No deploy, antes de trocar `dist-next` para `dist`, copiar assets hashados antigos com `rsync --ignore-existing`.
+3. Nao apagar imediatamente chunks antigos de `dist/assets`; hashes evitam conflito com a build nova.
+4. Quando usar URLs absolutas `/assets/...`, garantir que `public/assets/` seja copiado para o webroot.
+
 ### Verificar se WordPress está online: `curl https://djzeneyer.com/wp-json/wp/v2/posts`
 
 ### Deploy bem-sucedido, mas 404 no site

--- a/.github/workflows/CONTEXT.md
+++ b/.github/workflows/CONTEXT.md
@@ -9,8 +9,10 @@
    - O `inc/`, `plugins/`, `parts/` e `templates/` são sincronizados separadamente para garantir que o tema WordPress e o frontend React estejam em harmonia.
    - `plugins/` só pode ser publicado quando o commit atual realmente alterar `plugins/**`. Pushes de frontend/docs não devem redeployar plugins.
 3. **Atomic Dist Swap:** Nunca apagar o `dist/` ativo antes do upload terminar. Esse intervalo gera tela branca porque o WordPress continua servindo o shell sem bundles JS/CSS.
-4. **Prerender Fix:** O Job de Build SEMPRE executa `scripts/prerender.js`. Se o site estiver gerando "tela branca", o problema costuma estar no timeout do Puppeteer, erro de JS no build ou ativação incorreta do `dist`.
-5. **Composer Security:** Plugins com `composer.json` são instalados no CI com verificação de segurança ativada. Não use `--no-security-blocking` a menos que haja um falso positivo crítico bloqueando deploy de produção sem correção na biblioteca upstream.
+4. **Hashed Asset Retention:** Antes de promover `dist-next`, preserve `dist/assets` antigos com `rsync --ignore-existing`. Abas abertas e HTML cacheado podem pedir chunks lazy da build anterior; apagar esses arquivos causa `ChunkLoadError` ate o usuario atualizar.
+5. **Public Assets:** URLs absolutas `/assets/...` dependem da copia de `public/assets/` para o webroot no step `Prepare public assets`.
+6. **Prerender Fix:** O Job de Build SEMPRE executa `scripts/prerender.js`. Se o site estiver gerando "tela branca", o problema costuma estar no timeout do Puppeteer, erro de JS no build ou ativação incorreta do `dist`.
+7. **Composer Security:** Plugins com `composer.json` são instalados no CI com verificação de segurança ativada. Não use `--no-security-blocking` a menos que haja um falso positivo crítico bloqueando deploy de produção sem correção na biblioteca upstream.
 
 ## Key Files
 - `deploy.yml`: O motor principal. Versão atual é a v4.1 (Restaurada).

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -385,6 +385,15 @@ jobs:
               exit 1
             fi
 
+            # Keep old hashed Vite assets reachable for users with an already
+            # loaded SPA or cached HTML. Without this, lazy route chunks from
+            # the previous build can 404 until the user refreshes.
+            if [ -d "${LIVE_DIST_PATH}/assets" ]; then
+              mkdir -p "${NEXT_DIST_PATH}/assets"
+              rsync -a --ignore-existing "${LIVE_DIST_PATH}/assets/" "${NEXT_DIST_PATH}/assets/" || true
+              echo "previous hashed assets preserved for stale clients"
+            fi
+
             rm -rf "${PREV_DIST_PATH}"
             if [ -d "${LIVE_DIST_PATH}" ]; then
               mv "${LIVE_DIST_PATH}" "${PREV_DIST_PATH}"
@@ -423,6 +432,11 @@ jobs:
           if [ -d "public/images" ]; then
              echo "  ✓ Including images/ folder"
              cp -r "public/images" temp_public/
+          fi
+
+          if [ -d "public/assets" ]; then
+             echo "  Including assets/ folder"
+             cp -r "public/assets" temp_public/
           fi
           
           # Copiar .well-known

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ Produção: https://djzeneyer.com
 - **`safeUrl(null)`** retorna `'#'` (truthy) → `safeUrl(url) || fallback` NUNCA executa. Sempre: `safeUrl(url, '/fallback.svg')`.
 - **`loadingInitial` vs `loading`** no UserContext: usar `loadingInitial` em guards de rota privada — `loading` é para ações, default `false`, e causa tela branca no CTRL+F5.
 - **lucide-react 1.x**: ícones Facebook, Instagram, Youtube foram removidos → usar `src/components/icons/BrandIcons.tsx`.
-- **Vite base path**: assets em `public/` raiz NÃO chegam ao webroot em produção. Usar `public/images/` para assets que precisam ficar na raiz.
+- **Vite base path / assets públicos**: URLs absolutas como `/images/...` e `/assets/...` só chegam ao webroot quando `public/images/` ou `public/assets/` são copiadas pelo deploy. Não assumir que qualquer arquivo solto em `public/` vai para a raiz; confira `Prepare public assets` em `.github/workflows/deploy.yml`.
 - **Class components**: não podem usar `useTranslation()` → usar `withTranslation()` HOC.
 - **Zod v4 + PHP false returns**: `z.union([z.string(), z.literal(false)])` quebra em `null`/`undefined`. Padrão correto: `z.string().catch('')` (campos obrigatórios) ou `z.string().catch('').optional()` (campos opcionais). Nunca usar o padrão union+literal para campos de imagem/URL.
 - **`rankProgress` ZenGame**: o fallback de progresso por posição de rank retornava `0.0` nos dois lados do ternário — corrigido. Ao alterar lógica de rank, sempre testar o caminho sem `gamipress_get_rank_requirements_progress()`.
@@ -122,6 +122,7 @@ Produção: https://djzeneyer.com
 ### Build e Deploy
 - Minificador: OXC (padrão Vite 8) — nunca `minify: 'esbuild'`.
 - Prerender: `scripts/prerender.js` via Puppeteer — nunca remover.
+- Deploy SPA: preservar assets Vite hashados antigos em `dist/assets` durante a troca `dist-next` → `dist`; abas abertas podem pedir chunks lazy da build anterior.
 - ESLint ignores obrigatórios: `.claude`, `.agents`, `.bolt`, `.gemini`, `.jules`, `.devcontainer`.
 - `fetch-depth: 2` no CI — nunca `0`.
 

--- a/AI_CONTEXT_INDEX.md
+++ b/AI_CONTEXT_INDEX.md
@@ -33,6 +33,7 @@ Se houver divergencia: siga a ordem acima e atualize o arquivo inferior.
 - Infra: Hostinger VPS + LiteSpeed + Cloudflare + GitHub Actions
 - Cache em producao: LiteSpeed Cache 7.8.1 ativo, `WP_CACHE=true`, REST cache habilitado, ESI desabilitado, minificação CSS/JS desabilitada no provedor e defer de JS ativo
 - Deploy de frontend: o `dist/` deve ser publicado via pasta de staging (`dist-next`) e trocado de forma atomica para evitar tela branca durante rollout
+- Deploy de frontend: antes de ativar `dist-next`, preservar assets Vite hashados antigos em `dist/assets` com `rsync --ignore-existing`; abas abertas e HTML cacheado podem pedir chunks lazy da build anterior, e remover esses arquivos causa `ChunkLoadError`/tela de erro ate o usuario atualizar
 - Deploy de plugins: `plugins/` nao deve ser republicado em pushes que nao alterem `plugins/**`, para nao sobrescrever hotfixes ou reintroduzir backend quebrado
 
 ## Regras globais (SSOT)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ Esses pontos ja aparecem em PRs, reviews, docs ou codigos atuais e nao devem ser
 - `loadingInitial` e o estado seguro para guardas de rota privada; `loading` nao substitui esse papel.
 - `lucide-react` 1.x removeu alguns icones de marca, como Facebook, Instagram e YouTube; o projeto usa `BrandIcons.tsx` quando necessario.
 - `localStorage` e `sessionStorage` nao estao proibidos globalmente, mas ficam restritos a sessao e idioma quando ja adotados.
+- `ChunkLoadError` ao clicar em links apos deploy normalmente significa aba aberta/HTML cacheado usando bundle anterior; preservar `dist/assets` antigos no deploy e manter recuperacao client-side antes de culpar rota ou React Router.
 - `speakable` e intencional em algumas paginas; `cssSelector` so faz sentido para seletores que existem no DOM.
 - MusicEvent precisa manter campos obrigatorios, com fallback quando a fonte nao entrega tudo:
   - `eventStatus`

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,6 +28,7 @@
 - Rotas privadas usam `noindex`.
 - Mudanca em dependencia exige lockfile sincronizado.
 - PR duplicado deve ser consolidado em um branch canonico.
+- Deploy SPA preserva assets Vite hashados antigos para abas abertas e HTML cacheado.
 
 ## Quando este arquivo ajuda
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -35,6 +35,7 @@ Este arquivo nao tenta repetir toda a base do projeto. Ele serve para ajustes de
 - Rotas publicas usam `<HeadlessSEO />`.
 - Rotas privadas usam `noindex` e OG image generica.
 - `package-lock.json` acompanha `package.json` em mudancas de dependencia.
+- Deploy Vite preserva assets hashados antigos para evitar `ChunkLoadError` em abas abertas apos troca de build.
 - Review de bots e triagem, nao veredito final.
 
 ## O que este arquivo nao faz

--- a/docs/AI_GOVERNANCE.md
+++ b/docs/AI_GOVERNANCE.md
@@ -48,6 +48,8 @@ Em caso de conflito, aplicar nesta ordem:
 - [ ] GitHub Actions: `fetch-depth: 2`.
 - [ ] Plugins: Verificação de mudanças em `plugins/` via `git diff HEAD^..HEAD`.
 - [ ] Rotas privadas (`dashboard`, `my-account`) excluídas do sitemap e do prerender.
+- [ ] Deploy Vite preserva assets hashados antigos antes da troca `dist-next` -> `dist`, para evitar `ChunkLoadError` em abas abertas ou HTML cacheado.
+- [ ] Assets referenciados por URL absoluta (`/assets/...`) são copiados do `public/assets` para o webroot.
 
 ---
 

--- a/docs/AI_LEARNINGS.md
+++ b/docs/AI_LEARNINGS.md
@@ -46,6 +46,8 @@
 - O JWT canonico do `zeneyer-auth` usa `ZENEYER_JWT_SECRET`; `JWT_AUTH_SECRET_KEY` e `SIMPLE_JWT_PRIVATE_KEY` ficam apenas como compatibilidade legada.
 - O registro protegido do `zeneyer-auth` depende de `ZEN_TURNSTILE_SITE_KEY` e `ZEN_TURNSTILE_SECRET_KEY` no `wp-config.php`.
 - Em LiteSpeed Cache, manter conservador o caminho de SPA: `optm-js_min=false`, `optm-css_min=false`, `optm-js_defer=1`, exclusoes de `react`, `react-dom`, `framer-motion` e bundles do tema.
+- Em deploy de SPA Vite, nunca remover imediatamente os assets hashados antigos de `dist/assets`. Abas abertas e HTML cacheado podem carregar o bundle anterior e pedir chunks lazy antigos; preserve esses arquivos durante a ativacao de `dist-next` e mantenha recuperacao client-side para `ChunkLoadError`.
+- `public/assets/**` precisa ser copiado para o webroot quando URLs absolutas como `/assets/press/...` forem usadas; o `publicDir` do Vite tambem copia para `dist`, mas isso nao substitui assets esperados na raiz publica.
 - Quando a configuracao do LiteSpeed ja estiver estável em producao, nao ligar minificacao/combinacao por impulso; teste antes de mudar.
 - Se o plano de hospedagem nao oferece Redis ou Memcached, manter `object=false` e documentar isso como limitacao da plataforma, nao como omissao de configuracao.
 

--- a/src/components/AppRoutes.tsx
+++ b/src/components/AppRoutes.tsx
@@ -1,8 +1,12 @@
-import React, { lazy } from 'react';
 import { useRoutes, RouteObject } from 'react-router-dom';
 import MainLayout from '../layouts/MainLayout';
 import ErrorBoundary from './common/ErrorBoundary';
-const ZenLinkPage = lazy(() => import('../pages/ZenLinkPage').then(m => ({ default: m.ZenLinkPage })));
+import { lazyWithRetry } from '../utils/lazyWithRetry';
+
+const ZenLinkPage = lazyWithRetry(
+  () => import('../pages/ZenLinkPage').then(m => ({ default: m.ZenLinkPage })),
+  'route:zenlink-standalone'
+);
 // CORREÇÃO: Apontando para o local correto onde você definiu suas rotas
 import {
   ROUTES_CONFIG,

--- a/src/components/common/ErrorBoundary.tsx
+++ b/src/components/common/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import React, { Component, ErrorInfo, ReactNode } from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
+import { recoverFromChunkLoadError } from '../../utils/chunkRecovery';
 
 interface OwnProps {
   children: ReactNode;
@@ -22,6 +23,10 @@ class ErrorBoundaryBase extends Component<Props, State> {
   }
 
   public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    if (recoverFromChunkLoadError(error, 'error-boundary')) {
+      return;
+    }
+
     console.error('Uncaught error in route:', error, errorInfo);
   }
 

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -20,7 +20,8 @@
  * - ZenLink: zenlink / links-zen
  */
 
-import { lazy, ComponentType } from 'react';
+import { ComponentType } from 'react';
+import { lazyWithRetry } from '../utils/lazyWithRetry';
 
 // ============================================================================
 // TYPES
@@ -54,33 +55,33 @@ export interface RouteConfig {
 import HomePage from '../pages/HomePage';
 
 // Demais páginas são lazy loaded
-const AboutPage = lazy(() => import('../pages/AboutPage'));
-const EventsPage = lazy(() => import('../pages/EventsPage'));
-const MusicPage = lazy(() => import('../pages/MusicPage'));
-const ZenTribePage = lazy(() => import('../pages/ZenTribePage'));
-const MediaPage = lazy(() => import('../pages/MediaPage'));
-const PressKitPage = lazy(() => import('../pages/PressKitPage'));
-const PressKitDownloadPage = lazy(() => import('../pages/PressKitDownloadPage'));
-const ShopPage = lazy(() => import('../pages/ShopPage'));
-const ProductPage = lazy(() => import('../pages/ProductPage'));
-const CartPage = lazy(() => import('../pages/CartPage'));
-const CheckoutPage = lazy(() => import('../pages/CheckoutPage'));
-const DashboardPage = lazy(() => import('../pages/DashboardPage'));
-const MyAccountPage = lazy(() => import('../pages/MyAccountPage'));
-const FAQPage = lazy(() => import('../pages/FAQPage'));
-const PhilosophyPage = lazy(() => import('../pages/PhilosophyPage'));
-const NewsPage = lazy(() => import('../pages/NewsPage'));
-const PrivacyPolicyPage = lazy(() => import('../pages/PrivacyPolicyPage'));
-const ReturnPolicyPage = lazy(() => import('../pages/ReturnPolicyPage'));
-const TermsPage = lazy(() => import('../pages/TermsPage'));
-const CodeOfConductPage = lazy(() => import('../pages/CodeOfConductPage'));
-const SupportArtistPage = lazy(() => import('../pages/SupportArtistPage'));
-const TicketsPage = lazy(() => import('../pages/TicketsPage'));
-const TicketsCheckoutPage = lazy(() => import('../pages/TicketsCheckoutPage'));
-const ResetPasswordPage = lazy(() => import('../pages/ResetPasswordPage'));
-const ZenLinkPage = lazy(() => import('../pages/ZenLinkPage').then(m => ({ default: m.ZenLinkPage })));
-const ZoukPersonaQuizPage = lazy(() => import('../pages/ZoukPersonaQuizPage'));
-const NotFoundPage = lazy(() => import('../pages/NotFoundPage'));
+const AboutPage = lazyWithRetry(() => import('../pages/AboutPage'), 'route:about');
+const EventsPage = lazyWithRetry(() => import('../pages/EventsPage'), 'route:events');
+const MusicPage = lazyWithRetry(() => import('../pages/MusicPage'), 'route:music');
+const ZenTribePage = lazyWithRetry(() => import('../pages/ZenTribePage'), 'route:zentribe');
+const MediaPage = lazyWithRetry(() => import('../pages/MediaPage'), 'route:media');
+const PressKitPage = lazyWithRetry(() => import('../pages/PressKitPage'), 'route:booking');
+const PressKitDownloadPage = lazyWithRetry(() => import('../pages/PressKitDownloadPage'), 'route:presskit');
+const ShopPage = lazyWithRetry(() => import('../pages/ShopPage'), 'route:shop');
+const ProductPage = lazyWithRetry(() => import('../pages/ProductPage'), 'route:product');
+const CartPage = lazyWithRetry(() => import('../pages/CartPage'), 'route:cart');
+const CheckoutPage = lazyWithRetry(() => import('../pages/CheckoutPage'), 'route:checkout');
+const DashboardPage = lazyWithRetry(() => import('../pages/DashboardPage'), 'route:dashboard');
+const MyAccountPage = lazyWithRetry(() => import('../pages/MyAccountPage'), 'route:my-account');
+const FAQPage = lazyWithRetry(() => import('../pages/FAQPage'), 'route:faq');
+const PhilosophyPage = lazyWithRetry(() => import('../pages/PhilosophyPage'), 'route:philosophy');
+const NewsPage = lazyWithRetry(() => import('../pages/NewsPage'), 'route:news');
+const PrivacyPolicyPage = lazyWithRetry(() => import('../pages/PrivacyPolicyPage'), 'route:privacy');
+const ReturnPolicyPage = lazyWithRetry(() => import('../pages/ReturnPolicyPage'), 'route:returns');
+const TermsPage = lazyWithRetry(() => import('../pages/TermsPage'), 'route:terms');
+const CodeOfConductPage = lazyWithRetry(() => import('../pages/CodeOfConductPage'), 'route:conduct');
+const SupportArtistPage = lazyWithRetry(() => import('../pages/SupportArtistPage'), 'route:support');
+const TicketsPage = lazyWithRetry(() => import('../pages/TicketsPage'), 'route:tickets');
+const TicketsCheckoutPage = lazyWithRetry(() => import('../pages/TicketsCheckoutPage'), 'route:tickets-checkout');
+const ResetPasswordPage = lazyWithRetry(() => import('../pages/ResetPasswordPage'), 'route:reset-password');
+const ZenLinkPage = lazyWithRetry(() => import('../pages/ZenLinkPage').then(m => ({ default: m.ZenLinkPage })), 'route:zenlink');
+const ZoukPersonaQuizPage = lazyWithRetry(() => import('../pages/ZoukPersonaQuizPage'), 'route:quiz');
+const NotFoundPage = lazyWithRetry(() => import('../pages/NotFoundPage'), 'route:not-found');
 
 import routesSlugs from './routes-slugs.json';
 

--- a/src/utils/chunkRecovery.ts
+++ b/src/utils/chunkRecovery.ts
@@ -1,0 +1,77 @@
+const CHUNK_RECOVERY_KEY = 'djz:chunk-recovery';
+
+const CHUNK_ERROR_PATTERNS = [
+  /ChunkLoadError/i,
+  /Loading chunk \S+ failed/i,
+  /Failed to fetch dynamically imported module/i,
+  /Importing a module script failed/i,
+  /error loading dynamically imported module/i,
+  /Failed to load module script/i,
+  /dynamically imported module/i,
+];
+
+const getErrorText = (error: unknown): string => {
+  if (error instanceof Error) {
+    return `${error.name}: ${error.message}`;
+  }
+
+  return String(error ?? '');
+};
+
+export const isChunkLoadError = (error: unknown): boolean => {
+  const errorText = getErrorText(error);
+  return CHUNK_ERROR_PATTERNS.some((pattern) => pattern.test(errorText));
+};
+
+const getCurrentEntryMarker = (): string => {
+  const script = document.querySelector<HTMLScriptElement>(
+    'script[type="module"][src*="/assets/"]'
+  );
+
+  return script?.src || 'unknown-entry';
+};
+
+const shouldReloadForChunkError = (marker: string): boolean => {
+  try {
+    if (window.sessionStorage.getItem(CHUNK_RECOVERY_KEY) === marker) {
+      return false;
+    }
+
+    window.sessionStorage.setItem(CHUNK_RECOVERY_KEY, marker);
+    return true;
+  } catch {
+    const windowWithRecoveryFlag = window as Window & {
+      __DJZ_CHUNK_RECOVERY_MARKER__?: string;
+    };
+
+    if (windowWithRecoveryFlag.__DJZ_CHUNK_RECOVERY_MARKER__ === marker) {
+      return false;
+    }
+
+    windowWithRecoveryFlag.__DJZ_CHUNK_RECOVERY_MARKER__ = marker;
+    return true;
+  }
+};
+
+export const recoverFromChunkLoadError = (
+  error: unknown,
+  source: string
+): boolean => {
+  if (typeof window === 'undefined' || !isChunkLoadError(error)) {
+    return false;
+  }
+
+  const marker = [
+    getCurrentEntryMarker(),
+    window.location.pathname,
+    window.location.search,
+    source,
+  ].join('|');
+
+  if (!shouldReloadForChunkError(marker)) {
+    return false;
+  }
+
+  window.location.reload();
+  return true;
+};

--- a/src/utils/lazyWithRetry.ts
+++ b/src/utils/lazyWithRetry.ts
@@ -1,0 +1,20 @@
+import { lazy, type ComponentType, type LazyExoticComponent } from 'react';
+import { recoverFromChunkLoadError } from './chunkRecovery';
+
+type LazyComponentModule<T extends ComponentType<object>> = {
+  default: T;
+};
+
+export const lazyWithRetry = <T extends ComponentType<object>>(
+  factory: () => Promise<LazyComponentModule<T>>,
+  source: string
+): LazyExoticComponent<T> =>
+  lazy(() =>
+    factory().catch((error) => {
+      if (recoverFromChunkLoadError(error, source)) {
+        return new Promise<LazyComponentModule<T>>(() => undefined);
+      }
+
+      throw error;
+    })
+  );


### PR DESCRIPTION
## Description
Corrige a falha em que links internos podiam cair no `ErrorBoundary` com `Something went wrong` ate o usuario atualizar a pagina.

Causa tecnica: apos deploy, uma aba aberta ou HTML cacheado pode continuar executando o bundle Vite anterior. Ao clicar numa rota lazy, esse bundle tenta buscar chunks hashados antigos; como o deploy substituia `dist` e apagava os assets anteriores, a requisicao podia virar 404/`ChunkLoadError`. O refresh funciona porque baixa o HTML/bundle atual.

Mudancas:
- adiciona `lazyWithRetry` + `chunkRecovery` para recarregar uma unica vez quando um import lazy falha por chunk antigo;
- usa o wrapper nas rotas lazy de `src/config/routes.ts` e na rota standalone de ZenLink;
- faz o `ErrorBoundary` tambem reconhecer erro de chunk como fallback defensivo;
- preserva `dist/assets` antigos durante a ativacao `dist-next` -> `dist` com `rsync --ignore-existing`;
- copia `public/assets/` para o webroot, necessario para URLs absolutas `/assets/...`;
- atualiza os arquivos de contexto com o aprendizado de deploy.

## Type of Change
- [x] Frontend (React/TypeScript/Vite)
- [x] CI/CD/Deployment
- [x] Documentation
- [x] Bug fix

## Impact Area
- [x] React components (`src/`)
- [x] Deployment (`/.github/workflows`)
- [x] TypeScript types and interfaces

## Testing
- [x] Build passes (`npm run build`)
- [x] ESLint passes (`npm run lint`)
- [x] No TypeScript errors
- [x] Manual testing completed

## Gate Checklist (AI_GOVERNANCE)
- [x] Lazy loading mantido para paginas
- [x] Sem strings visiveis novas sem i18n
- [x] Deploy preserva assets hashados antigos
- [x] Contexto atualizado para mudanca de deploy

## Avaliacao de sugestoes de outros bots
- Sugestoes aproveitadas: nao aplicavel nesta PR.
- Sugestoes rejeitadas: nao aplicavel.
- Risco residual: baixo; se o chunk continuar indisponivel apos reload unico, o ErrorBoundary ainda aparece em vez de loop infinito.
- Proximos passos: merge apos checks.

## Notes for Reviewers
`vite preview` local pela raiz nao representa producao porque o build usa `base=/wp-content/themes/zentheme/dist/`; a navegacao foi validada no dev server, e o build de producao passou.