### PR TITLE
[codex] Redirect legacy SEO slugs

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -212,15 +212,23 @@ RewriteRule ^pt/pagamentos/?$ /pt/apoie-dj-zen-eyer/ [R=301,L]
 RewriteRule ^pt/press-kit/?$ /pt/kit-de-imprensa/ [R=301,L]
 
 # Legacy support and philosophy aliases -> canonical pages
+RewriteRule ^about/?$ /about-dj-zen-eyer/ [R=301,L,NC]
+RewriteRule ^pt/sobre/?$ /pt/sobre-dj-zen-eyer/ [R=301,L,NC]
+RewriteRule ^music/?$ /zouk-music/ [R=301,L,NC]
+RewriteRule ^pt/musica/?$ /pt/musica-zouk/ [R=301,L,NC]
+RewriteRule ^news/?$ /zouk-dance-news/ [R=301,L,NC]
+RewriteRule ^pt/noticias/?$ /pt/noticias-zouk/ [R=301,L,NC]
 RewriteRule ^support-the-artist/?$ /support-dj-zen-eyer/ [R=301,L]
 RewriteRule ^pt/apoie-o-artista/?$ /pt/apoie-dj-zen-eyer/ [R=301,L]
 RewriteRule ^pt/contrate/?$ /pt/trabalhe-comigo/ [R=301,L]
 RewriteRule ^pt/minha-filosofia/?$ /pt/filosofia-zouk/ [R=301,L]
+RewriteRule ^my-philosophy/?$ /zouk-philosophy/ [R=301,L,NC]
 RewriteRule ^pt/privacy-policy-2/?$ /pt/privacidade/ [R=301,L]
 
 # Legacy media route -> canonical clipping pages
 RewriteRule ^media/?$ /media-clipping/ [R=301,L]
 RewriteRule ^pt/media/?$ /pt/na-midia/ [R=301,L]
+RewriteRule ^pt/midia/?$ /pt/na-midia/ [R=301,L]
 
 # Events Standardization (SSOT)
 # Redireciona slugs legados/curtos para a estrutura canônica de Zouk Events


### PR DESCRIPTION
## Summary
- Adds 301 redirects for legacy indexed slugs that still appear in search results.
- Consolidates old About, Music, News, Philosophy, and media paths into the current Zouk-focused canonical URLs.

## Why
Old indexed URLs such as `/about/`, `/music/`, and `/pt/noticias/` fragment entity authority and can keep outdated snippets in Google/Bing/LLM indexes.

## Validation
- Inspected `public/.htaccess` rewrite placement before the WordPress fallback block.
