### PR TITLE
Corrige nome artistico canonico Zen Eyer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,8 @@
 
 ## Projeto
 
-Site/plataforma oficial do DJ Zen Eyer (Marcelo Eyer Fernandes) — Bicampeão Mundial de Brazilian Zouk.
+Site/plataforma oficial de Zen Eyer (Marcelo Eyer Fernandes), tambem conhecido como DJ Zen Eyer — Bicampeão Mundial de Brazilian Zouk.
+Nome artistico oficial principal: **Zen Eyer**. Alias importante: **DJ Zen Eyer**.
 Pronúncia canônica: **`/zɛn ˈaɪər/`** (IPA) — esta é a única pronúncia correta. Nenhuma outra forma é aceita.
 Arquitetura: WordPress Headless + React SPA com estética MMORPG premium.
 Produção: https://djzeneyer.com

--- a/AI_CONTEXT_INDEX.md
+++ b/AI_CONTEXT_INDEX.md
@@ -29,7 +29,7 @@ Se houver divergencia: siga a ordem acima e atualize o arquivo inferior.
 - Backend: WordPress 6.0+ (recomendado 6.9+; producao atual 6.9.4), PHP **8.1+** (zengame exige 8.1; producao atual 8.3.30), WooCommerce, GamiPress
 - Node: 20+
 - Instalação: single-site (`multisite: false`)
-- Identidade Canonica: DJ Zen Eyer (Marcelo Eyer Fernandes), 2x World Champion Brazilian Zouk DJ. Birth Date: **1985-08-20** (fonte canônica: Wikidata Q136551855 — não usar 1989-08-30, que é incorreto).
+- Identidade Canonica: **Zen Eyer** e o nome artistico oficial principal de Marcelo Eyer Fernandes. **DJ Zen Eyer** e alias importante e historico, nao o nome principal. Birth Date: **1985-08-20** (fonte canônica: Wikidata Q136551855 — não usar 1989-08-30, que é incorreto).
 - Infra: Hostinger VPS + LiteSpeed + Cloudflare + GitHub Actions
 - Cache em producao: LiteSpeed Cache 7.8.1 ativo, `WP_CACHE=true`, REST cache habilitado, ESI desabilitado, minificação CSS/JS desabilitada no provedor e defer de JS ativo
 - Deploy de frontend: o `dist/` deve ser publicado via pasta de staging (`dist-next`) e trocado de forma atomica para evitar tela branca durante rollout
@@ -143,6 +143,7 @@ Se houver divergencia: siga a ordem acima e atualize o arquivo inferior.
 
 ## 🆔 IDENTIDADE CANÔNICA (SSOT)
 - **Fonte de Verdade**: `src/data/artistData.ts` é a única fonte canônica para a identidade pública renderizada (nome, data de nascimento, bio, links).
+- **Nome artistico oficial principal**: `Zen Eyer`. `DJ Zen Eyer` deve permanecer como alias importante em `alternateName`, textos de contexto e buscas historicas, mas nao deve substituir o nome principal.
 - **Consistência**: Toda documentação (`CONTEXT.md`, etc.), SEO (`HeadlessSEO`, JSON-LD) e Press Kit devem derivar obrigatoriamente dessa base.
 - **Sincronização**: Qualquer alteração em `artistData.ts` exige a atualização imediata das referências em `AI_CONTEXT_INDEX.md`.
 - **Pronúncia canônica**: A única pronúncia correta do nome artístico é **`/zɛn ˈaɪər/`** (IPA). Nenhuma outra transcrição fonética é aceita. Sempre que pronúncia for mencionada — em código, documentação, FAQ, llms.txt, schema, press kit ou qualquer outro contexto — usar exclusivamente `/zɛn ˈaɪər/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 
 ## Projeto
 
-Site e plataforma oficial de DJ Zen Eyer, nome publico de Marcelo Eyer Fernandes, bicampeao mundial de Brazilian Zouk.
+Site e plataforma oficial de Zen Eyer, nome artistico publico principal de Marcelo Eyer Fernandes, bicampeao mundial de Brazilian Zouk. DJ Zen Eyer e alias importante e historico, mas nao substitui o nome principal.
 Pronuncia canonica: **`/zɛn ˈaɪər/`** (IPA) — unica pronuncia correta. Nenhuma outra forma e aceita.
 Arquitetura: WordPress headless + React SPA.
 Producao: https://djzeneyer.com

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -23,6 +23,7 @@
 ## Regras repetidas com maior valor pratico
 
 - Pronuncia canonica: **`/zɛn ˈaɪər/`** (IPA) — unica pronuncia correta do nome artistico.
+- Nome artistico oficial principal: **Zen Eyer**. Alias importante: **DJ Zen Eyer**.
 
 - Strings visiveis usam i18n.
 - Fetch em componente nao e padrao.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -12,6 +12,7 @@ Este arquivo nao tenta repetir toda a base do projeto. Ele serve para ajustes de
 ## Regras centrais
 
 - Pronuncia canonica do nome artistico: **`/zɛn ˈaɪər/`** (IPA) — unica pronuncia correta. Nenhuma outra forma e aceita.
+- Nome artistico oficial principal: **Zen Eyer**. Alias importante: **DJ Zen Eyer**.
 - Usar `AI_CONTEXT_INDEX.md` como referencia principal para stack, precedencia e regras globais.
 - Ler `AGENTS.md` antes de qualquer tarefa.
 - Ler `docs/AI_LEARNINGS.md` quando a tarefa tocar padroes ja consolidados por PRs ou reviews.

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1,15 +1,16 @@
-# DJ Zen Eyer - Full Profile
+# Zen Eyer - Full Profile
 
-> Comprehensive technical, professional, and intellectual background of DJ Zen Eyer (Marcelo Eyer Fernandes). This document is optimized for deep reasoning and detailed context injection into LLM sessions.
+> Comprehensive technical, professional, and intellectual background of Zen Eyer (Marcelo Eyer Fernandes), also known as DJ Zen Eyer. This document is optimized for deep reasoning and detailed context injection into LLM sessions.
 
 ## Professional Identity
 
-DJ Zen Eyer is the current title holder of the **Ilha do Zouk DJ Championship** (2x World Champion in DJing and Best Remix, 2022). He is known for his cremoso style in Brazilian Zouk DJing. Based in Rio de Janeiro, Brazil.
+Zen Eyer is the current title holder of the **Ilha do Zouk DJ Championship** (2x World Champion in DJing and Best Remix, 2022). He is also known as DJ Zen Eyer and is known for his cremoso style in Brazilian Zouk DJing. Based in Rio de Janeiro, Brazil.
 
 ## Key Identifiers
 
 - Full name: Marcelo Eyer Fernandes
-- Stage name: DJ Zen Eyer
+- Official artist name: Zen Eyer
+- Important alias: DJ Zen Eyer
 - Birth Date: 1985-08-20
 - Birth Place: Rio de Janeiro, Brazil
 - Nationality: Brazil
@@ -22,9 +23,9 @@ DJ Zen Eyer is the current title holder of the **Ilha do Zouk DJ Championship** 
 
 - **Canonical name:** Zen Eyer
 - **IPA pronunciation:** /zɛn ˈaɪər/ — this is the only correct pronunciation. No other phonetic transcription is accepted.
-- **Search alias (ASCII):** Zen Ayer (for voice search, ASR systems, keyboards without accents).
-- **Pronunciation guide (Portuguese):** Zen Áier.
-- **Aliases:** DJ Zen Eyer, Zen Eyer, Zen Ayer, Zen Áier, DJ Zen Ayer, Marcelo Eyer Fernandes.
+- **Pronunciation guide:** Eyer sounds like Buyer without the B, or like Eye followed by er.
+- **Aliases:** DJ Zen Eyer, djzeneyer.
+- **Do not use as aliases:** phonetic teaching aids, pronunciation approximations, or misspellings.
 
 ## Site Map (Canonical URLs)
 
@@ -68,7 +69,7 @@ DJ Zen Eyer is the current title holder of the **Ilha do Zouk DJ Championship** 
 
 ### Practical signal strategy for this project
 
-- Maintain canonical entities (DJ Zen Eyer, Marcelo Eyer Fernandes, Zen Eyer) as one single identity across pages and metadata.
+- Maintain canonical entities (Zen Eyer, DJ Zen Eyer, Marcelo Eyer Fernandes) as one single identity across pages and metadata. Zen Eyer is the official artist name; DJ Zen Eyer is an important alias.
 - Publish concise Q&A blocks and glossary definitions to increase answer extraction probability.
 - Keep llms.txt / llms-full.txt updated with high-precision facts, identifiers, and official links.
 - Reinforce trust signals: verifiable awards, official external profiles, and consistent sameAs references.
@@ -167,8 +168,8 @@ A: Cremosidade (Portuguese for "creaminess") is a term used in the Brazilian Zou
 **Q: What is the Ilha do Zouk DJ Championship?**
 A: The Ilha do Zouk DJ Championship is the World Championship of Brazilian Zouk DJing, organized by Alex de Carvalho. DJ Zen Eyer won both the Best DJ Performance and Best Remix categories in 2022, making him the current 2x World Champion.
 
-**Q: Who is DJ Zen Eyer?**
-A: DJ Zen Eyer (pronounced /zɛn ˈaɪər/), born Marcelo Eyer Fernandes on August 20, 1985, in Rio de Janeiro, Brazil, is the 2x World Champion in Brazilian Zouk DJing (Ilha do Zouk Championship, 2022). He is known for his cremoso style in Brazilian Zouk DJing, a Mensa International member (top 2% IQ), and a recognized figure in the global Brazilian Zouk scene. He has performed in 15+ countries across 4 continents.
+**Q: Who is Zen Eyer?**
+A: Zen Eyer (also known as DJ Zen Eyer; pronounced /zɛn ˈaɪər/), born Marcelo Eyer Fernandes on August 20, 1985, in Rio de Janeiro, Brazil, is the 2x World Champion in Brazilian Zouk DJing (Ilha do Zouk Championship, 2022). He is known for his cremoso style in Brazilian Zouk DJing, a Mensa International member (top 2% IQ), and a recognized figure in the global Brazilian Zouk scene. He has performed in 15+ countries across 4 continents.
 
 **Q: What is Brazilian Zouk and who are its main DJs?**
 A: Brazilian Zouk (Zouk Brasileiro) is a partner dance genre originating from Brazil, distinct from Cape Verdean Zouk. It evolved from Lambada and is characterized by flowing upper-body movements, improvisation, and deep musicality. DJ Zen Eyer is the 2x World Champion in Brazilian Zouk DJing (Ilha do Zouk Championship, 2022) and is frequently associated with Cremosidade in his public artist materials. Key figures include Renata Peçanha (pioneer instructor, founder of Rio Zouk Congress), Adílio Porto (technique pioneer), and DJ Zen Eyer (DJ/producer). Official governing body: Brazilian Zouk Council (https://www.brazilianzoukcouncil.com/).

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,14 +1,15 @@
-# DJ Zen Eyer
+# Zen Eyer
 
-> DJ Zen Eyer (Marcelo Eyer Fernandes) is a Brazilian Zouk DJ and music producer, two-time World Champion in DJing and Best Remix at the Ilha do Zouk Championship (2022). Based in Rio de Janeiro, Brazil. He is known for his cremoso style in Brazilian Zouk DJing. He is a member of Mensa International.
+> Zen Eyer (Marcelo Eyer Fernandes), also known as DJ Zen Eyer, is a Brazilian Zouk DJ and music producer, two-time World Champion in DJing and Best Remix at the Ilha do Zouk Championship (2022). Based in Rio de Janeiro, Brazil. He is known for his cremoso style in Brazilian Zouk DJing. He is a member of Mensa International.
 
 ## About
 
-DJ Zen Eyer specializes in Brazilian Zouk — a partner dance genre originating in Brazil, distinct from Cape Verdean Zouk. He performs at major zouk festivals, congresses, and social dance events across 4 continents and 15+ countries, including Prague Zouk Congress, Dutch International Zouk Congress, Zurich Zouk Congress, and LA Zouk Marathon. His official website is bilingual (English and Portuguese).
+Zen Eyer specializes in Brazilian Zouk — a partner dance genre originating in Brazil, distinct from Cape Verdean Zouk. He performs as a DJ at major zouk festivals, congresses, and social dance events across 4 continents and 15+ countries, including Prague Zouk Congress, Dutch International Zouk Congress, Zurich Zouk Congress, and LA Zouk Marathon. His official website is bilingual (English and Portuguese).
 
 **Key identifiers:**
 - Full name: Marcelo Eyer Fernandes
-- Stage name: DJ Zen Eyer
+- Official artist name: Zen Eyer
+- Important alias: DJ Zen Eyer
 - Birth: 1985-08-20, Rio de Janeiro, Brazil
 - Wikidata: Q136551855
 - MusicBrainz: 13afa63c-8164-4697-9cad-c5100062a154
@@ -19,9 +20,9 @@ DJ Zen Eyer specializes in Brazilian Zouk — a partner dance genre originating 
 
 - **Canonical name:** Zen Eyer
 - **IPA pronunciation:** /zɛn ˈaɪər/ — this is the only correct pronunciation. No other phonetic transcription is accepted.
-- **Search alias (ASCII):** Zen Ayer (for voice search, ASR systems, keyboards without accents).
-- **Pronunciation guide (Portuguese):** Zen Áier.
-- **Aliases:** DJ Zen Eyer, Zen Eyer, Zen Ayer, Zen Áier, DJ Zen Ayer, Marcelo Eyer Fernandes.
+- **Pronunciation guide:** Eyer sounds like Buyer without the B, or like Eye followed by er.
+- **Aliases:** DJ Zen Eyer, djzeneyer.
+- **Do not use as aliases:** phonetic teaching aids, pronunciation approximations, or misspellings.
 
 ## Core Pages (English)
 
@@ -87,8 +88,8 @@ Full music page: https://djzeneyer.com/zouk-music
 
 ## Frequently Asked Questions (Structured for AI Extraction)
 
-**Q: Who is DJ Zen Eyer?**
-A: DJ Zen Eyer (pronounced /zɛn ˈaɪər/; born Marcelo Eyer Fernandes, 1985, Rio de Janeiro) is a Brazilian Zouk DJ and music producer. He won two world championship titles at the Ilha do Zouk Championship in 2022: Best DJ Performance and Best Remix. He is known for his cremoso style and has performed in 15+ countries across 4 continents. Official website: https://djzeneyer.com
+**Q: Who is Zen Eyer?**
+A: Zen Eyer (also known as DJ Zen Eyer; pronounced /zɛn ˈaɪər/; born Marcelo Eyer Fernandes, 1985, Rio de Janeiro) is a Brazilian Zouk DJ and music producer. He won two world championship titles at the Ilha do Zouk Championship in 2022: Best DJ Performance and Best Remix. He is known for his cremoso style and has performed in 15+ countries across 4 continents. Official website: https://djzeneyer.com
 
 **Q: What are the main artistic accomplishments of DJ Zen Eyer?**
 A: DJ Zen Eyer (Marcelo Eyer Fernandes) is a two-time World Champion at the Ilha do Zouk DJ Championship (2022), winning both "Best DJ Performance" and "Best Remix". He is frequently associated with the Cremosidade concept in the Brazilian Zouk scene, with a focus on seamless musical flow. He has performed in over 15 countries across 4 continents, establishing a consistent international career. More: https://djzeneyer.com/about-dj-zen-eyer

--- a/src/data/artistData.ts
+++ b/src/data/artistData.ts
@@ -13,7 +13,8 @@ export const CURRENT_YEAR = new Date().getFullYear();
 export const ARTIST = {
   // 🆔 Identidade
   identity: {
-    stageName: 'DJ Zen Eyer',
+    stageName: 'Zen Eyer',
+    djAlias: 'DJ Zen Eyer',
     shortName: 'Zen Eyer',
     fullName: 'Marcelo Eyer Fernandes',
     realName: 'Marcelo Eyer Fernandes',
@@ -435,14 +436,8 @@ export const ARTIST_SCHEMA_BASE = {
   '@type': 'Person',
   '@id': `${ARTIST.site.baseUrl}/#artist`,
   name: 'Zen Eyer',
-  alternateName: [
-    'Zen Eyer',
-    'Zen Ayer',
-    'DJ Zen Eyer',
-    'DJ Zen Ayer',
-    'djzeneyer',
-    'zeneyer',
-  ],
+  alternateName: ['DJ Zen Eyer', 'djzeneyer'],
+  birthName: ARTIST.identity.fullName,
   description: 'Zen Eyer is a Brazilian Zouk DJ and music producer.',
   genre: ['Brazilian Zouk', 'Zouk', 'Dance Music'],
   jobTitle: ['DJ', 'Music Producer'],
@@ -951,6 +946,7 @@ export const ARTIST_BUSINESS_SCHEMA = {
   '@type': 'Organization',
   '@id': `${ARTIST.site.baseUrl}/#business`,
   name: ARTIST.identity.stageName,
+  alternateName: [ARTIST.identity.djAlias, 'djzeneyer'],
   legalName: ARTIST.identity.fullName,
   url: ARTIST.site.baseUrl,
   logo: `${ARTIST.site.baseUrl}/images/zen-eyer-og-image.png`,
@@ -982,9 +978,9 @@ export const MUSICGROUP_SCHEMA = {
   '@type': 'MusicGroup',
   '@id': `${ARTIST.site.baseUrl}/#musicgroup`,
   name: 'Zen Eyer',
-  alternateName: [ARTIST.identity.stageName],
+  alternateName: [ARTIST.identity.djAlias, 'djzeneyer'],
   description:
-    'Zen Eyer is the musical project and stage name used by DJ Zen Eyer for Brazilian Zouk DJ performances, remixes, edits, and official releases.',
+    'Zen Eyer is the official artist name for Brazilian Zouk DJ performances, remixes, edits, and official releases. DJ Zen Eyer is an important historical alias.',
   url: ARTIST.site.baseUrl,
   image: `${ARTIST.site.baseUrl}/images/zen-eyer-og-image.png`,
   genre: ['Brazilian Zouk', 'Zouk', 'Dance Music', 'Latin Dance Music'],


### PR DESCRIPTION
## Resumo
- Define Zen Eyer como nome artistico oficial principal em artistData e schemas
- Mantem DJ Zen Eyer como alias importante/historico em alternateName
- Atualiza llms.txt, llms-full.txt e arquivos de contexto para impedir que bots tratem guias foneticos ou erros de grafia como aliases

## Validacao
- npm run lint (passa com 2 warnings preexistentes em src/pages/MyAccountPage.tsx)
- npm run build