### PR TITLE
Remove seletor redundante do speakable

### DIFF
--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -107,7 +107,7 @@ const AboutPage: React.FC = () => {
         mainEntity: { '@id': `${artist.site.baseUrl}/#artist` },
         speakable: {
           '@type': 'SpeakableSpecification',
-          cssSelector: ['h1', '#artist-voice-bio', '#pronunciation-faq-summary'],
+          cssSelector: ['h1', '#artist-voice-bio'],
         },
         breadcrumb: {
           '@type': 'BreadcrumbList',

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -152,7 +152,7 @@ const HomePage: React.FC = () => {
         "isPartOf": { "@id": `${ARTIST.site.baseUrl}/#website` },
         "speakable": {
           "@type": "SpeakableSpecification",
-          "cssSelector": ["h1", "#artist-voice-bio", "#pronunciation-faq-summary"]
+          "cssSelector": ["h1", "#artist-voice-bio"]
         },
         "primaryImageOfPage": {
           "@type": "ImageObject",


### PR DESCRIPTION
## Description
PR empilhado sobre #436. Remove `#pronunciation-faq-summary` de `SpeakableSpecification.cssSelector` em Home/About para evitar que a pronúncia invisível seja selecionada separadamente além do bloco de bio.

## Type of Change
- [x] Frontend (React/TypeScript/Vite)
- [x] Bug fix

## Impact Area
- [x] React components (`src/`)

## Testing
- [x] Build passes (`npm run build`)
- [x] ESLint passes (`npm run lint`)
- [x] No TypeScript errors

## Gate Checklist (AI_GOVERNANCE)
- [x] `HeadlessSEO` validado para mudanças de página/rota
- [x] Sem conflito com `AGENTS.md` e contextos locais

## 🤖 Avaliação de sugestões de outros bots
- Sugestões aproveitadas: remover seletor redundante do `SpeakableSpecification`.
- Sugestões rejeitadas: nenhuma.
- Risco residual: baixo, dependente do PR base #436.
- Próximos passos: mesclar em #436 antes dele ir para `main`.

## Related Issues
Base: #436

## Notes for Reviewers
Schema impact: Strong Candidate. A mudança só reduz redundância e mantém seletores reais no DOM.
Lint passou com 2 warnings preexistentes em `src/pages/MyAccountPage.tsx` sobre eslint-disable sem uso.

## Final Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code
- [x] Ready for production