### PR TITLE
Corrige i18n do schema WebSite da home

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -332,7 +332,6 @@
   "play_featured_mix": "Play Featured Mix",
   "upcoming_events": "Upcoming Events",
   "home": {
-    "site_name": "DJ Zen Eyer - Official Website",
     "site_desc": "Official website of DJ Zen Eyer, 2x World Champion Brazilian Zouk DJ & Producer",
     "page_title": "DJ Zen Eyer | 2x World Champion Brazilian Zouk DJ & Producer",
     "page_meta_desc": "DJ Zen Eyer, two-time world champion (Best Remix & Best DJ Performance) at Brazilian Zouk World Championships. Book for international events.",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -332,6 +332,8 @@
   "play_featured_mix": "Play Featured Mix",
   "upcoming_events": "Upcoming Events",
   "home": {
+    "site_name": "DJ Zen Eyer - Official Website",
+    "site_desc": "Official website of DJ Zen Eyer, 2x World Champion Brazilian Zouk DJ & Producer",
     "page_title": "DJ Zen Eyer | 2x World Champion Brazilian Zouk DJ & Producer",
     "page_meta_desc": "DJ Zen Eyer, two-time world champion (Best Remix & Best DJ Performance) at Brazilian Zouk World Championships. Book for international events.",
     "headline": "Experience the <1>Zen</1> in Brazilian Zouk",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -363,7 +363,6 @@
   "play_featured_mix": "Ouvir no SoundCloud",
   "upcoming_events": "Próximos Eventos",
   "home": {
-    "site_name": "DJ Zen Eyer - Site Oficial",
     "site_desc": "Site oficial do DJ Zen Eyer, bicampe\u00e3o mundial de Zouk Brasileiro e produtor musical",
     "page_title": "DJ Zen Eyer | Bicampeão Mundial de Zouk Brasileiro",
     "page_meta_desc": "DJ Zen Eyer, bicampeão mundial (Melhor Remix e Melhor Performance DJ) no Brazilian Zouk World Championships. Contrate para eventos internacionais.",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -363,6 +363,8 @@
   "play_featured_mix": "Ouvir no SoundCloud",
   "upcoming_events": "Próximos Eventos",
   "home": {
+    "site_name": "DJ Zen Eyer - Site Oficial",
+    "site_desc": "Site oficial do DJ Zen Eyer, bicampe\u00e3o mundial de Zouk Brasileiro e produtor musical",
     "page_title": "DJ Zen Eyer | Bicampeão Mundial de Zouk Brasileiro",
     "page_meta_desc": "DJ Zen Eyer, bicampeão mundial (Melhor Remix e Melhor Performance DJ) no Brazilian Zouk World Championships. Contrate para eventos internacionais.",
     "headline": "Experiencie o <1>Zen</1> no Zouk Brasileiro",

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -127,10 +127,8 @@ const HomePage: React.FC = () => {
         "@type": "WebSite",
         "@id": `${ARTIST.site.baseUrl}/#website`,
         "url": ARTIST.site.baseUrl,
-        "name": seoSettings?.real_name || t('home.site_name', { defaultValue: 'DJ Zen Eyer - Official Website' }),
-        "description": t('home.site_desc', {
-          defaultValue: 'Official website of DJ Zen Eyer, 2x World Champion Brazilian Zouk DJ & Producer',
-        }),
+        "name": "Zen Eyer",
+        "description": t('home.site_desc'),
         "publisher": { "@id": `${ARTIST.site.baseUrl}/#artist` },
         "inLanguage": ["en", "pt-BR"],
         "potentialAction": {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -127,8 +127,10 @@ const HomePage: React.FC = () => {
         "@type": "WebSite",
         "@id": `${ARTIST.site.baseUrl}/#website`,
         "url": ARTIST.site.baseUrl,
-        "name": seoSettings?.real_name || "DJ Zen Eyer - Official Website",
-        "description": "Official website of DJ Zen Eyer, 2× World Champion Brazilian Zouk DJ & Producer",
+        "name": seoSettings?.real_name || t('home.site_name', { defaultValue: 'DJ Zen Eyer - Official Website' }),
+        "description": t('home.site_desc', {
+          defaultValue: 'Official website of DJ Zen Eyer, 2x World Champion Brazilian Zouk DJ & Producer',
+        }),
         "publisher": { "@id": `${ARTIST.site.baseUrl}/#artist` },
         "inLanguage": ["en", "pt-BR"],
         "potentialAction": {


### PR DESCRIPTION
## Description
Corrige o schema `WebSite` da Home para usar i18n em `name` e `description`, mantendo o `SearchAction` existente apontando para a busca funcional de News.

## Type of Change
- [x] Frontend (React/TypeScript/Vite)
- [x] Bug fix

## Impact Area
- [x] React components (`src/`)
- [x] TypeScript types and interfaces

## Testing
- [x] Build passes (`npm run build`)
- [x] ESLint passes (`npm run lint`)
- [x] No TypeScript errors

## Gate Checklist (AI_GOVERNANCE)
- [x] Sem strings visíveis hardcoded (paridade i18n PT/EN quando aplicável)
- [x] `HeadlessSEO` validado para mudanças de página/rota
- [x] Sem conflito com `AGENTS.md` e contextos locais

## 🤖 Avaliação de sugestões de outros bots
- Sugestões aproveitadas: i18n do `WebSite` schema.
- Sugestões rejeitadas: criar `/search`; o contexto consolidado define News como alvo canônico de `SearchAction`.
- Risco residual: baixo.
- Próximos passos: aguardar review.

## Notes for Reviewers
Lint passou com 2 warnings preexistentes em `src/pages/MyAccountPage.tsx` sobre eslint-disable sem uso.

## Final Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code
- [x] Documentation updated (if needed)
- [x] Ready for production

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Localização**
  * Adicionadas strings de tradução do site em inglês e português, incluindo nome e descrição do site.
  * A página inicial agora utiliza strings localizadas em vez de valores fixos para nome e descrição, melhorando o suporte multilíngue.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarceloEyer/djzeneyer/pull/438)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->