### PR TITLE
Adiciona breadcrumb global limpo

### DIFF
--- a/src/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { ChevronRight, Home } from 'lucide-react';
+import { motion } from 'framer-motion';
+import { useTranslation } from 'react-i18next';
+import { getLocalizedRoute, normalizeLanguage } from '../config/routes';
+
+const BREADCRUMB_INITIAL = { opacity: 0, y: -8 };
+const BREADCRUMB_ANIMATE = { opacity: 1, y: 0 };
+const BREADCRUMB_TRANSITION = { duration: 0.4, ease: 'easeOut' };
+
+export interface BreadcrumbItem {
+  label: string;
+  path?: string;
+}
+
+interface BreadcrumbProps {
+  items: BreadcrumbItem[];
+  className?: string;
+}
+
+export const Breadcrumb: React.FC<BreadcrumbProps> = ({ items, className = '' }) => {
+  const { t, i18n } = useTranslation();
+  const currentLang = normalizeLanguage(i18n.language);
+
+  return (
+    <motion.nav
+      aria-label={t('nav.breadcrumb')}
+      className={className}
+      initial={BREADCRUMB_INITIAL}
+      animate={BREADCRUMB_ANIMATE}
+      transition={BREADCRUMB_TRANSITION}
+    >
+      <ol className="flex flex-wrap items-center gap-2 text-xs sm:text-sm text-white/50">
+        <li>
+          <Link
+            to={getLocalizedRoute('home', currentLang)}
+            className="inline-flex items-center gap-1.5 py-1 font-medium tracking-wide transition-colors hover:text-primary"
+          >
+            <Home size={14} className="text-primary/70" aria-hidden="true" />
+            <span>{t('nav.home')}</span>
+          </Link>
+        </li>
+        {items.map((item, index) => (
+          <li key={`${item.label}-${index}`} className="flex min-w-0 items-center gap-2">
+            <ChevronRight size={14} className="flex-shrink-0 text-white/20" aria-hidden="true" />
+            {item.path ? (
+              <Link
+                to={item.path}
+                className="truncate py-1 font-medium tracking-wide transition-colors hover:text-primary"
+              >
+                {item.label}
+              </Link>
+            ) : (
+              <span className="truncate py-1 font-semibold tracking-wide text-white/80" aria-current="page">
+                {item.label}
+              </span>
+            )}
+          </li>
+        ))}
+      </ol>
+    </motion.nav>
+  );
+};

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -11,6 +11,7 @@
     "shop": "Shop",
     "sign_in": "Sign In",
     "logout": "Logout",
+    "breadcrumb": "Breadcrumb",
     "dashboard": "Dashboard",
     "my_account": "My Account",
     "join_the_tribe": "Join the Tribe",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -11,6 +11,7 @@
     "shop": "Loja",
     "sign_in": "Entrar",
     "logout": "Sair",
+    "breadcrumb": "Navegação estrutural",
     "dashboard": "Painel",
     "my_account": "Minha Conta",
     "join_the_tribe": "Entrar na Tribo",

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -15,6 +15,7 @@ import {
 } from 'lucide-react';
 
 import { HeadlessSEO } from '../components/HeadlessSEO';
+import { Breadcrumb } from '../components/Breadcrumb';
 import { useTranslation, Trans } from 'react-i18next';
 import { ARTIST, ARTIST_SCHEMA_BASE } from '../data/artistData';
 import { useBranding } from '../contexts/BrandingContext';
@@ -201,7 +202,8 @@ const AboutPage: React.FC = () => {
 
         {/* Hero Section */}
         <div className="pt-24 pb-12 relative md:pt-32 md:pb-20">
-          <div className="container mx-auto max-w-6xl relative z-10">
+          <div className="container mx-auto max-w-6xl relative z-10 px-4">
+            <Breadcrumb items={[{ label: t('nav.about') }]} className="mb-8" />
             <motion.div
               initial={FADE_IN_UP_INITIAL}
               animate={FADE_IN_UP_ANIMATE}

--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -1,6 +1,7 @@
 import React, { memo, useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { HeadlessSEO } from '../components/HeadlessSEO';
+import { Breadcrumb } from '../components/Breadcrumb';
 import { useParams, Link, generatePath } from 'react-router-dom';
 import { normalizeLanguage, getLocalizedRoute, type Language } from '../config/routes';
 import { useEventsQuery, useEventById } from '../hooks/useQueries';
@@ -80,6 +81,14 @@ const EventDetailContent = ({ id, lang }: { id: string; lang: string }) => {
         url={`${origin}${getLocalizedRoute('events', lang as Language)}/${id}`}
         image={event.image || undefined}
         events={[event]}
+      />
+
+      <Breadcrumb
+        items={[
+          { label: t('nav.events'), path: getLocalizedRoute('events', lang as Language) },
+          { label: event.title },
+        ]}
+        className="mb-8"
       />
 
       <Link
@@ -326,6 +335,7 @@ const EventsPage: React.FC = () => {
   return (
     <div className="min-h-screen bg-background text-white pt-24 pb-20 px-4">
       <div className="max-w-6xl mx-auto">
+        <Breadcrumb items={[{ label: t('nav.events') }]} className="mb-8" />
         <header className="text-center mb-16 px-4">
           <h1 className="text-3xl md:text-4xl lg:text-5xl font-black mb-4 font-display uppercase text-white tracking-tighter">
             {t('events.title_part1')} <span className="text-primary">{t('events.title_part2')}</span>

--- a/src/pages/FAQPage.tsx
+++ b/src/pages/FAQPage.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { useTranslation, Trans } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import { HeadlessSEO } from '../components/HeadlessSEO';
+import { Breadcrumb } from '../components/Breadcrumb';
 import { ChevronDown, Users, Award, Globe, Brain, Mic2, BookOpen, HeartPulse } from 'lucide-react';
 import { ARTIST } from '../data/artistData';
 import { sanitizeHtml, safeUrl } from '../utils/sanitize';
@@ -135,6 +136,7 @@ const FAQPage: React.FC = () => {
       />
 
       <div className="container mx-auto px-4">
+        <Breadcrumb items={[{ label: t('faq.title') }]} className="mb-8" />
 
         {/* Header */}
         <motion.div

--- a/src/pages/MusicPage.tsx
+++ b/src/pages/MusicPage.tsx
@@ -3,6 +3,7 @@ import React, { useMemo } from 'react';
 import { motion, useReducedMotion } from 'framer-motion';
 import { useTranslation, Trans } from 'react-i18next';
 import { HeadlessSEO } from '../components/HeadlessSEO';
+import { Breadcrumb } from '../components/Breadcrumb';
 import { Music2, Cloud, ExternalLink, Download, Coffee } from 'lucide-react';
 import { YoutubeIcon } from '../components/icons/BrandIcons';
 import { Link, generatePath } from 'react-router-dom';
@@ -207,6 +208,7 @@ const MusicPage: React.FC = () => {
       />
       <div className="min-h-screen bg-background text-white pt-24 pb-20">
         <div className="container mx-auto px-4 max-w-5xl">
+          <Breadcrumb items={[{ label: t('nav.music') }]} className="mb-8" />
 
           <div className="text-center mb-16">
             <motion.div

--- a/src/pages/NewsPage.tsx
+++ b/src/pages/NewsPage.tsx
@@ -13,6 +13,7 @@ import {
 import { useNewsQuery, useNewsBySlug, useNewsTaxonomiesQuery, type WPPost } from '../hooks/useQueries';
 import { normalizeLanguage, getLocalizedRoute } from '../config/routes';
 import { HeadlessSEO } from '../components/HeadlessSEO';
+import { Breadcrumb } from '../components/Breadcrumb';
 import { ARTIST } from '../data/artistData';
 import { sanitizeHtml, safeUrl } from '../utils/sanitize';
 import { stripHtml } from '../utils/text';
@@ -181,29 +182,16 @@ const NewsPage: React.FC = () => {
         />
         <div className="min-h-screen bg-background text-white pt-24 pb-20">
           <div className="container mx-auto px-4 max-w-4xl">
+            <Breadcrumb
+              items={[
+                { label: t('footer_news'), path: getRouteForKey('news') },
+                { label: stripHtml(singlePost?.title?.rendered || '') },
+              ]}
+              className="mb-8"
+            />
             <Link to={getRouteForKey('news')} className="inline-flex items-center gap-2 text-primary hover:text-white transition-colors mb-8 font-bold">
               <ArrowLeft size={20} /> {t('news.back_to_list')}
             </Link>
-
-            <nav aria-label="Breadcrumb" className="mb-8 text-sm text-white/45">
-              <ol className="flex flex-wrap items-center gap-2">
-                <li>
-                  <Link to={getLocalizedRoute('home', normalizedLanguage)} className="hover:text-primary transition-colors">
-                    {t('nav.home')}
-                  </Link>
-                </li>
-                <li aria-hidden="true">/</li>
-                <li>
-                  <Link to={getRouteForKey('news')} className="hover:text-primary transition-colors">
-                    {t('footer_news')}
-                  </Link>
-                </li>
-                <li aria-hidden="true">/</li>
-                <li className="max-w-full truncate text-white/70" aria-current="page">
-                  {stripHtml(singlePost?.title?.rendered || '')}
-                </li>
-              </ol>
-            </nav>
 
             <article>
               <header className="mb-10 text-center">
@@ -259,6 +247,7 @@ const NewsPage: React.FC = () => {
         </div>
 
         <div className="container mx-auto px-4 relative z-10">
+          <Breadcrumb items={[{ label: t('footer_news') }]} className="mb-8" />
 
           <header className="mb-16 border-b border-white/10 pb-8 flex flex-col md:flex-row justify-between items-end gap-6">
             <div>

--- a/src/pages/PhilosophyPage.tsx
+++ b/src/pages/PhilosophyPage.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 import { motion } from 'framer-motion';
 import { HeadlessSEO } from '../components/HeadlessSEO';
+import { Breadcrumb } from '../components/Breadcrumb';
 import { Heart, Music2, Sparkles } from 'lucide-react';
 import { ARTIST } from '../data/artistData';
 import { useTranslation, Trans } from 'react-i18next';
@@ -105,6 +106,9 @@ const PhilosophyPage: React.FC = () => {
             animate="visible"
             variants={HERO_VARIANTS}
           >
+            <div className="flex justify-center">
+              <Breadcrumb items={[{ label: t('philosophy.page_title') }]} className="mb-6" />
+            </div>
             <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-primary/15 border border-primary/30 text-primary text-xs font-bold uppercase tracking-[0.2em] mb-8">
               <Sparkles className="w-3.5 h-3.5" />
               {t('philosophy_page.manifesto_badge')}

--- a/src/pages/PressKitPage.tsx
+++ b/src/pages/PressKitPage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { HeadlessSEO } from '../components/HeadlessSEO';
+import { Breadcrumb } from '../components/Breadcrumb';
 import { useBranding } from '../contexts/BrandingContext';
 import { sanitizeHtml } from '../utils/sanitize';
 import {
@@ -221,6 +222,9 @@ const PressKitPage: React.FC = () => {
               transition={{ duration: 0.7 }}
               className="mx-auto max-w-4xl text-center"
             >
+              <div className="flex justify-center">
+                <Breadcrumb items={[{ label: t('nav.presskit') }]} className="mb-6" />
+              </div>
               <div className="inline-flex items-center rounded-full border border-primary/30 bg-primary/10 px-5 py-2 text-xs font-bold uppercase tracking-[0.28em] text-primary">
                 {t('presskit.tag')}
               </div>

--- a/src/pages/ZenTribePage.tsx
+++ b/src/pages/ZenTribePage.tsx
@@ -14,6 +14,7 @@ import React, { memo, useMemo } from 'react';
 import { motion } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
 import { HeadlessSEO } from '../components/HeadlessSEO';
+import { Breadcrumb } from '../components/Breadcrumb';
 import { getLocalizedRoute, normalizeLanguage } from '../config/routes';
 import { Award, Star, Users, TrendingUp, Shield, Gift, Clock, Zap } from 'lucide-react';
 import { useUser } from '../contexts/UserContext';
@@ -292,6 +293,9 @@ const ZenTribePage: React.FC = () => {
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.5 }}
             >
+              <div className="flex justify-center">
+                <Breadcrumb items={[{ label: t('nav.tribe') }]} className="mb-6" />
+              </div>
               <div className="inline-block mb-4">
                 <div className="bg-primary/20 border border-primary/50 rounded-full px-6 py-2 text-primary font-bold uppercase tracking-wider text-sm">
                   {t('zenTribe.badge')}


### PR DESCRIPTION
## Description
Cria uma implementação limpa de breadcrumb visual para páginas públicas principais, extraída do escopo útil do #435 sem trazer junto mudanças de chunk recovery, deploy, docs globais ou otimizações não relacionadas.

## Type of Change
- [x] Frontend (React/TypeScript/Vite)
- [x] SEO/UX enhancement

## Impact Area
- [x] React components (src/)
- [x] i18n (src/locales)

## Testing
- [x] 
pm run lint passou com 2 warnings preexistentes em src/pages/MyAccountPage.tsx
- [x] 
pm run build passou
- [x] Locale JSON parse validado com Node

## Notes
- src/components/Breadcrumb.tsx usa ria-label via i18n e animações estáveis em escopo de módulo.
- Integração visual discreta em About, Events, FAQ, Music, News, Philosophy, Press Kit e Zen Tribe.
- Não altera deploy/chunk recovery; esses ajustes continuam nos PRs #434/#440/#441.

## Related
Substitui a parte de breadcrumb do #435 com escopo menor e mais seguro.