### PR TITLE
Ajusta ordem da musica e valida sessao sem 401

### DIFF
--- a/src/config/queryClient.ts
+++ b/src/config/queryClient.ts
@@ -154,6 +154,7 @@ export const QUERY_KEYS = {
 
   /** Usuário */
   user: {
+    session: (hasToken: boolean) => ['user', 'session', hasToken] as const,
     profile: (userId?: number) => ['user', 'profile', userId] as const,
     orders: (userId?: number, limit?: number) => ['user', 'orders', userId, limit] as const,
     gamipress: (userId: number) => ['user', 'gamipress', userId] as const,

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -103,7 +103,14 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
           fetch(`${API_URL}/session`, {
             headers: { 'Authorization': `Bearer ${token}` }
           })
-            .then(res => res.json())
+            .then(async res => {
+              const text = await res.text();
+              if (!res.ok || text.trim().startsWith('<!DOCTYPE') || text.trim().startsWith('<html')) {
+                throw new Error('Invalid session response');
+              }
+
+              return JSON.parse(text);
+            })
             .then(data => {
               if (!data.authenticated) {
                 logout();

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -1,6 +1,7 @@
 // src/contexts/UserContext.tsx - VERSÃO ATUALIZADA COM TURNSTILE
 import React, { createContext, useState, useContext, useEffect, ReactNode, useMemo, useCallback } from 'react';
-import { clearAllCache } from '../config/queryClient';
+import { clearAllCache, queryClient, QUERY_KEYS } from '../config/queryClient';
+import { fetchAuthSessionFn } from '../hooks/useQueries';
 
 interface WordPressUser {
   id: number;
@@ -53,7 +54,7 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     clearAllCache();
   }, []);
 
-  const saveSession = useCallback((userData: WordPressUser, token: string) => {
+  const saveSession = useCallback((userData: Omit<WordPressUser, 'isLoggedIn'> & { isLoggedIn?: boolean }, token: string) => {
     const userWithStatus = { ...userData, isLoggedIn: true, token };
     setUser(userWithStatus);
     localStorage.setItem('zen_jwt', token);
@@ -100,17 +101,11 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
           setUser({ ...parsedUser, token, isLoggedIn: true });
 
           // Validação silenciosa
-          fetch(`${API_URL}/session`, {
-            headers: { 'Authorization': `Bearer ${token}` }
+          queryClient.fetchQuery({
+            queryKey: QUERY_KEYS.user.session(Boolean(token)),
+            queryFn: () => fetchAuthSessionFn(token),
+            staleTime: 0,
           })
-            .then(async res => {
-              const text = await res.text();
-              if (!res.ok || text.trim().startsWith('<!DOCTYPE') || text.trim().startsWith('<html')) {
-                throw new Error('Invalid session response');
-              }
-
-              return JSON.parse(text);
-            })
             .then(data => {
               if (!data.authenticated) {
                 logout();

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -100,14 +100,18 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
           setUser({ ...parsedUser, token, isLoggedIn: true });
 
           // Validação silenciosa
-          fetch(`${API_URL}/auth/validate`, {
-            method: 'POST',
+          fetch(`${API_URL}/session`, {
             headers: { 'Authorization': `Bearer ${token}` }
           })
             .then(res => res.json())
             .then(data => {
-              if (!data.success) {
+              if (!data.authenticated) {
                 logout();
+                return;
+              }
+
+              if (data.user) {
+                saveSession(data.user, token);
               }
             })
             .catch(err => {
@@ -123,7 +127,7 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     };
 
     init();
-  }, [API_URL, logout]);
+  }, [API_URL, logout, saveSession]);
 
 
 

--- a/src/hooks/useQueries.ts
+++ b/src/hooks/useQueries.ts
@@ -78,6 +78,15 @@ export interface UserProfile {
   gender?: '' | 'male' | 'female' | 'non-binary';
 }
 
+export interface AuthSessionResponse {
+  authenticated: boolean;
+  user: UserProfile | null;
+  roles?: string[];
+  exp?: number;
+  message?: string;
+  code?: string;
+}
+
 const UserProfileSchema = z.object({
   id: z.number(),
   email: z.string().email(),
@@ -91,6 +100,15 @@ const UserProfileSchema = z.object({
   instagram_url: z.string().optional(),
   dance_role: z.array(z.string()).optional(),
   gender: z.enum(['', 'male', 'female', 'non-binary']).optional(),
+}).catchall(z.unknown());
+
+const AuthSessionResponseSchema = z.object({
+  authenticated: z.boolean(),
+  user: UserProfileSchema.nullable().catch(null),
+  roles: z.array(z.string()).optional(),
+  exp: z.number().optional(),
+  message: z.string().optional(),
+  code: z.string().optional(),
 }).catchall(z.unknown());
 
 export interface WCOrder {
@@ -286,6 +304,20 @@ export const fetchArtistProfileFn = async (): Promise<ArtistProfile> => {
   if (!res.ok) throw new Error('Failed to fetch artist profile');
   const json = await res.json();
   return json.data;
+};
+
+export const fetchAuthSessionFn = async (token: string): Promise<AuthSessionResponse> => {
+  const apiUrl = buildApiUrl('zeneyer-auth/v1/session');
+  const res = await fetch(apiUrl, {
+    headers: getAuthHeaders(token),
+  });
+  const text = await res.text();
+
+  if (!res.ok || text.trim().startsWith('<!DOCTYPE') || text.trim().startsWith('<html')) {
+    throw new Error('Invalid session response');
+  }
+
+  return AuthSessionResponseSchema.parse(JSON.parse(text));
 };
 
 export const fetchEventsFn = async ({

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -50,6 +50,8 @@ i18n
   .use(initReactI18next)
   .init({
     fallbackLng: 'en',
+    debug: false,
+    showSupportNotice: false,
     supportedLngs: ['en', 'pt'],
     ns: ['translation', 'quiz'],
     defaultNS: 'translation',

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -489,6 +489,12 @@
     "releases_title": "Music releases",
     "releases_subtitle": "Release notes, credits, and official links published in Zen News.",
     "read_release": "Read release notes",
+    "release_type": {
+      "album": "Album",
+      "ep": "EP",
+      "remix": "Remix",
+      "single": "Single"
+    },
     "discography_schema_name": "DJ Zen Eyer Discography",
     "discography_schema_desc": "Official releases by DJ Zen Eyer, including singles, remixes, and music for Brazilian Zouk dancing."
   },

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -488,6 +488,12 @@
     "releases_title": "Lançamentos musicais",
     "releases_subtitle": "Notas de lançamento, créditos e links oficiais publicados no Zen News.",
     "read_release": "Ler notas do lançamento",
+    "release_type": {
+      "album": "Álbum",
+      "ep": "EP",
+      "remix": "Remix",
+      "single": "Single"
+    },
     "discography_schema_name": "Discografia Zen Eyer",
     "discography_schema_desc": "Lançamentos oficiais do Zen Eyer, incluindo singles, remixes e músicas para dançar Zouk Brasileiro."
   },

--- a/src/pages/MusicPage.tsx
+++ b/src/pages/MusicPage.tsx
@@ -369,7 +369,7 @@ const MusicPage: React.FC = () => {
                     />
                     <div className="min-w-0 flex-1">
                       <div className="mb-2 inline-flex rounded-full border border-primary/20 bg-primary/10 px-2 py-1 text-[11px] font-bold uppercase tracking-wider text-primary">
-                        {release.type}
+                        {t(`music.release_type.${release.type}`, { defaultValue: release.type })}
                       </div>
                       <h3 className="line-clamp-2 text-lg font-black text-white transition-colors group-hover:text-primary">
                         {release.name}

--- a/src/pages/MusicPage.tsx
+++ b/src/pages/MusicPage.tsx
@@ -293,50 +293,7 @@ const MusicPage: React.FC = () => {
             </div>
           </div>
 
-          {releaseCards.length > 0 && (
-            <section className="mb-16" aria-labelledby="music-releases-title">
-              <div className="mb-6 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-                <div>
-                  <h2 id="music-releases-title" className="text-2xl font-black font-display text-white">
-                    {t('music.releases_title')}
-                  </h2>
-                  <p className="mt-1 text-sm text-white/50">{t('music.releases_subtitle')}</p>
-                </div>
-                <Link to={getLocalizedRoute('news', currentLang)} className="inline-flex items-center gap-2 text-sm font-bold text-primary hover:text-primary/80">
-                  {t('news.title')} <ExternalLink size={14} />
-                </Link>
-              </div>
-              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-                {releaseCards.map((release) => (
-                  <Link
-                    key={release.id}
-                    to={release.path}
-                    className="group flex min-h-[132px] gap-4 rounded-2xl border border-white/10 bg-surface/35 p-4 transition-colors hover:border-primary/50 hover:bg-surface/60"
-                  >
-                    <img
-                      src={safeUrl(release.image, '/images/zen-eyer-og-image.png')}
-                      alt={release.name}
-                      className="h-24 w-24 flex-none rounded-xl object-cover"
-                      width="96"
-                      height="96"
-                      loading="lazy"
-                    />
-                    <div className="min-w-0 flex-1">
-                      <div className="mb-2 inline-flex rounded-full border border-primary/20 bg-primary/10 px-2 py-1 text-[11px] font-bold uppercase tracking-wider text-primary">
-                        {release.type}
-                      </div>
-                      <h3 className="line-clamp-2 text-lg font-black text-white transition-colors group-hover:text-primary">
-                        {release.name}
-                      </h3>
-                      <p className="mt-2 text-sm text-white/50">{t('music.read_release')}</p>
-                    </div>
-                  </Link>
-                ))}
-              </div>
-            </section>
-          )}
-
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mb-16">
             {/* Download / Grab & Go Card */}
             <motion.div
               variants={CARD_VARIANTS(0.7)}
@@ -381,6 +338,49 @@ const MusicPage: React.FC = () => {
               </Link>
             </motion.div>
           </div>
+
+          {releaseCards.length > 0 && (
+            <section aria-labelledby="music-releases-title">
+              <div className="mb-6 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+                <div>
+                  <h2 id="music-releases-title" className="text-2xl font-black font-display text-white">
+                    {t('music.releases_title')}
+                  </h2>
+                  <p className="mt-1 text-sm text-white/50">{t('music.releases_subtitle')}</p>
+                </div>
+                <Link to={getLocalizedRoute('news', currentLang)} className="inline-flex items-center gap-2 text-sm font-bold text-primary hover:text-primary/80">
+                  {t('news.title')} <ExternalLink size={14} />
+                </Link>
+              </div>
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                {releaseCards.map((release) => (
+                  <Link
+                    key={release.id}
+                    to={release.path}
+                    className="group flex min-h-[132px] gap-4 rounded-2xl border border-white/10 bg-surface/35 p-4 transition-colors hover:border-primary/50 hover:bg-surface/60"
+                  >
+                    <img
+                      src={safeUrl(release.image, '/images/zen-eyer-og-image.png')}
+                      alt={release.name}
+                      className="h-24 w-24 flex-none rounded-xl object-cover"
+                      width="96"
+                      height="96"
+                      loading="lazy"
+                    />
+                    <div className="min-w-0 flex-1">
+                      <div className="mb-2 inline-flex rounded-full border border-primary/20 bg-primary/10 px-2 py-1 text-[11px] font-bold uppercase tracking-wider text-primary">
+                        {release.type}
+                      </div>
+                      <h3 className="line-clamp-2 text-lg font-black text-white transition-colors group-hover:text-primary">
+                        {release.name}
+                      </h3>
+                      <p className="mt-2 text-sm text-white/50">{t('music.read_release')}</p>
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            </section>
+          )}
 
         </div>
       </div>


### PR DESCRIPTION
## Resumo
- move os cards de download e apoio acima da listagem de releases na página de música
- troca a validação inicial de sessão de `POST /auth/validate` para `GET /session`, evitando 401 esperado quando há token expirado no localStorage
- desativa o aviso de suporte do i18next/Locize no console com `showSupportNotice: false`

## Verificação
- `npm run lint` (0 erros; 2 warnings antigos em `src/pages/MyAccountPage.tsx`)
- `npm run build`
- Puppeteer local em `/zouk-music`: releases aparecem depois dos CTAs, sem requests para `/auth/validate`, sem logs i18next/Locize
- Produção: `/wp-json/zeneyer-auth/v1/session` com token inválido retorna 200 + `authenticated:false`

## Notas sobre o console reportado
- `ERR_BLOCKED_BY_CLIENT` normalmente vem de adblock/extensão ou bloqueio local do navegador, não do app.
- `cdn-cgi/challenge-platform` é Cloudflare Challenge Platform normal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notas de Versão

* **Melhorias**
  * Restauração de sessão do usuário mais confiável durante inicialização; usuários não autenticados são desconectados automaticamente.
  * Ordem dos cartões na página Música reorganizada para melhorar a leitura e navegação.

* **Configuração**
  * Debug e avisos de suporte do sistema de internacionalização desativados.

* **Traduções**
  * Adicionados rótulos de tipo de lançamento: album, ep, remix, single.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarceloEyer/djzeneyer/pull/463)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->