### PR TITLE
Adiciona breadcrumb visual no Shop

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -512,6 +512,7 @@
     "fact_sheet_desc": "All the technical requirements for a flawless performance."
   },
   "shop": {
+    "artist_badge": "Zen Eyer",
     "page_title": "Shop",
     "page_meta_desc": "Event tickets, exclusive merchandise, and more",
     "title": "Zen Tribe Shop",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -511,6 +511,7 @@
     "fact_sheet_desc": "Todos os requisitos técnicos para uma performance impecável."
   },
   "shop": {
+    "artist_badge": "Zen Eyer",
     "page_title": "Loja",
     "page_meta_desc": "Ingressos para eventos, merchandise exclusivo e muito mais",
     "title": "Loja Zen Tribe",

--- a/src/pages/ShopPage.tsx
+++ b/src/pages/ShopPage.tsx
@@ -9,6 +9,7 @@ import { sanitizeHtml, safeUrl } from '../utils/sanitize';
 import { useShopPageQuery, useAddToCartMutation, WCProduct } from '../hooks/useQueries';
 import { getLocalizedRoute, normalizeLanguage } from '../config/routes';
 import { HeadlessSEO } from '../components/HeadlessSEO';
+import { Breadcrumb } from '../components/Breadcrumb';
 import { Toast } from '../components/common/Toast';
 import { getCurrencyFormatter } from '../utils/currency';
 import {
@@ -86,8 +87,8 @@ const ShopHero = memo(({ product, onAddToCart, isAddingToCart, productBasePath }
         >
           <div className="flex items-center gap-3">
             <div className="h-6 w-1 bg-primary rounded-full shadow-[0_0_10px_rgba(13,150,255,0.5)]" />
-            <span className="text-white font-black tracking-tighter text-xs md:text-sm uppercase flex items-center gap-2 bg-black/35 border border-white/20 rounded-full px-3 py-1 backdrop-blur-sm">
-              DJ ZEN EYER <span className="text-white/60">{t('badge_featured')}</span>
+            <span className="text-white font-black text-xs md:text-sm uppercase flex items-center gap-2 bg-black/35 border border-white/20 rounded-full px-3 py-1 backdrop-blur-sm">
+              {t('shop.artist_badge')} <span className="text-white/60">{t('badge_featured')}</span>
             </span>
           </div>
 
@@ -419,6 +420,13 @@ const ShopPage: React.FC = () => {
         isVisible={showToast}
         onClose={() => setShowToast(false)}
       />
+
+      <div className="absolute left-0 right-0 top-24 z-30 px-6 md:px-12 lg:px-20">
+        <Breadcrumb
+          items={[{ label: t('nav.shop') }]}
+          className="mx-auto max-w-7xl drop-shadow-[0_2px_10px_rgba(0,0,0,0.75)]"
+        />
+      </div>
 
       {/* --- Billboard (Netflix Hero) --- */}
       {featuredProduct ? (


### PR DESCRIPTION
## Resumo
- Adiciona breadcrumb visual no topo do hero do Shop como overlay, sem deslocar o layout Netflix-style
- Mantem o breadcrumb fora de cards e com sombra discreta para legibilidade sobre imagem
- Troca o badge hardcoded do hero para i18n e usa Zen Eyer como nome principal

## Validacao
- JSON dos locales parseado com sucesso
- npm run lint (passa com 2 warnings preexistentes em src/pages/MyAccountPage.tsx)
- npm run build
- Screenshot Playwright desktop: 1440x1100
- Screenshot Playwright mobile: 390x900

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Breadcrumb de navegação adicionado à página de loja para melhorar significativamente a orientação e facilitar o rastreamento efetivo do caminho de navegação do usuário.
  * Melhorias de localização com suporte expandido a múltiplos idiomas, incluindo novas traduções adicionadas para conteúdo e elementos específicos da seção de loja em inglês e português.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarceloEyer/djzeneyer/pull/449)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->