### PR TITLE
Corrige schema WebSite da home

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -333,6 +333,7 @@
   "play_featured_mix": "Play Featured Mix",
   "upcoming_events": "Upcoming Events",
   "home": {
+    "site_desc": "Official website of Zen Eyer, also known as DJ Zen Eyer, 2x World Champion Brazilian Zouk DJ and music producer",
     "page_title": "DJ Zen Eyer | 2x World Champion Brazilian Zouk DJ & Producer",
     "page_meta_desc": "DJ Zen Eyer, two-time world champion (Best Remix & Best DJ Performance) at Brazilian Zouk World Championships. Book for international events.",
     "headline": "Experience the <1>Zen</1> in Brazilian Zouk",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -364,6 +364,7 @@
   "play_featured_mix": "Ouvir no SoundCloud",
   "upcoming_events": "Próximos Eventos",
   "home": {
+    "site_desc": "Site oficial de Zen Eyer, também conhecido como DJ Zen Eyer, bicampeão mundial de Zouk Brasileiro e produtor musical",
     "page_title": "DJ Zen Eyer | Bicampeão Mundial de Zouk Brasileiro",
     "page_meta_desc": "DJ Zen Eyer, bicampeão mundial (Melhor Remix e Melhor Performance DJ) no Brazilian Zouk World Championships. Contrate para eventos internacionais.",
     "headline": "Experiencie o <1>Zen</1> no Zouk Brasileiro",

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -127,8 +127,8 @@ const HomePage: React.FC = () => {
         "@type": "WebSite",
         "@id": `${ARTIST.site.baseUrl}/#website`,
         "url": ARTIST.site.baseUrl,
-        "name": seoSettings?.real_name || "DJ Zen Eyer - Official Website",
-        "description": "Official website of DJ Zen Eyer, 2× World Champion Brazilian Zouk DJ & Producer",
+        "name": "Zen Eyer",
+        "description": t('home.site_desc'),
         "publisher": { "@id": `${ARTIST.site.baseUrl}/#artist` },
         "inLanguage": ["en", "pt-BR"],
         "potentialAction": {


### PR DESCRIPTION
## Resumo
- Substitui o PR #438 por uma versao limpa alinhada ao nome canonico
- Define WebSite.name como Zen Eyer sem depender de seoSettings.real_name
- Move a descricao do WebSite para i18n mantendo Zen Eyer como nome principal e DJ Zen Eyer apenas como alias/contexto

## Validacao
- JSON dos locales parseado com sucesso
- npm run lint (passa com 2 warnings preexistentes em src/pages/MyAccountPage.tsx)
- npm run build