### PR TITLE
Padroniza breadcrumbs e corrige eventos

### DIFF
--- a/src/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb.tsx
@@ -26,12 +26,12 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({ items, className = '' })
   return (
     <motion.nav
       aria-label={t('nav.breadcrumb')}
-      className={className}
+      className={`${className} w-full text-left`}
       initial={BREADCRUMB_INITIAL}
       animate={BREADCRUMB_ANIMATE}
       transition={BREADCRUMB_TRANSITION}
     >
-      <ol className="flex flex-wrap items-center gap-2 text-xs sm:text-sm text-white/50">
+      <ol className="flex flex-wrap items-center justify-start gap-2 text-xs sm:text-sm text-white/50">
         <li>
           <Link
             to={getLocalizedRoute('home', currentLang)}

--- a/src/components/HeadlessSEO.tsx
+++ b/src/components/HeadlessSEO.tsx
@@ -583,7 +583,7 @@ export const HeadlessSEO = React.memo<HeadlessSEOProps>(({
 
       {/* Hreflang Tags */}
       {computedHrefLang.map(({ lang, url: hrefUrl }) => (
-        <link key={lang} rel="alternate" hreflang={lang} href={safeUrl(hrefUrl)} />
+        <link key={lang} rel="alternate" hrefLang={lang} href={safeUrl(hrefUrl)} />
       ))}
 
       {/* Schema JSON-LD */}

--- a/src/hooks/useQueries.ts
+++ b/src/hooks/useQueries.ts
@@ -10,10 +10,11 @@
 
 import { useQuery, useMutation } from '@tanstack/react-query';
 import type { UseQueryOptions } from '@tanstack/react-query';
+import { generatePath } from 'react-router-dom';
 import { z } from 'zod';
 import { buildApiUrl, getAuthHeaders } from '../config/api';
 import { QUERY_KEYS, STALE_TIME, invalidateQueries } from '../config/queryClient';
-import { type Language } from '../config/routes';
+import { getLocalizedRoute, type Language } from '../config/routes';
 import type { ZenGameUserData, ZenGameLeaderboard } from '../types/gamification';
 import { ZenGameUserDataSchema, ZenGameLeaderboardSchema, EventsApiResponseSchema, ZenBitEventListItemSchema, EventDetailApiResponseSchema } from '../schemas';
 
@@ -330,7 +331,7 @@ export const fetchEventsFn = async ({
     }
 
     // Optimization: Pre-process dates and IDs at fetch time to avoid O(N) on render
-    const eventsDetailRoute = getLocalizedRoute('events-detail', lang || 'en');
+    const eventsDetailRoute = getLocalizedRoute('events-detail', (lang || 'en') as Language);
     
     return events.map(event => {
       const eventDate = new Date(event.starts_at);

--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useState, useMemo } from 'react';
+import React, { memo, useState, useMemo, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { HeadlessSEO } from '../components/HeadlessSEO';
 import { Breadcrumb } from '../components/Breadcrumb';
@@ -179,9 +179,11 @@ const EventListContent = ({ lang }: { lang: string }) => {
   const [showToast, setShowToast] = useState(false);
   const eventsDetailRoute = useMemo(() => getLocalizedRoute('events-detail', lang as Language), [lang]);
 
-  if (error) {
-    console.error('Error fetching events:', error);
-  }
+  useEffect(() => {
+    if (error) {
+      console.error('Error fetching events:', error);
+    }
+  }, [error]);
 
   // Extrai regiões únicas (Estados)
   const regions = useMemo(() => {
@@ -287,7 +289,7 @@ const EventListContent = ({ lang }: { lang: string }) => {
                     ? e.canonical_path.split('/').pop() || e.event_id
                     : e.event_id;
 
-                  const detailHref = generatePath(eventsDetailRoute, { id: identifier });
+                  const detailHref = e._processed?.detailHref || generatePath(eventsDetailRoute, { id: identifier });
                   const loc = e.location;
 
                   return (

--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -13,6 +13,7 @@ import { getDateTimeFormatter } from '../utils/date';
 import { Toast } from '../components/common/Toast';
 import NotFoundPage from './NotFoundPage';
 import type { ZenBitEventListItem, ZenBitEventDetail } from '../types/events';
+import type { EventSchemaData } from '../components/HeadlessSEO';
 
 // ⚡ Bolt: Extracted static MONTH_NAMES array to module scope to prevent reallocation on every render cycle.
 const MONTH_NAMES = ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec'] as const;
@@ -167,7 +168,7 @@ const EventDetailContent = ({ id, lang }: { id: string; lang: string }) => {
 const EventListContent = ({ lang }: { lang: string }) => {
   const { t } = useTranslation();
   const origin = typeof window !== 'undefined' ? window.location.origin : ARTIST.site.baseUrl;
-  const { data: events = [] } = useEventsQuery({
+  const { data: events = [], isLoading, error } = useEventsQuery({
     mode: 'upcoming',
     days: 365,
     limit: 50,
@@ -176,6 +177,11 @@ const EventListContent = ({ lang }: { lang: string }) => {
 
   const [selectedRegion, setSelectedRegion] = useState<string>('all');
   const [showToast, setShowToast] = useState(false);
+  const eventsDetailRoute = useMemo(() => getLocalizedRoute('events-detail', lang as Language), [lang]);
+
+  if (error) {
+    console.error('Error fetching events:', error);
+  }
 
   // Extrai regiões únicas (Estados)
   const regions = useMemo(() => {
@@ -214,6 +220,10 @@ const EventListContent = ({ lang }: { lang: string }) => {
     }
   };
 
+  if (isLoading && events.length === 0) {
+    return <EventSkeleton />;
+  }
+
   if (events.length === 0) {
     return (
       <div className="text-center py-20 bg-surface/30 rounded-3xl border border-white/5 animate-in fade-in duration-500">
@@ -228,7 +238,7 @@ const EventListContent = ({ lang }: { lang: string }) => {
         title={t('events_page_title')}
         description={t('events_page_meta_desc')}
         url={`${origin}${getLocalizedRoute('events', lang as Language)}`}
-        events={events as unknown as EventListItem[]}
+        events={events as EventSchemaData[]}
       />
       {/* Filter Bar */}
       {regions.length > 0 && (
@@ -277,7 +287,7 @@ const EventListContent = ({ lang }: { lang: string }) => {
                     ? e.canonical_path.split('/').pop() || e.event_id
                     : e.event_id;
 
-                  const detailHref = generatePath(getLocalizedRoute('events-detail', lang as Language), { id: identifier });
+                  const detailHref = generatePath(eventsDetailRoute, { id: identifier });
                   const loc = e.location;
 
                   return (

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -30,6 +30,11 @@ export interface ZenBitEventListItem {
     canonical_path: string;   // ex: /zouk-events/2025-06-20-dj-zen-eyer-at-club-x-15619775
     canonical_url: string;
     source_url?: string;   // URL Bandsintown
+    _processed?: {
+        eventDate: Date;
+        day: number;
+        detailHref: string;
+    };
 }
 
 // ============================================================================


### PR DESCRIPTION
## Resumo
- padroniza o componente global de breadcrumbs para alinhar sempre à esquerda
- corrige a busca/renderização de eventos importando as rotas usadas no processamento do hook
- evita estado vazio durante carregamento inicial da página de eventos
- corrige `hrefLang` no HeadlessSEO para remover warning React

## Verificação
- `npm run lint` (0 erros; 2 warnings existentes em `src/pages/MyAccountPage.tsx`)
- `npm run build`
- Puppeteer local em `/zouk-events`: eventos renderizados e breadcrumb com `text-align: left` / `justify-content: flex-start`
- Checagem local em páginas com breadcrumb: About, Events, Music, Shop, Zen Tribe e FAQ

## Observação
A API de produção `zen-bit/v2/events` retorna eventos corretamente. O problema encontrado era no frontend: `fetchEventsFn` tentava usar `getLocalizedRoute`/`generatePath` sem import, caía no `catch` e retornava lista vazia.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notas de Lançamento

* **Bug Fixes**
  * Corrigido atributo de alternância de idioma para geração correta de tags de SEO.

* **New Features**
  * Adicionado esqueleto de carregamento na lista de eventos e melhor tratamento/registro de erros ao buscar eventos.
  * URLs de detalhe de evento agora são geradas de forma consistente para cada item.

* **Style**
  * Ajustado layout do breadcrumb para melhor espaçamento e alinhamento.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarceloEyer/djzeneyer/pull/459)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->