### PR TITLE
Corrige i18n da pronuncia invisivel

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -352,6 +352,7 @@
     "hero_badge": "2x World Champion - Zouk World Championships",
     "hero_title": "DJ Zen Eyer",
     "hero_subtitle": "2x World Champion Brazilian Zouk DJ & Producer",
+    "pronunciation_summary": " (Phonetic: /zɛn ˈaɪɚ/. Pronounced: Zen Ayer, like Buyer without the B).",
     "hero_slogan": "Haste is the enemy of creaminess",
     "hero_cta_text": "Full sets and remixes. For more streaming and download options, go to <0>Music</0>.",
     "stat_champion": "World Champion",
@@ -1629,7 +1630,8 @@
     "hero": {
       "badge": "MY STORY",
       "title": "The <1>Journey</1>",
-      "subtitle": "From a passion for music to connecting with thousands of souls through Brazilian Zouk"
+      "subtitle": "From a passion for music to connecting with thousands of souls through Brazilian Zouk",
+      "pronunciation_hint": " (Phonetic: /zɛn ˈaɪɚ/. Pronounced: Zen Ayer, like Buyer without the B)."
     },
     "stats": {
       "stories": "Connection",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -383,6 +383,7 @@
     "hero_badge": "Bicampeão Mundial - Zouk World Championships",
     "hero_title": "DJ Zen Eyer",
     "hero_subtitle": "Bicampeão Mundial de Zouk Brasileiro",
+    "pronunciation_summary": " (Fonética: /zɛn ˈaɪɚ/. Pronúncia: Zen Áier, como Buyer sem o B).",
     "hero_slogan": "A pressa é inimiga da cremosidade",
     "hero_cta_text": "Sets completos e remixes. Para mais opções de streaming e downloads, vá em <0>Músicas</0>.",
     "stat_champion": "Bicampeão Mundial",
@@ -1066,7 +1067,8 @@
     "hero": {
       "badge": "MINHA HISTÓRIA",
       "title": "A <1>Jornada</1>",
-      "subtitle": "Da paixão pela música à conexão com milhares de almas através do Zouk Brasileiro"
+      "subtitle": "Da paixão pela música à conexão com milhares de almas através do Zouk Brasileiro",
+      "pronunciation_hint": " (Fonética: /zɛn ˈaɪɚ/. Pronúncia: Zen Áier, como Buyer sem o B)."
     },
     "stats": {
       "stories": "Conexão",

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -227,7 +227,7 @@ const AboutPage: React.FC = () => {
               </h1>
               <p id="artist-voice-bio" className="text-base sm:text-xl md:text-2xl text-white/80 max-w-3xl mx-auto leading-relaxed" data-speakable>
                 {t('about.hero.subtitle')}
-                <span id="pronunciation-faq-summary" className="sr-only"> (Phonetic: /zɛn ˈaɪɚ/. Pronounced: Zen Ayer, like Buyer without the B).</span>
+                <span id="pronunciation-faq-summary" className="sr-only">{t('about.hero.pronunciation_hint')}</span>
               </p>
             </motion.div>
           </div>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -226,7 +226,7 @@ const HomePage: React.FC = () => {
 
             <motion.p id="artist-voice-bio" variants={ITEM_VARIANTS} className="text-base sm:text-xl md:text-2xl text-white mb-2 font-light" data-speakable>
               {t('home.hero_subtitle')}
-              <span id="pronunciation-faq-summary" className="sr-only"> (Phonetic: /zɛn ˈaɪɚ/. Pronounced: Zen Ayer, like Buyer without the B).</span>
+              <span id="pronunciation-faq-summary" className="sr-only">{t('home.pronunciation_summary')}</span>
             </motion.p>
 
             <motion.p variants={ITEM_VARIANTS} className="text-lg md:text-xl italic text-primary/90 mb-8">


### PR DESCRIPTION
## Description
PR empilhado sobre #436. Move as strings `sr-only` de pronúncia para i18n em PT/EN e troca os textos hardcoded em Home/About por `t()`.

## Type of Change
- [x] Frontend (React/TypeScript/Vite)
- [x] Bug fix

## Impact Area
- [x] React components (`src/`)
- [x] TypeScript types and interfaces

## Testing
- [x] Build passes (`npm run build`)
- [x] ESLint passes (`npm run lint`)
- [x] No TypeScript errors
- [x] Locale JSON parse validado com Node

## Gate Checklist (AI_GOVERNANCE)
- [x] Sem strings visíveis hardcoded (paridade i18n PT/EN quando aplicável)
- [x] `HeadlessSEO` validado para mudanças de página/rota
- [x] Sem conflito com `AGENTS.md` e contextos locais

## 🤖 Avaliação de sugestões de outros bots
- Sugestões aproveitadas: i18n para conteúdo `sr-only` de pronúncia.
- Sugestões rejeitadas: nenhuma.
- Risco residual: baixo, dependente do PR base #436.
- Próximos passos: mesclar em #436 antes dele ir para `main`.

## Related Issues
Base: #436

## Notes for Reviewers
Lint passou com 2 warnings preexistentes em `src/pages/MyAccountPage.tsx` sobre eslint-disable sem uso.

## Final Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code
- [x] Ready for production