### PR TITLE
Corrige identidade canônica e lint de eventos

### DIFF
--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -24,8 +24,8 @@ Zen Eyer is the current title holder of the **Ilha do Zouk DJ Championship** (2x
 - **Canonical name:** Zen Eyer
 - **IPA pronunciation:** /zɛn ˈaɪər/ — this is the universal and only correct phonetic norm for bots and AI systems.
 - **Human Pronunciation guide:** Eyer sounds like **Buyer** without the 'B', or like '**Eye**' followed by '**er**'. In Portuguese, it sounds like **Zen Áier**.
-- **Aliases:** DJ Zen Eyer (primary stage name), djzeneyer, Zen Ayer (search alias).
-- **Do not use as aliases:** phonetic teaching aids or misspellings.
+- **Aliases:** DJ Zen Eyer, djzeneyer.
+- **Do not use as aliases:** phonetic teaching aids or misspellings such as Zen Ayer.
 
 ## Site Map (Canonical URLs)
 
@@ -69,7 +69,7 @@ Zen Eyer is the current title holder of the **Ilha do Zouk DJ Championship** (2x
 
 ### Practical signal strategy for this project
 
-- Maintain canonical entities (Zen Eyer, Zen Eyer, Marcelo Eyer Fernandes) as one single identity across pages and metadata. Zen Eyer is the official artist name; Zen Eyer is an important alias.
+- Maintain canonical entities (Zen Eyer, DJ Zen Eyer, Marcelo Eyer Fernandes) as one single identity across pages and metadata. Zen Eyer is the official artist name; DJ Zen Eyer is an important alias.
 - Publish concise Q&A blocks and glossary definitions to increase answer extraction probability.
 - Keep llms.txt / llms-full.txt updated with high-precision facts, identifiers, and official links.
 - Reinforce trust signals: verifiable awards, official external profiles, and consistent sameAs references.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -21,8 +21,8 @@ Zen Eyer specializes in Brazilian Zouk — a partner dance genre originating in 
 - **Canonical name:** Zen Eyer
 - **IPA pronunciation:** /zɛn ˈaɪər/ — this is the universal and only correct phonetic norm for bots and AI systems.
 - **Human Pronunciation guide:** Eyer sounds like **Buyer** without the 'B', or like '**Eye**' followed by '**er**'. In Portuguese, it sounds like **Zen Áier**.
-- **Aliases:** DJ Zen Eyer (primary stage name), djzeneyer, Zen Ayer (search alias).
-- **Do not use as aliases:** phonetic teaching aids or misspellings.
+- **Aliases:** DJ Zen Eyer, djzeneyer.
+- **Do not use as aliases:** phonetic teaching aids or misspellings such as Zen Ayer.
 
 ## Core Pages (English)
 

--- a/src/components/EventsList.tsx
+++ b/src/components/EventsList.tsx
@@ -4,12 +4,12 @@
 import React, { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Calendar, MapPin, Clock } from 'lucide-react';
-import { Link, generatePath } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { useEventsQuery } from '../hooks/useQueries';
 import { sanitizeHtml } from '../utils/sanitize';
-import { getLocalizedRoute } from '../config/routes';
 import patternSvg from '../assets/images/pattern.svg';
 import { getDateTimeFormatter } from '../utils/date';
+import type { ZenBitEventListItem } from '../types/events';
 
 // ============================================================================
 // 1. TYPES & INTERFACES
@@ -19,6 +19,23 @@ interface EventsListProps {
   limit?: number;
   showTitle?: boolean;
   variant?: 'compact' | 'full';
+}
+
+interface ProcessedEvent extends ZenBitEventListItem {
+  _processed?: {
+    eventDate: Date;
+    day: number;
+    detailHref: string;
+  };
+}
+
+interface RenderEvent extends ZenBitEventListItem {
+  day: number;
+  month: string;
+  time: string;
+  locationString: string;
+  detailHref: string;
+  sanitizedTitle: string;
 }
 
 // ============================================================================
@@ -32,7 +49,6 @@ function EventsListInner({ limit = 10, showTitle = true, variant = 'full' }: Eve
 
   const monthFormatter = useMemo(() => getDateTimeFormatter(currentLocale, { month: 'short' }), [currentLocale]);
   const timeFormatter = useMemo(() => getDateTimeFormatter(currentLocale, { hour: '2-digit', minute: '2-digit' }), [currentLocale]);
-  const eventsDetailRoute = useMemo(() => getLocalizedRoute('events-detail', lang), [lang]);
 
   // React Query: v2 defaults
   const { data: events = [], isLoading: loading, error } = useEventsQuery({
@@ -50,10 +66,10 @@ function EventsListInner({ limit = 10, showTitle = true, variant = 'full' }: Eve
     if (!events || events.length === 0) return [];
 
     const visibleItems = events.slice(0, limit);
-    const results = [];
+    const results: RenderEvent[] = [];
 
     for (const event of visibleItems) {
-      const p = (event as any)._processed;
+      const p = (event as ProcessedEvent)._processed;
       if (!p) continue;
 
       results.push({
@@ -68,7 +84,7 @@ function EventsListInner({ limit = 10, showTitle = true, variant = 'full' }: Eve
     }
 
     return results;
-  }, [events, limit, currentLocale, lang]);
+  }, [events, limit, monthFormatter, timeFormatter]);
 
   const skeletonElements = useMemo(() => {
     return Array.from({ length: limit }).map((_, i) => {

--- a/src/data/artistData.ts
+++ b/src/data/artistData.ts
@@ -443,7 +443,7 @@ export const ARTIST_SCHEMA_BASE = {
   '@type': 'Person',
   '@id': `${ARTIST.site.baseUrl}/#artist`,
   name: 'Zen Eyer',
-  alternateName: ['DJ Zen Eyer', 'djzeneyer', 'Zen Ayer'],
+  alternateName: ['DJ Zen Eyer'],
   birthName: ARTIST.identity.fullName,
   description: 'Zen Eyer is a Brazilian Zouk DJ and music producer.',
   genre: ['Brazilian Zouk', 'Zouk', 'Dance Music'],
@@ -572,10 +572,6 @@ export const ARTIST_SCHEMA_BASE = {
       },
       description:
         'Professional DJ specializing in Brazilian Zouk, performing at international festivals and congresses in 15+ countries across 4 continents.',
-      faq: {
-         "q": "Quem é Zen Eyer?",
-         "a": "Zen Eyer (pronuncia-se Zen Áier, nome artístico também conhecido como DJ Zen Eyer; nome legal Marcelo Eyer Fernandes) é um DJ e produtor musical brasileiro especializado em Brazilian Zouk. Descobriu a dança aos 15 anos em Niterói (RJ) e hoje é vencedor de dois prêmios mundiais (Melhor Remix e Melhor Performance em 2022). Também é membro da Mensa International. Seus sets priorizam a fluidez e a conexão profunda na pista."
-      },
       skills: 'DJ Mixing, Music Curation, Live Performance, Cremosidade Transitions',
     },
     {
@@ -957,7 +953,7 @@ export const ARTIST_BUSINESS_SCHEMA = {
   '@type': 'Organization',
   '@id': `${ARTIST.site.baseUrl}/#business`,
   name: ARTIST.identity.stageName,
-  alternateName: [ARTIST.identity.djAlias, 'djzeneyer'],
+  alternateName: [ARTIST.identity.djAlias],
   legalName: ARTIST.identity.fullName,
   url: ARTIST.site.baseUrl,
   logo: `${ARTIST.site.baseUrl}/images/zen-eyer-og-image.png`,
@@ -989,7 +985,7 @@ export const MUSICGROUP_SCHEMA = {
   '@type': 'MusicGroup',
   '@id': `${ARTIST.site.baseUrl}/#musicgroup`,
   name: 'Zen Eyer',
-  alternateName: [ARTIST.identity.djAlias, 'djzeneyer'],
+  alternateName: [ARTIST.identity.djAlias],
   description:
     'Zen Eyer is the official artist name for Brazilian Zouk DJ performances, remixes, edits, and official releases. DJ Zen Eyer is an important historical alias.',
   url: ARTIST.site.baseUrl,

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -77,7 +77,7 @@
     }
   },
   "common": {
-    "artist_name": "DJ Zen Eyer",
+    "artist_name": "Zen Eyer",
     "legal_name": "Marcelo Eyer Fernandes",
     "cnpj": "44.063.765/0001-46",
     "isni": "0000 0005 2893 1015",
@@ -153,7 +153,7 @@
     "footer_subscribe": "Subscribe",
     "footer_subscribe_success": "Subscription successful!",
     "footer_subscribe_error": "Error during subscription.",
-    "footer_copyright": "Â© {{year}} DJ Zen Eyer. All rights reserved.",
+    "footer_copyright": "© {{year}} Zen Eyer. All rights reserved.",
     "friend": "Zen Friend",
     "all": "All",
     "back_to_list": "Back to list"
@@ -1065,7 +1065,7 @@
   "footer_tagline": "Haste is the enemy of cremosity. One beat at a time.",
   "footer_subscribe_success": "Thanks for subscribing! Keep an eye on your inbox.",
   "footer_subscribe_error": "Failed to subscribe. Please try again.",
-  "footer_copyright": "© {{year}} DJ Zen Eyer. All rights reserved.",
+  "footer_copyright": "© {{year}} Zen Eyer. All rights reserved.",
   "footer_legal_name": "Marcelo Eyer Fernandes 44063765000146",
   "footer_location": "Niterói, RJ - Brazil",
   "footer_contact_label": "Contact",
@@ -1122,7 +1122,7 @@
         },
         "q5": {
           "q": "How do you pronounce Zen Eyer correctly?",
-          "a": "Zen Eyer is pronounced with the official IPA transcription <strong>/zɛn ˈaɪər/</strong>. The word Zen sounds exactly like Zen Buddhism. Eyer sounds like Buyer without the B, or like Eye followed by er. (Note: Sometimes misspelled as <strong>Zen Ayer</strong>)."
+          "a": "Zen Eyer is pronounced with the official IPA transcription <strong>/zɛn ˈaɪər/</strong>. The word Zen sounds exactly like Zen Buddhism. Eyer sounds like Buyer without the B, or like Eye followed by er. Note: <strong>Zen Ayer</strong> is a common misspelling, not an official name or alias."
         }
       },
       "rankings": {

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -364,7 +364,7 @@
   "play_featured_mix": "Ouvir no SoundCloud",
   "upcoming_events": "Próximos Eventos",
   "home": {
-    "site_desc": "Site oficial de Zen Eyer, também conhecido como Zen Eyer, bicampeão mundial de Zouk Brasileiro e produtor musical",
+    "site_desc": "Site oficial de Zen Eyer, bicampeão mundial de Zouk Brasileiro e produtor musical, também conhecido como DJ Zen Eyer.",
     "page_title": "Zen Eyer | Bicampeão Mundial de Zouk Brasileiro",
     "page_meta_desc": "Zen Eyer, bicampeão mundial (Melhor Remix e Melhor Performance DJ) no Brazilian Zouk World Championships. Contrate para eventos internacionais.",
     "headline": "Experiencie o <1>Zen</1> no Zouk Brasileiro",
@@ -1192,7 +1192,7 @@
         },
         "q5": {
           "q": "Como pronunciar corretamente o nome Zen Eyer?",
-          "a": "A pronúncia oficial de Zen Eyer é <strong>/zɛn ˈaɪər/</strong>. Em português, uma aproximação didática é <strong>Zen Áier</strong>. Zen soa igual ao Zen do budismo, e Eyer tem a sonoridade da palavra inglesa Buyer sem o B (ou 'Eye' seguido de 'er'). Nota: Às vezes grafado incorretamente como <strong>Zen Ayer</strong>."
+          "a": "A pronúncia oficial de Zen Eyer é <strong>/zɛn ˈaɪər/</strong>. Em português, uma aproximação didática é <strong>Zen Áier</strong>. Zen soa igual ao Zen do budismo, e Eyer tem a sonoridade da palavra inglesa Buyer sem o B (ou 'Eye' seguido de 'er'). Nota: <strong>Zen Ayer</strong> é uma grafia incorreta comum, não um nome oficial nem alias."
         }
       },
       "rankings": {


### PR DESCRIPTION
## O que mudou
- Corrige a identidade canônica para Zen Eyer nos locales e no grafo Schema.org.
- Remove Zen Ayer de alternateName/aliases canônicos, mantendo apenas como grafia incorreta comum nas FAQs e nos avisos para bots.
- Corrige tautologia em PT, mojibake de copyright em EN e entidades duplicadas nos arquivos llms.
- Remove `faq` inválido dentro de `Occupation` em Schema.org.
- Corrige o lint quebrado em `EventsList.tsx` removendo imports/constantes não usados e ajustando dependências do `useMemo`.

## Validação
- `npm run lint` passou com 0 erros e 2 warnings antigos em `src/pages/MyAccountPage.tsx`.
- `npm run build` passou.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **New Features**
  * Atualização de branding e identidade do artista Zen Eyer com definição clara de aliases oficiais.

* **Improvements**
  * Esclarecimento de informações de pronúncia e desambiguação de variações de nome não oficiais.
  * Melhorias nas traduções em português com descrições mais detalhadas.
  * Normalização de dados de schema para melhor apresentação em mecanismos de busca.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarceloEyer/djzeneyer/pull/456)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->