### PR TITLE
[codex] Fix Zen BIT canonical event slugs

### DIFF
--- a/plugins/zen-bit/README.md
+++ b/plugins/zen-bit/README.md
@@ -18,8 +18,8 @@ Bandsintown bridge for event data, schema, and cache management.
 
 - `GET /events`
 - `GET /events/schema`
-- `GET /events/{event_id}`
-- `GET /events/{event_id}/schema`
+- `GET /events/{event_id}` or `GET /events/{canonical-slug-ending-in-event_id}`
+- `GET /events/{event_id}/schema` or `GET /events/{canonical-slug-ending-in-event_id}/schema`
 - `POST /admin/fetch-now`
 - `POST /admin/clear-cache`
 - `GET /admin/health`

--- a/plugins/zen-bit/includes/class-zen-bit-api.php
+++ b/plugins/zen-bit/includes/class-zen-bit-api.php
@@ -67,6 +67,28 @@ class Zen_BIT_API_V2
         return max(1, (int) \get_option('zen_bit_default_days', 365));
     }
 
+    /**
+     * Accepts a raw Bandsintown ID or the canonical public route slug and returns
+     * the final numeric ID segment used by Bandsintown.
+     */
+    private static function extract_event_id(string $route_param): string
+    {
+        $route_param = trim($route_param);
+        if ($route_param === '') {
+            return '';
+        }
+
+        if (ctype_digit($route_param)) {
+            return $route_param;
+        }
+
+        if (preg_match('/(?:^|[-\/])(\d+)$/', $route_param, $matches)) {
+            return $matches[1];
+        }
+
+        return '';
+    }
+
     // =========================================================================
     // PARAMETER PARSING
     // =========================================================================
@@ -398,9 +420,10 @@ class Zen_BIT_API_V2
      */
     public static function get_event(\WP_REST_Request $req)
     {
-        $event_id = sanitize_text_field((string) $req->get_param('event_id'));
-        if ($event_id === '' || !ctype_digit($event_id)) {
-            return new \WP_Error('invalid_event_id', 'event_id deve ser numérico.', ['status' => 400]);
+        $route_param = sanitize_text_field((string) $req->get_param('event_id'));
+        $event_id = self::extract_event_id($route_param);
+        if ($event_id === '') {
+            return new \WP_Error('invalid_event_id', 'event_id deve ser numerico ou slug canonico terminado em ID numerico.', ['status' => 400]);
         }
 
         $include_raw = (bool) \get_option('zen_bit_include_raw_debug', false);

--- a/plugins/zen-bit/includes/class-zen-bit-normalizer.php
+++ b/plugins/zen-bit/includes/class-zen-bit-normalizer.php
@@ -20,7 +20,7 @@ if (!defined('ABSPATH'))
 class Zen_BIT_Normalizer
 {
     // Versão — mudar invalida todos os caches de payload
-    const VERSION = 'v2.1';
+    const VERSION = 'v2.2';
 
     // =========================================================================
     // CANONICAL PATH
@@ -266,6 +266,9 @@ class Zen_BIT_Normalizer
 
         // endDate: fallback startDate + 4h quando não fornecido
         $start_ts = strtotime($event['starts_at']);
+        if (!$start_ts) {
+            return [];
+        }
         $end_date = !empty($event['ends_at'])
             ? $event['ends_at']
             : gmdate('c', $start_ts + 4 * 3600);
@@ -356,13 +359,20 @@ class Zen_BIT_Normalizer
         return [
             '@type' => 'MusicGroup',
             '@id' => home_url('/') . '#musicgroup',
-            'name' => 'DJ Zen Eyer',
+            'name' => 'Zen Eyer',
+            'alternateName' => ['DJ Zen Eyer'],
             'genre' => 'Brazilian Zouk',
             'url' => home_url('/'),
             'sameAs' => [
+                'https://www.wikidata.org/wiki/Q136551855',
+                'https://musicbrainz.org/artist/13afa63c-8164-4697-9cad-c5100062a154',
+                'https://www.discogs.com/artist/16872046',
+                'https://isni.org/isni/0000000528931015',
+                'https://open.spotify.com/artist/68SHKGndTlq3USQ2LZmyLw',
+                'https://music.apple.com/us/artist/1439280950',
+                'https://www.youtube.com/@djzeneyer',
                 'https://www.instagram.com/djzeneyer/',
                 'https://soundcloud.com/djzeneyer',
-                'https://open.spotify.com/artist/68SHKGndTlq3USQ2LZmyLw',
             ],
         ];
     }

--- a/plugins/zen-bit/zen-bit.php
+++ b/plugins/zen-bit/zen-bit.php
@@ -123,22 +123,22 @@ if (!class_exists('Zen_BIT')) {
             ]);
 
             // Detalhe de evento (event_id numérico)
-            register_rest_route($ns, '/events/(?P<event_id>\d+)', [
+            register_rest_route($ns, '/events/(?P<event_id>[^/]+)', [
                 'methods' => 'GET',
                 'callback' => [$api_class, 'get_event'],
                 'permission_callback' => '__return_true',
                 'args' => [
-                    'event_id' => ['type' => 'integer', 'required' => true, 'minimum' => 1],
+                    'event_id' => ['type' => 'string', 'required' => true],
                 ],
             ]);
 
             // Schema JSON-LD — evento individual
-            register_rest_route($ns, '/events/(?P<event_id>\d+)/schema', [
+            register_rest_route($ns, '/events/(?P<event_id>[^/]+)/schema', [
                 'methods' => 'GET',
                 'callback' => [$api_class, 'get_event_schema'],
                 'permission_callback' => '__return_true',
                 'args' => [
-                    'event_id' => ['type' => 'integer', 'required' => true],
+                    'event_id' => ['type' => 'string', 'required' => true],
                 ],
             ]);
 


### PR DESCRIPTION
## Summary
- Allows Zen BIT detail/schema endpoints to resolve canonical dynamic event slugs that end in the Bandsintown numeric event ID.
- Keeps raw numeric event IDs supported for backward compatibility.
- Bumps the normalizer cache version and hardens MusicEvent schema generation for invalid start dates.
- Enriches the performer MusicGroup node with the same authoritative IDs used elsewhere in the project.

## Scope clarification
Zen BIT is only for Bandsintown-driven dynamic events. Permanent/reference events are already separate on the site and are not part of this plugin or this PR.

## Why
The frontend and sitemap use canonical URLs like /zouk-events/2026-10-15-dutch-international-zouk-congress-107930145, but the REST route only accepted /events/107930145. That mismatch can make canonical dynamic event pages fail even though Bandsintown has the event.

## Validation
- 
pm run type-check

## Not validated locally
- php -l was not available because PHP is not installed/on PATH in this Windows shell.