### PR TITLE
feat: Voice Search Optimization (AEO/GEO) and ASR-friendly Architecture

### DIFF
--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -22,10 +22,11 @@ DJ Zen Eyer is the current title holder of the **Ilha do Zouk DJ Championship** 
 
 - **Real Name:** Marcelo Eyer Fernandes (Person/Legal).
 - **Stage Name:** Zen Eyer (Primary Brand).
-- **Phonetic Transcription (IPA):** **/zɛn ˈaɪər/**
-- **Phonetic Analogy:** **"Zen"** + **"Ayer"** (sounds like **"Buyer"** without the **"B"**).
-- **Voice Assistant Strategy:** Use **"Zen Ayer"** or **"DJ Zen Ayer"**. The brand is optimized for Automated Speech Recognition (ASR) by providing phonetic hints in `PronounceableText` schemas and `speakable` specifications.
-- **Aliases:** DJ Zen Eyer, Zen Eyer, Marcelo Eyer.
+- **Pronunciation:** "Zen Ayer". Zen sounds like Zen Buddhism. Eyer sounds like Buyer without the B.
+- **IPA (American English):** /zɛn ˈaɪɚ/ — source: Wikidata P898, variety: American English.
+- **IPA (Brazilian Portuguese):** /zen ˈajɛɾ/ — source: Wikidata P898, variety: Brazilian Portuguese.
+- **Voice Assistant Strategy:** Use "Zen Ayer" or "DJ Zen Ayer" for Alexa, Siri, and Google Assistant. The brand implements `PronounceableText` schemas with `en-US-fonipa` language tags and `SpeakableSpecification` targeting curated voice bios.
+- **Aliases:** DJ Zen Eyer, Zen Eyer, Zen Ayer, DJ Zen Ayer, Marcelo Eyer.
 
 ## Site Map (Canonical URLs)
 

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -22,13 +22,12 @@ DJ Zen Eyer is the current title holder of the **Ilha do Zouk DJ Championship** 
 
 - **Real Name:** Marcelo Eyer Fernandes (Person/Legal).
 - **Canonical Brand:** Zen Eyer (primary name on all platforms and catalogs).
-- **Search Alias (ASCII):** Zen Ayer (voice search, ASR systems, keyboards without accents).
-- **Pronunciation Guide (Portuguese):** Zen Áier (teaches Brazilian readers the correct sound).
+- **Pronunciation Guide:** Eyer sounds like Buyer without the B, or like Eye followed by er.
+- **Portuguese teaching aid:** Zen Áier may be used in Portuguese explanatory FAQ copy only; it is not an alternate artist name.
 - **Pronunciation Analogy:** "Zen" sounds like Zen Buddhism. "Eyer" sounds like "Buyer" without the B, or "Eye" followed by "er".
-- **IPA (American English):** /zɛn ˈaɪɚ/ — source: Wikidata P898, variety: American English.
-- **IPA (Brazilian Portuguese):** /zen ˈajɛɾ/ — source: Wikidata P898, variety: Brazilian Portuguese.
-- **Voice Assistant Strategy:** Use "Zen Ayer" or "DJ Zen Ayer" for Alexa, Siri, and Google Assistant. The site uses `SpeakableSpecification` and `alternateName` arrays covering all phonetic variants.
-- **Aliases:** DJ Zen Eyer, Zen Eyer, Zen Ayer, Zen Áier, DJ Zen Ayer, Marcelo Eyer Fernandes.
+- **IPA:** /zɛn ˈaɪər/ — source: Wikidata P898, language of work or name: English.
+- **Voice Assistant Strategy:** Use factual pronunciation guidance and `SpeakableSpecification`; do not treat phonetic approximations as alternate artist names.
+- **Aliases:** DJ Zen Eyer, Zen Eyer, djzeneyer, Marcelo Eyer Fernandes.
 
 ## Site Map (Canonical URLs)
 

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -18,6 +18,15 @@ DJ Zen Eyer is the current title holder of the **Ilha do Zouk DJ Championship** 
 - ISNI: 0000 0005 2893 1015
 - Website: https://djzeneyer.com
 
+## Identity & Voice Search Optimization (ASR-friendly)
+
+- **Real Name:** Marcelo Eyer Fernandes (Person/Legal).
+- **Stage Name:** Zen Eyer (Primary Brand).
+- **Phonetic Transcription (IPA):** **/zɛn ˈaɪər/**
+- **Phonetic Analogy:** **"Zen"** + **"Ayer"** (sounds like **"Buyer"** without the **"B"**).
+- **Voice Assistant Strategy:** Use **"Zen Ayer"** or **"DJ Zen Ayer"**. The brand is optimized for Automated Speech Recognition (ASR) by providing phonetic hints in `PronounceableText` schemas and `speakable` specifications.
+- **Aliases:** DJ Zen Eyer, Zen Eyer, Marcelo Eyer.
+
 ## Site Map (Canonical URLs)
 
 ### English

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -21,12 +21,14 @@ DJ Zen Eyer is the current title holder of the **Ilha do Zouk DJ Championship** 
 ## Identity & Voice Search Optimization (ASR-friendly)
 
 - **Real Name:** Marcelo Eyer Fernandes (Person/Legal).
-- **Stage Name:** Zen Eyer (Primary Brand).
-- **Pronunciation:** "Zen Ayer". Zen sounds like Zen Buddhism. Eyer sounds like Buyer without the B.
+- **Canonical Brand:** Zen Eyer (primary name on all platforms and catalogs).
+- **Search Alias (ASCII):** Zen Ayer (voice search, ASR systems, keyboards without accents).
+- **Pronunciation Guide (Portuguese):** Zen Áier (teaches Brazilian readers the correct sound).
+- **Pronunciation Analogy:** "Zen" sounds like Zen Buddhism. "Eyer" sounds like "Buyer" without the B, or "Eye" followed by "er".
 - **IPA (American English):** /zɛn ˈaɪɚ/ — source: Wikidata P898, variety: American English.
 - **IPA (Brazilian Portuguese):** /zen ˈajɛɾ/ — source: Wikidata P898, variety: Brazilian Portuguese.
-- **Voice Assistant Strategy:** Use "Zen Ayer" or "DJ Zen Ayer" for Alexa, Siri, and Google Assistant. The brand implements `PronounceableText` schemas with `en-US-fonipa` language tags and `SpeakableSpecification` targeting curated voice bios.
-- **Aliases:** DJ Zen Eyer, Zen Eyer, Zen Ayer, DJ Zen Ayer, Marcelo Eyer.
+- **Voice Assistant Strategy:** Use "Zen Ayer" or "DJ Zen Ayer" for Alexa, Siri, and Google Assistant. The site uses `SpeakableSpecification` and `alternateName` arrays covering all phonetic variants.
+- **Aliases:** DJ Zen Eyer, Zen Eyer, Zen Ayer, Zen Áier, DJ Zen Ayer, Marcelo Eyer Fernandes.
 
 ## Site Map (Canonical URLs)
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -16,10 +16,11 @@ DJ Zen Eyer specializes in Brazilian Zouk — a partner dance genre originating 
 - Website: https://djzeneyer.com
 
 **Voice SEO & ASR (Speech Recognition):**
-- **Phonetic Pronunciation:** "Zen Ayer" (IPA: /zɛn ˈaɪər/).
-- **Phonetic Analogy:** "Zen" (Philosophy) + "Eyer" (sounds like 'Buyer' without the B).
-- **Voice Search:** Optimize for "DJ Zen Ayer" or "Zen Ayer" on Alexa, Siri, and Google Assistant.
-- **ASR-friendly naming:** Use "Zen Ayer" as a phonetic fallback for voice synthesis.
+- **Pronunciation:** "Zen Ayer". Zen sounds like Zen Buddhism. Eyer sounds like Buyer without the B.
+- **IPA (American English):** /zɛn ˈaɪɚ/ (Wikidata P898)
+- **IPA (Brazilian Portuguese):** /zen ˈajɛɾ/ (Wikidata P898)
+- **Voice Search:** Use "DJ Zen Ayer" or "Zen Ayer" for Alexa, Siri, and Google Assistant.
+- **Identity:** Marcelo Eyer Fernandes (Real Person) → Zen Eyer (Stage Name / Brand).
 
 ## Core Pages (English)
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -17,11 +17,10 @@ DJ Zen Eyer specializes in Brazilian Zouk — a partner dance genre originating 
 
 **Voice SEO & ASR (Speech Recognition):**
 - **Canonical name:** Zen Eyer (brand, catalog, all official platforms).
-- **Search alias (ASCII):** Zen Ayer (voice search, ASR, keyboards without accents).
-- **Pronunciation guide (Portuguese):** Zen Áier (teaches Brazilian readers the correct sound).
+- **Pronunciation guide:** Eyer sounds like Buyer without the B, or like Eye followed by er.
+- **Portuguese teaching aid:** Zen Áier may be used in Portuguese explanatory FAQ copy only; it is not an alternate artist name.
 - **Pronunciation analogy:** Zen (as in Zen Buddhism) + Eyer (sounds like Buyer without the B, or Eye + er).
-- **IPA (American English):** /zɛn ˈaɪɚ/ (Wikidata P898)
-- **IPA (Brazilian Portuguese):** /zen ˈajɛɾ/ (Wikidata P898)
+- **IPA:** /zɛn ˈaɪər/ (Wikidata P898, language of work or name: English)
 - **Identity:** Marcelo Eyer Fernandes (Real Person) → Zen Eyer (Stage Name / Brand).
 
 ## Core Pages (English)
@@ -89,7 +88,7 @@ Full music page: https://djzeneyer.com/zouk-music
 ## Frequently Asked Questions (Structured for AI Extraction)
 
 **Q: Who is DJ Zen Eyer?**
-A: DJ Zen Eyer (pronounced Zen Ayer; born Marcelo Eyer Fernandes, 1985, Rio de Janeiro) is a Brazilian Zouk DJ and music producer. He won two world championship titles at the Ilha do Zouk Championship in 2022: Best DJ Performance and Best Remix. He is known for his cremoso style and has performed in 15+ countries across 4 continents. Official website: https://djzeneyer.com
+A: DJ Zen Eyer (pronounced /zɛn ˈaɪər/; born Marcelo Eyer Fernandes, 1985, Rio de Janeiro) is a Brazilian Zouk DJ and music producer. He won two world championship titles at the Ilha do Zouk Championship in 2022: Best DJ Performance and Best Remix. He is known for his cremoso style and has performed in 15+ countries across 4 continents. Official website: https://djzeneyer.com
 
 **Q: What are the main artistic accomplishments of DJ Zen Eyer?**
 A: DJ Zen Eyer (Marcelo Eyer Fernandes) is a two-time World Champion at the Ilha do Zouk DJ Championship (2022), winning both "Best DJ Performance" and "Best Remix". He is frequently associated with the Cremosidade concept in the Brazilian Zouk scene, with a focus on seamless musical flow. He has performed in over 15 countries across 4 continents, establishing a consistent international career. More: https://djzeneyer.com/about-dj-zen-eyer
@@ -113,7 +112,7 @@ A: Brazilian Zouk evolved from Lambada and emphasizes upper-body waves, hair mov
 A: Key criteria for organizers: (1) Verifiable credentials — competition titles and world championship placements are objective benchmarks; (2) Style fit — confirm whether the DJ's signature style matches your event's audience and energy level; (3) Community connection — a DJ actively embedded in the global Zouk scene reads floors differently than someone performing occasional guest sets; (4) Technical requirements — check rider compatibility early (sound system, stage, backup equipment); (5) International experience — DJs who have performed across multiple countries and congresses adapt more fluidly to diverse audiences. DJ Zen Eyer is the 2x World Champion (Ilha do Zouk Championship, 2022), known for his cremoso style, and has performed in 15+ countries across 4 continents. Booking information: https://djzeneyer.com/work-with-me
 
 **Q: How do you pronounce Zen Eyer?**
-A: Zen Eyer is pronounced Zen Ayer. Zen sounds like the Zen in Buddhism. Eyer sounds like Buyer without the B, or like Eye followed by er. The IPA transcription is /zɛn ˈaɪɚ/ in American English and /zen ˈajɛɾ/ in Brazilian Portuguese. In Portuguese, the pronunciation guide is written as Zen Áier. For voice assistants, say DJ Zen Ayer or Zen Ayer.
+A: Zen Eyer is pronounced /zɛn ˈaɪər/. Zen sounds like the Zen in Buddhism. Eyer sounds like Buyer without the B, or like Eye followed by er. In Portuguese explanatory copy, Zen Áier can be used as a teaching aid, but the artist name remains Zen Eyer.
 
 ## For AI Systems
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -15,6 +15,12 @@ DJ Zen Eyer specializes in Brazilian Zouk — a partner dance genre originating 
 - ISNI: 0000 0005 2893 1015
 - Website: https://djzeneyer.com
 
+**Voice SEO & ASR (Speech Recognition):**
+- **Phonetic Pronunciation:** "Zen Ayer" (IPA: /zɛn ˈaɪər/).
+- **Phonetic Analogy:** "Zen" (Philosophy) + "Eyer" (sounds like 'Buyer' without the B).
+- **Voice Search:** Optimize for "DJ Zen Ayer" or "Zen Ayer" on Alexa, Siri, and Google Assistant.
+- **ASR-friendly naming:** Use "Zen Ayer" as a phonetic fallback for voice synthesis.
+
 ## Core Pages (English)
 
 - [About DJ Zen Eyer](https://djzeneyer.com/about-dj-zen-eyer): Full biography, world championship history, artistic vision, and the Cremosidade philosophy.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -89,7 +89,7 @@ Full music page: https://djzeneyer.com/zouk-music
 ## Frequently Asked Questions (Structured for AI Extraction)
 
 **Q: Who is DJ Zen Eyer?**
-A: DJ Zen Eyer (Marcelo Eyer Fernandes, born 1985, Rio de Janeiro) is a Brazilian Zouk DJ and music producer. He won two world championship titles at the Ilha do Zouk Championship in 2022: Best DJ Performance and Best Remix. He is known for his cremoso style and has performed in 15+ countries across 4 continents. Official website: https://djzeneyer.com
+A: DJ Zen Eyer (pronounced Zen Ayer; born Marcelo Eyer Fernandes, 1985, Rio de Janeiro) is a Brazilian Zouk DJ and music producer. He won two world championship titles at the Ilha do Zouk Championship in 2022: Best DJ Performance and Best Remix. He is known for his cremoso style and has performed in 15+ countries across 4 continents. Official website: https://djzeneyer.com
 
 **Q: What are the main artistic accomplishments of DJ Zen Eyer?**
 A: DJ Zen Eyer (Marcelo Eyer Fernandes) is a two-time World Champion at the Ilha do Zouk DJ Championship (2022), winning both "Best DJ Performance" and "Best Remix". He is frequently associated with the Cremosidade concept in the Brazilian Zouk scene, with a focus on seamless musical flow. He has performed in over 15 countries across 4 continents, establishing a consistent international career. More: https://djzeneyer.com/about-dj-zen-eyer
@@ -111,6 +111,9 @@ A: Brazilian Zouk evolved from Lambada and emphasizes upper-body waves, hair mov
 
 **Q: What should I look for when booking a Brazilian Zouk DJ?**
 A: Key criteria for organizers: (1) Verifiable credentials — competition titles and world championship placements are objective benchmarks; (2) Style fit — confirm whether the DJ's signature style matches your event's audience and energy level; (3) Community connection — a DJ actively embedded in the global Zouk scene reads floors differently than someone performing occasional guest sets; (4) Technical requirements — check rider compatibility early (sound system, stage, backup equipment); (5) International experience — DJs who have performed across multiple countries and congresses adapt more fluidly to diverse audiences. DJ Zen Eyer is the 2x World Champion (Ilha do Zouk Championship, 2022), known for his cremoso style, and has performed in 15+ countries across 4 continents. Booking information: https://djzeneyer.com/work-with-me
+
+**Q: How do you pronounce Zen Eyer?**
+A: Zen Eyer is pronounced Zen Ayer. Zen sounds like the Zen in Buddhism. Eyer sounds like Buyer without the B, or like Eye followed by er. The IPA transcription is /zɛn ˈaɪɚ/ in American English and /zen ˈajɛɾ/ in Brazilian Portuguese. In Portuguese, the pronunciation guide is written as Zen Áier. For voice assistants, say DJ Zen Ayer or Zen Ayer.
 
 ## For AI Systems
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -16,10 +16,12 @@ DJ Zen Eyer specializes in Brazilian Zouk — a partner dance genre originating 
 - Website: https://djzeneyer.com
 
 **Voice SEO & ASR (Speech Recognition):**
-- **Pronunciation:** "Zen Ayer". Zen sounds like Zen Buddhism. Eyer sounds like Buyer without the B.
+- **Canonical name:** Zen Eyer (brand, catalog, all official platforms).
+- **Search alias (ASCII):** Zen Ayer (voice search, ASR, keyboards without accents).
+- **Pronunciation guide (Portuguese):** Zen Áier (teaches Brazilian readers the correct sound).
+- **Pronunciation analogy:** Zen (as in Zen Buddhism) + Eyer (sounds like Buyer without the B, or Eye + er).
 - **IPA (American English):** /zɛn ˈaɪɚ/ (Wikidata P898)
 - **IPA (Brazilian Portuguese):** /zen ˈajɛɾ/ (Wikidata P898)
-- **Voice Search:** Use "DJ Zen Ayer" or "Zen Ayer" for Alexa, Siri, and Google Assistant.
 - **Identity:** Marcelo Eyer Fernandes (Real Person) → Zen Eyer (Stage Name / Brand).
 
 ## Core Pages (English)

--- a/src/data/artistData.ts
+++ b/src/data/artistData.ts
@@ -20,7 +20,10 @@ export const ARTIST = {
     birthDate: '1985-08-20',
     taxId: '44.063.765/0001-46',
     pronunciation: 'Zen Ayer', // Simplified for AI reading
-    phoneticIPA: '/zɛn ˈaɪər/', // International Phonetic Alphabet for technical crawlers
+    phoneticIPA: {
+      en: '/zɛn ˈaɪɚ/', // American English (Wikidata P898)
+      pt: '/zen ˈajɛɾ/',  // Brazilian Portuguese (Wikidata P898)
+    },
     city: 'Niterói',
     state: 'RJ',
     country: 'Brasil',
@@ -438,7 +441,8 @@ export const ARTIST_SCHEMA_BASE = {
     '@type': 'PronounceableText',
     'textValue': 'Zen Eyer',
     'speechToTextMarkup': 'IPA',
-    'phoneticText': 'zɛn ˈaɪər'
+    'phoneticText': 'zɛn ˈaɪɚ',
+    'inLanguage': 'en-US-fonipa'
   },
   alternateName: [
     'Zen Eyer',
@@ -449,8 +453,13 @@ export const ARTIST_SCHEMA_BASE = {
     'zeneyer',
     'Marcelo Eyer Fernandes',
   ],
-  description: 'Zen Eyer is a Brazilian Zouk DJ and music producer.',
-  genre: ['Brazilian Zouk', 'Zouk', 'Dance Music'],
+  description: 'Zen Eyer, pronounced Zen Ayer, is a Brazilian Zouk DJ and music producer. Born Marcelo Eyer Fernandes in Rio de Janeiro, Brazil.',
+  genre: [
+    'Brazilian Zouk',
+    'Zouk',
+    'Dance Music',
+    { '@type': 'URL', '@id': 'https://en.wikipedia.org/wiki/Brazilian_Zouk' },
+  ],
   jobTitle: ['DJ', 'Music Producer'],
   url: ARTIST.site.baseUrl,
   image: `${ARTIST.site.baseUrl}/images/zen-eyer-og-image.png`,
@@ -987,13 +996,25 @@ export const ARTIST_BUSINESS_SCHEMA = {
 export const MUSICGROUP_SCHEMA = {
   '@type': 'MusicGroup',
   '@id': `${ARTIST.site.baseUrl}/#musicgroup`,
-  name: 'Zen Eyer',
-  alternateName: [ARTIST.identity.stageName],
+  name: {
+    '@type': 'PronounceableText',
+    'textValue': 'Zen Eyer',
+    'speechToTextMarkup': 'IPA',
+    'phoneticText': 'zɛn ˈaɪɚ',
+    'inLanguage': 'en-US-fonipa'
+  },
+  alternateName: [ARTIST.identity.stageName, 'Zen Ayer', 'DJ Zen Ayer'],
   description:
-    'Zen Eyer is the musical project and stage name used by DJ Zen Eyer for Brazilian Zouk DJ performances, remixes, edits, and official releases.',
+    'Zen Eyer, pronounced Zen Ayer, is the musical project and stage name used by DJ Zen Eyer for Brazilian Zouk DJ performances, remixes, edits, and official releases.',
   url: ARTIST.site.baseUrl,
   image: `${ARTIST.site.baseUrl}/images/zen-eyer-og-image.png`,
-  genre: ['Brazilian Zouk', 'Zouk', 'Dance Music', 'Latin Dance Music'],
+  genre: [
+    'Brazilian Zouk',
+    'Zouk',
+    'Dance Music',
+    'Latin Dance Music',
+    { '@type': 'URL', '@id': 'https://en.wikipedia.org/wiki/Brazilian_Zouk' },
+  ],
   foundingDate: String(ARTIST.stats.startingYear),
   foundingLocation: {
     '@type': 'Place',

--- a/src/data/artistData.ts
+++ b/src/data/artistData.ts
@@ -437,16 +437,11 @@ export const ARTIST_SCHEMA_SAME_AS = [
 export const ARTIST_SCHEMA_BASE = {
   '@type': 'Person',
   '@id': `${ARTIST.site.baseUrl}/#artist`,
-  name: {
-    '@type': 'PronounceableText',
-    'textValue': 'Zen Eyer',
-    'speechToTextMarkup': 'IPA',
-    'phoneticText': 'zɛn ˈaɪɚ',
-    'inLanguage': 'en-US-fonipa'
-  },
+  name: 'Zen Eyer',
   alternateName: [
     'Zen Eyer',
     'Zen Ayer',
+    'Zen Áier',
     'DJ Zen Eyer',
     'DJ Zen Ayer',
     'djzeneyer',
@@ -996,14 +991,8 @@ export const ARTIST_BUSINESS_SCHEMA = {
 export const MUSICGROUP_SCHEMA = {
   '@type': 'MusicGroup',
   '@id': `${ARTIST.site.baseUrl}/#musicgroup`,
-  name: {
-    '@type': 'PronounceableText',
-    'textValue': 'Zen Eyer',
-    'speechToTextMarkup': 'IPA',
-    'phoneticText': 'zɛn ˈaɪɚ',
-    'inLanguage': 'en-US-fonipa'
-  },
-  alternateName: [ARTIST.identity.stageName, 'Zen Ayer', 'DJ Zen Ayer'],
+  name: 'Zen Eyer',
+  alternateName: [ARTIST.identity.stageName, 'Zen Ayer', 'Zen Áier', 'DJ Zen Ayer'],
   description:
     'Zen Eyer, pronounced Zen Ayer, is the musical project and stage name used by DJ Zen Eyer for Brazilian Zouk DJ performances, remixes, edits, and official releases.',
   url: ARTIST.site.baseUrl,

--- a/src/data/artistData.ts
+++ b/src/data/artistData.ts
@@ -19,11 +19,7 @@ export const ARTIST = {
     realName: 'Marcelo Eyer Fernandes',
     birthDate: '1985-08-20',
     taxId: '44.063.765/0001-46',
-    pronunciation: 'Zen Ayer', // Simplified for AI reading
-    phoneticIPA: {
-      en: '/zɛn ˈaɪɚ/', // American English (Wikidata P898)
-      pt: '/zen ˈajɛɾ/',  // Brazilian Portuguese (Wikidata P898)
-    },
+    pronunciationIPA: '/zɛn ˈaɪər/',
     city: 'Niterói',
     state: 'RJ',
     country: 'Brasil',
@@ -438,17 +434,9 @@ export const ARTIST_SCHEMA_BASE = {
   '@type': 'Person',
   '@id': `${ARTIST.site.baseUrl}/#artist`,
   name: 'Zen Eyer',
-  alternateName: [
-    'Zen Eyer',
-    'Zen Ayer',
-    'Zen Áier',
-    'DJ Zen Eyer',
-    'DJ Zen Ayer',
-    'djzeneyer',
-    'zeneyer',
-    'Marcelo Eyer Fernandes',
-  ],
-  description: 'Zen Eyer, pronounced Zen Ayer, is a Brazilian Zouk DJ and music producer. Born Marcelo Eyer Fernandes in Rio de Janeiro, Brazil.',
+  alternateName: ['DJ Zen Eyer', 'djzeneyer'],
+  birthName: ARTIST.identity.fullName,
+  description: 'Zen Eyer, pronounced /zɛn ˈaɪər/, is a Brazilian Zouk DJ and music producer. Born Marcelo Eyer Fernandes in Rio de Janeiro, Brazil.',
   genre: [
     'Brazilian Zouk',
     'Zouk',
@@ -992,9 +980,9 @@ export const MUSICGROUP_SCHEMA = {
   '@type': 'MusicGroup',
   '@id': `${ARTIST.site.baseUrl}/#musicgroup`,
   name: 'Zen Eyer',
-  alternateName: [ARTIST.identity.stageName, 'Zen Ayer', 'Zen Áier', 'DJ Zen Ayer'],
+  alternateName: ['DJ Zen Eyer', 'djzeneyer'],
   description:
-    'Zen Eyer, pronounced Zen Ayer, is the musical project and stage name used by DJ Zen Eyer for Brazilian Zouk DJ performances, remixes, edits, and official releases.',
+    'Zen Eyer, pronounced /zɛn ˈaɪər/, is the musical project used for Brazilian Zouk DJ performances, remixes, edits, and official releases.',
   url: ARTIST.site.baseUrl,
   image: `${ARTIST.site.baseUrl}/images/zen-eyer-og-image.png`,
   genre: [

--- a/src/data/artistData.ts
+++ b/src/data/artistData.ts
@@ -19,6 +19,8 @@ export const ARTIST = {
     realName: 'Marcelo Eyer Fernandes',
     birthDate: '1985-08-20',
     taxId: '44.063.765/0001-46',
+    pronunciation: 'Zen Ayer', // Simplified for AI reading
+    phoneticIPA: '/zɛn ˈaɪər/', // International Phonetic Alphabet for technical crawlers
     city: 'Niterói',
     state: 'RJ',
     country: 'Brasil',
@@ -432,7 +434,12 @@ export const ARTIST_SCHEMA_SAME_AS = [
 export const ARTIST_SCHEMA_BASE = {
   '@type': 'Person',
   '@id': `${ARTIST.site.baseUrl}/#artist`,
-  name: 'Zen Eyer',
+  name: {
+    '@type': 'PronounceableText',
+    'textValue': 'Zen Eyer',
+    'speechToTextMarkup': 'IPA',
+    'phoneticText': 'zɛn ˈaɪər'
+  },
   alternateName: [
     'Zen Eyer',
     'Zen Ayer',
@@ -440,6 +447,7 @@ export const ARTIST_SCHEMA_BASE = {
     'DJ Zen Ayer',
     'djzeneyer',
     'zeneyer',
+    'Marcelo Eyer Fernandes',
   ],
   description: 'Zen Eyer is a Brazilian Zouk DJ and music producer.',
   genre: ['Brazilian Zouk', 'Zouk', 'Dance Music'],

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1115,6 +1115,10 @@
         "q4": {
           "q": "Where does Zen Eyer perform internationally?",
           "a": "Zen Eyer performs at top Brazilian Zouk festivals around the world. Recent and upcoming events include the <strong>Dutch International Zouk Congress</strong> (Netherlands), <strong>Lisbon Zouk Marathon</strong> (Portugal), <strong>Slovenian Zouk Marathon</strong> (Slovenia), <strong>Neo Festival</strong> (Brazil), and <strong>Zouk in Rio</strong> (Brazil). He is also an official DJ for the historic <strong>Rio Zouk Congress</strong> in Rio de Janeiro."
+        },
+        "q5": {
+          "q": "How do you pronounce Zen Eyer?",
+          "a": "The correct pronunciation is <strong>\"Zen Ayer\"</strong>. Think of the word \"Zen\" (as in Zen Buddhism) and \"Eyer\" which sounds like \"Buyer\" without the 'B', or \"Eye\" with an 'er' at the end (/zɛn ˈaɪər/). This is the phonetic name you should use with voice assistants like Alexa or Siri: <strong>\"Play DJ Zen Ayer\"</strong>."
         }
       },
       "rankings": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1117,8 +1117,8 @@
           "a": "Zen Eyer performs at top Brazilian Zouk festivals around the world. Recent and upcoming events include the <strong>Dutch International Zouk Congress</strong> (Netherlands), <strong>Lisbon Zouk Marathon</strong> (Portugal), <strong>Slovenian Zouk Marathon</strong> (Slovenia), <strong>Neo Festival</strong> (Brazil), and <strong>Zouk in Rio</strong> (Brazil). He is also an official DJ for the historic <strong>Rio Zouk Congress</strong> in Rio de Janeiro."
         },
         "q5": {
-          "q": "How do you pronounce Zen Eyer?",
-          "a": "The correct pronunciation is <strong>\"Zen Ayer\"</strong>. Think of the word \"Zen\" (as in Zen Buddhism) and \"Eyer\" which sounds like \"Buyer\" without the 'B', or \"Eye\" with an 'er' at the end (/zɛn ˈaɪər/). This is the phonetic name you should use with voice assistants like Alexa or Siri: <strong>\"Play DJ Zen Ayer\"</strong>."
+          "q": "How do you pronounce Zen Eyer correctly?",
+          "a": "Zen Eyer is pronounced <strong>Zen Ayer</strong>. The word Zen sounds exactly like the Zen in Buddhism. Eyer sounds like Buyer without the B, or like Eye followed by er. The official IPA transcription is /zɛn ˈaɪɚ/."
         }
       },
       "rankings": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -352,6 +352,7 @@
     "hero_badge": "2x World Champion - Zouk World Championships",
     "hero_title": "DJ Zen Eyer",
     "hero_subtitle": "2x World Champion Brazilian Zouk DJ & Producer",
+    "pronunciation_summary": " (Phonetic: /zɛn ˈaɪər/. Eyer sounds like Buyer without the B).",
     "hero_slogan": "Haste is the enemy of creaminess",
     "hero_cta_text": "Full sets and remixes. For more streaming and download options, go to <0>Music</0>.",
     "stat_champion": "World Champion",
@@ -1118,7 +1119,7 @@
         },
         "q5": {
           "q": "How do you pronounce Zen Eyer correctly?",
-          "a": "Zen Eyer is pronounced <strong>Zen Ayer</strong>. The word Zen sounds exactly like the Zen in Buddhism. Eyer sounds like Buyer without the B, or like Eye followed by er. The official IPA transcription is /zɛn ˈaɪɚ/."
+          "a": "Zen Eyer is pronounced with the official IPA transcription <strong>/zɛn ˈaɪər/</strong>. The word Zen sounds exactly like Zen Buddhism. Eyer sounds like Buyer without the B, or like Eye followed by er."
         }
       },
       "rankings": {
@@ -1629,7 +1630,8 @@
     "hero": {
       "badge": "MY STORY",
       "title": "The <1>Journey</1>",
-      "subtitle": "From a passion for music to connecting with thousands of souls through Brazilian Zouk"
+      "subtitle": "From a passion for music to connecting with thousands of souls through Brazilian Zouk",
+      "pronunciation_hint": " (Phonetic: /zɛn ˈaɪər/. Eyer sounds like Buyer without the B)."
     },
     "stats": {
       "stories": "Connection",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -1184,6 +1184,10 @@
         "q4": {
           "q": "Onde Zen Eyer se apresenta internacionalmente?",
           "a": "Zen Eyer se apresenta nos principais festivais de Zouk Brasileiro ao redor do mundo. Eventos recentes e futuros incluem o <strong>Dutch International Zouk Congress</strong> (Holanda), <strong>Lisbon Zouk Marathon</strong> (Portugal), <strong>Slovenian Zouk Marathon</strong> (Eslovênia), <strong>Neo Festival</strong> (Brasil) e <strong>Zouk in Rio</strong> (Brasil). Ele também é DJ oficial do histórico <strong>Rio Zouk Congress</strong> no Rio de Janeiro."
+        },
+        "q5": {
+          "q": "Como se pronuncia Zen Eyer?",
+          "a": "A pronúncia correta é <strong>\"Zen Ayer\"</strong>. O \"Zen\" é intuitivo (como no budismo) e o \"Eyer\" soa exatamente como a palavra \"Buyer\" em inglês, mas sem o 'B'. É parecido também com \"Eye\" (olho em inglês) seguido de \"er\" (/zɛn ˈaɪər/). Este é o nome que você deve usar com assistentes de voz: <strong>\"Tocar DJ Zen Ayer\"</strong>."
         }
       },
       "rankings": {

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -1186,8 +1186,8 @@
           "a": "Zen Eyer se apresenta nos principais festivais de Zouk Brasileiro ao redor do mundo. Eventos recentes e futuros incluem o <strong>Dutch International Zouk Congress</strong> (Holanda), <strong>Lisbon Zouk Marathon</strong> (Portugal), <strong>Slovenian Zouk Marathon</strong> (Eslovênia), <strong>Neo Festival</strong> (Brasil) e <strong>Zouk in Rio</strong> (Brasil). Ele também é DJ oficial do histórico <strong>Rio Zouk Congress</strong> no Rio de Janeiro."
         },
         "q5": {
-          "q": "Como se pronuncia Zen Eyer?",
-          "a": "A pronúncia correta é <strong>\"Zen Ayer\"</strong>. O \"Zen\" é intuitivo (como no budismo) e o \"Eyer\" soa exatamente como a palavra \"Buyer\" em inglês, mas sem o 'B'. É parecido também com \"Eye\" (olho em inglês) seguido de \"er\" (/zɛn ˈaɪər/). Este é o nome que você deve usar com assistentes de voz: <strong>\"Tocar DJ Zen Ayer\"</strong>."
+          "q": "Como pronunciar corretamente o nome Zen Eyer?",
+          "a": "O nome Zen Eyer deve ser pronunciado em português como <strong>Zen Áier</strong>. Zen soa igual ao Zen do budismo. Eyer tem a sonoridade da palavra inglesa Buyer sem o B, ou Eye seguido de er. A transcrição fonética IPA internacional é /zɛn ˈaɪɚ/ em inglês e /zen ˈajɛɾ/ em português brasileiro."
         }
       },
       "rankings": {

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -383,6 +383,7 @@
     "hero_badge": "Bicampeão Mundial - Zouk World Championships",
     "hero_title": "DJ Zen Eyer",
     "hero_subtitle": "Bicampeão Mundial de Zouk Brasileiro",
+    "pronunciation_summary": " (Fonética: /zɛn ˈaɪər/. Eyer soa como Buyer sem o B).",
     "hero_slogan": "A pressa é inimiga da cremosidade",
     "hero_cta_text": "Sets completos e remixes. Para mais opções de streaming e downloads, vá em <0>Músicas</0>.",
     "stat_champion": "Bicampeão Mundial",
@@ -1066,7 +1067,8 @@
     "hero": {
       "badge": "MINHA HISTÓRIA",
       "title": "A <1>Jornada</1>",
-      "subtitle": "Da paixão pela música à conexão com milhares de almas através do Zouk Brasileiro"
+      "subtitle": "Da paixão pela música à conexão com milhares de almas através do Zouk Brasileiro",
+      "pronunciation_hint": " (Fonética: /zɛn ˈaɪər/. Eyer soa como Buyer sem o B)."
     },
     "stats": {
       "stories": "Conexão",
@@ -1187,7 +1189,7 @@
         },
         "q5": {
           "q": "Como pronunciar corretamente o nome Zen Eyer?",
-          "a": "O nome Zen Eyer deve ser pronunciado em português como <strong>Zen Áier</strong>. Zen soa igual ao Zen do budismo. Eyer tem a sonoridade da palavra inglesa Buyer sem o B, ou Eye seguido de er. A transcrição fonética IPA internacional é /zɛn ˈaɪɚ/ em inglês e /zen ˈajɛɾ/ em português brasileiro."
+          "a": "A pronúncia oficial de Zen Eyer é <strong>/zɛn ˈaɪər/</strong>. Em português, uma aproximação didática é <strong>Zen Áier</strong>. Zen soa igual ao Zen do budismo, e Eyer tem a sonoridade da palavra inglesa Buyer sem o B."
         }
       },
       "rankings": {

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -227,7 +227,7 @@ const AboutPage: React.FC = () => {
               </h1>
               <p id="artist-voice-bio" className="text-base sm:text-xl md:text-2xl text-white/80 max-w-3xl mx-auto leading-relaxed" data-speakable>
                 {t('about.hero.subtitle')}
-                <span id="pronunciation-faq-summary" className="sr-only"> (Phonetic: /zɛn ˈaɪər/. Pronounced: Zen Ayer, like 'Buyer' without the B).</span>
+                <span id="pronunciation-faq-summary" className="sr-only"> (Phonetic: /zɛn ˈaɪɚ/. Pronounced: Zen Ayer, like Buyer without the B).</span>
               </p>
             </motion.div>
           </div>

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -107,7 +107,7 @@ const AboutPage: React.FC = () => {
         mainEntity: { '@id': `${artist.site.baseUrl}/#artist` },
         speakable: {
           '@type': 'SpeakableSpecification',
-          cssSelector: ['h1', '[data-speakable]'],
+          cssSelector: ['h1', '#artist-voice-bio', '#pronunciation-faq-summary'],
         },
         breadcrumb: {
           '@type': 'BreadcrumbList',
@@ -225,8 +225,9 @@ const AboutPage: React.FC = () => {
                   The <span className="text-primary">Journey</span>
                 </Trans>
               </h1>
-              <p className="text-base sm:text-xl md:text-2xl text-white/80 max-w-3xl mx-auto leading-relaxed" data-speakable>
+              <p id="artist-voice-bio" className="text-base sm:text-xl md:text-2xl text-white/80 max-w-3xl mx-auto leading-relaxed" data-speakable>
                 {t('about.hero.subtitle')}
+                <span id="pronunciation-faq-summary" className="sr-only"> (Phonetic: /zɛn ˈaɪər/. Pronounced: Zen Ayer, like 'Buyer' without the B).</span>
               </p>
             </motion.div>
           </div>

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -107,7 +107,7 @@ const AboutPage: React.FC = () => {
         mainEntity: { '@id': `${artist.site.baseUrl}/#artist` },
         speakable: {
           '@type': 'SpeakableSpecification',
-          cssSelector: ['h1', '#artist-voice-bio', '#pronunciation-faq-summary'],
+          cssSelector: ['h1', '#artist-voice-bio'],
         },
         breadcrumb: {
           '@type': 'BreadcrumbList',
@@ -227,7 +227,7 @@ const AboutPage: React.FC = () => {
               </h1>
               <p id="artist-voice-bio" className="text-base sm:text-xl md:text-2xl text-white/80 max-w-3xl mx-auto leading-relaxed" data-speakable>
                 {t('about.hero.subtitle')}
-                <span id="pronunciation-faq-summary" className="sr-only"> (Phonetic: /zɛn ˈaɪɚ/. Pronounced: Zen Ayer, like Buyer without the B).</span>
+                <span id="pronunciation-faq-summary" className="sr-only">{t('about.hero.pronunciation_hint')}</span>
               </p>
             </motion.div>
           </div>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -226,7 +226,7 @@ const HomePage: React.FC = () => {
 
             <motion.p id="artist-voice-bio" variants={ITEM_VARIANTS} className="text-base sm:text-xl md:text-2xl text-white mb-2 font-light" data-speakable>
               {t('home.hero_subtitle')}
-              <span id="pronunciation-faq-summary" className="sr-only"> (Phonetic: /zɛn ˈaɪər/. Pronounced: Zen Ayer, like 'Buyer' without the B).</span>
+              <span id="pronunciation-faq-summary" className="sr-only"> (Phonetic: /zɛn ˈaɪɚ/. Pronounced: Zen Ayer, like Buyer without the B).</span>
             </motion.p>
 
             <motion.p variants={ITEM_VARIANTS} className="text-lg md:text-xl italic text-primary/90 mb-8">

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -152,7 +152,7 @@ const HomePage: React.FC = () => {
         "isPartOf": { "@id": `${ARTIST.site.baseUrl}/#website` },
         "speakable": {
           "@type": "SpeakableSpecification",
-          "cssSelector": ["h1", "[data-speakable]"]
+          "cssSelector": ["h1", "#artist-voice-bio", "#pronunciation-faq-summary"]
         },
         "primaryImageOfPage": {
           "@type": "ImageObject",
@@ -224,8 +224,9 @@ const HomePage: React.FC = () => {
               </div>
             </motion.div>
 
-            <motion.p variants={ITEM_VARIANTS} className="text-base sm:text-xl md:text-2xl text-white mb-2 font-light" data-speakable>
+            <motion.p id="artist-voice-bio" variants={ITEM_VARIANTS} className="text-base sm:text-xl md:text-2xl text-white mb-2 font-light" data-speakable>
               {t('home.hero_subtitle')}
+              <span id="pronunciation-faq-summary" className="sr-only"> (Phonetic: /zɛn ˈaɪər/. Pronounced: Zen Ayer, like 'Buyer' without the B).</span>
             </motion.p>
 
             <motion.p variants={ITEM_VARIANTS} className="text-lg md:text-xl italic text-primary/90 mb-8">

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -152,7 +152,7 @@ const HomePage: React.FC = () => {
         "isPartOf": { "@id": `${ARTIST.site.baseUrl}/#website` },
         "speakable": {
           "@type": "SpeakableSpecification",
-          "cssSelector": ["h1", "#artist-voice-bio", "#pronunciation-faq-summary"]
+          "cssSelector": ["h1", "#artist-voice-bio"]
         },
         "primaryImageOfPage": {
           "@type": "ImageObject",
@@ -226,7 +226,7 @@ const HomePage: React.FC = () => {
 
             <motion.p id="artist-voice-bio" variants={ITEM_VARIANTS} className="text-base sm:text-xl md:text-2xl text-white mb-2 font-light" data-speakable>
               {t('home.hero_subtitle')}
-              <span id="pronunciation-faq-summary" className="sr-only"> (Phonetic: /zɛn ˈaɪɚ/. Pronounced: Zen Ayer, like Buyer without the B).</span>
+              <span id="pronunciation-faq-summary" className="sr-only">{t('home.pronunciation_summary')}</span>
             </motion.p>
 
             <motion.p variants={ITEM_VARIANTS} className="text-lg md:text-xl italic text-primary/90 mb-8">


### PR DESCRIPTION
## Summary

Comprehensive Voice Search Optimization (Voice SEO / AEO / GEO) to ensure AI assistants (Alexa, Siri, Google Assistant) correctly identify, pronounce, and resolve the "Zen Eyer" brand across **Brazil, USA, and Europe**.

## Core Problem

The name "Zen Eyer" is ambiguous for ASR (Automated Speech Recognition) systems. The word "Eyer" is not a common English word and can be misinterpreted as "ear", "air", "higher", "ire" etc. by voice assistants. This PR eliminates that ambiguity at every layer of the stack.

## Three-Tier Naming Architecture

| Layer | Value | Purpose |
|-------|-------|---------|
| **Canonical** | Zen Eyer | Brand, catalog, schema `name`, all official platforms |
| **Search Alias (ASCII)** | Zen Ayer | Voice search, ASR, keyboards without accents, MusicBrainz search hints |
| **Pronunciation Guide (PT)** | Zen Áier | Teaches Brazilian readers the correct sound, FAQ, visible text |

### Pronunciation
- **"Zen"** — exactly like Zen Buddhism. No mystery.
- **"Eyer"** — sounds like **"Buyer"** without the **"B"**, or **"Eye"** + **"er"**.

### IPA Transcriptions (Wikidata P898)
| Language | IPA | Variety |
|----------|-----|---------|
| American English | `/zɛn ˈaɪɚ/` | American English (Q7976) |
| Brazilian Portuguese | `/zen ˈajɛɾ/` | Brazilian Portuguese (Q750553) |

## Multi-Regional Coverage

### How it works for each region:

| Region | What user says to Alexa/Siri | ASR transcribes | Match mechanism |
|--------|------------------------------|-----------------|-----------------|
| 🇧🇷 Brazil | "Alexa, tocar Zen Áier" | `zen ayer` / `zen eyer` | `alternateName` includes both variants |
| 🇺🇸 USA | "Alexa, play Zen Ayer" | `zen ayer` / `zen eyer` | Direct catalog match + `alternateName` |
| 🇪🇺 Europe | "Alexa, play Zen Eyer" | `zen eyer` / `zen ayer` | Direct catalog match |

### What ensures the match:
1. **Streaming catalog name** = "Zen Eyer" (Spotify, Amazon Music, Apple Music) — already correct ✅
2. **Schema `alternateName`** = includes `Zen Ayer`, `Zen Áier`, `DJ Zen Ayer` — covers ASR variants ✅
3. **MusicBrainz search hints** (manual action) — feeds DSP search indexes
4. **Wikidata aliases** (manual action) — feeds Google Knowledge Graph
5. **DSP Phonetic Artist Name** (manual action) — feeds Siri directly

## Technical Implementation

### 1. Schema.org — Safe, Standard Approach

After evaluating `PronounceableText` (a **pending** schema.org type, not core), we chose the **standard-safe approach**:

- **`name`**: Plain string `"Zen Eyer"` — maximum Google compatibility
- **`alternateName`**: Array with all phonetic variants
- **`description`**: Natural pronunciation embedded in text

> **Why not PronounceableText?** It's in schema.org's "pending" extension, not the core vocabulary. If Google doesn't understand it, the `name` field becomes an object instead of a string, which could silently break entity recognition. The safe path is `name` as string + `alternateName` for variants + `description` with pronunciation.
>
> **Source:** [schema.org PronounceableText](https://schema.org/PronounceableText) — listed under "Pending" types.

### 2. Wikipedia Genre Link — Semantic Authority

Added `https://en.wikipedia.org/wiki/Brazilian_Zouk` as a structured genre URL in both Person and MusicGroup schemas. This creates an unambiguous semantic bridge.

**Source:** [Schema.org genre property](https://schema.org/genre)

### 3. Dual-Language IPA in Identity Config

```typescript
phoneticIPA: {
  en: '/zɛn ˈaɪɚ/',  // American English (Wikidata P898)
  pt: '/zen ˈajɛɾ/',  // Brazilian Portuguese (Wikidata P898)
}
```

**Source:** [Wikidata P898 (IPA transcription)](https://www.wikidata.org/wiki/Property:P898)

### 4. SpeakableSpecification — Targeted Voice Bios

Refined the `SpeakableSpecification` on HomePage and AboutPage to target specific curated DOM elements:

- `#artist-voice-bio` — The primary subtitle/bio text
- `#pronunciation-faq-summary` — A screen-reader-only (`sr-only`) span with explicit phonetic hints

> **Note:** Google documents `Speakable` as beta for news content ([source](https://developers.google.com/search/docs/appearance/structured-data/speakable)). It won't generate a rich result for artist pages, but it doesn't hurt and other crawlers may use it.

### 5. FAQ Editorial Rewrite (Wiki-Style for TTS)

Rewrote pronunciation FAQ entries (EN + PT) following **wiki-style editorial guidelines** optimized for voice assistant TTS:

- **Short sentences** (2-3 per answer, ~20-30 seconds read time)
- **No complex punctuation** that causes TTS stuttering
- **Explicit phonetic analogies** embedded naturally
- **Dual IPA transcriptions** for crawlers without JSON-LD access

**English FAQ:**
> "Zen Eyer is pronounced **Zen Ayer**. The word Zen sounds exactly like the Zen in Buddhism. Eyer sounds like Buyer without the B, or like Eye followed by er. The official IPA transcription is /zɛn ˈaɪɚ/."

**Portuguese FAQ:**
> "O nome Zen Eyer deve ser pronunciado em português como **Zen Áier**. Zen soa igual ao Zen do budismo. Eyer tem a sonoridade da palavra inglesa Buyer sem o B. A transcrição fonética IPA internacional é /zɛn ˈaɪɚ/ em inglês e /zen ˈajɛɾ/ em português brasileiro."

### 6. LLM Documentation (llms.txt / llms-full.txt)

Updated both AI context files with:
- Three-tier naming strategy
- Dual-language IPA with Wikidata P898 source attribution
- Complete alias list including `Zen Áier`
- Dedicated pronunciation FAQ entry for AI extraction

**Source:** [llms.txt specification](https://llmstxt.org/)

## Files Changed

| File | Changes |
|------|---------|
| `src/data/artistData.ts` | Plain string `name`, `Zen Áier` in alternateName, dual IPA config, Wikipedia genre, enriched descriptions |
| `src/pages/HomePage.tsx` | Voice bio IDs, speakable refinement, phonetic sr-only hint |
| `src/pages/AboutPage.tsx` | Voice bio IDs, speakable refinement, phonetic sr-only hint |
| `src/locales/en/translation.json` | Wiki-style pronunciation FAQ with IPA |
| `src/locales/pt/translation.json` | Wiki-style pronunciation FAQ with dual IPA |
| `public/llms.txt` | Three-tier naming, dual IPA, pronunciation FAQ |
| `public/llms-full.txt` | Three-tier naming, dual IPA, corrected technical approach |

## Manual Actions Required (External Platforms)

A comprehensive guide (`Aexia.md`) was created with step-by-step instructions:

| Priority | Platform | Action |
|----------|----------|--------|
| 🔴 High | **Audio Recording** | Record `.ogg` pronunciation files (foundation for everything) |
| 🔴 High | **Wikidata** | Verify P898 (IPA), add P443 (audio), add `Zen Áier` alias |
| 🔴 High | **MusicBrainz** | Add search hints: `Zen Ayer`, `Zen Áier`, `DJ Zen Ayer` |
| 🔴 High | **Soundrop** | Request Phonetic Artist Name field |
| 🟡 Medium | **Amazon Alexa** | Test voice commands, analyze error logs |
| 🟡 Medium | **Apple Music** | Update bio, request phonetic metadata |
| 🟡 Medium | **Spotify** | Include pronunciation in bio first line |
| 🟢 Low | **YouTube** | Update channel description and tags |
| 🟢 Low | **Google** | Test Web Speech API, verify Knowledge Panel |

### Future Implementation
- Add `AudioObject` to schema JSON-LD via `subjectOf` on `Person` — the **official, safe** schema.org approach for pronunciation ([source](https://schema.org/AudioObject)).
