### PR TITLE
[codex] Avoid Windows Vite compression artifacts

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,24 +6,28 @@ import path from 'path';
 
 export default defineConfig(({ command, mode }) => {
   const isProduction = command === 'build' || mode === 'production';
+  const shouldCompressAssets = isProduction && process.platform !== 'win32';
+  const compressibleAssetPattern = /\.(js|mjs|css|html|svg|json|xml|txt|webmanifest)$/i;
 
   return {
     plugins: [
       react(),
       tailwindcss(),
       // Gzip compression (suportado pelo servidor Hostinger)
-      isProduction && viteCompression({
+      shouldCompressAssets && viteCompression({
         algorithm: 'gzip',
         ext: '.gz',
         threshold: 1024, // Só comprime arquivos > 1KB
         deleteOriginFile: false,
+        filter: compressibleAssetPattern,
       }),
       // Brotli compression (melhor taxa para Cloudflare/CDN)
-      isProduction && viteCompression({
+      shouldCompressAssets && viteCompression({
         algorithm: 'brotliCompress',
         ext: '.br',
         threshold: 1024,
         deleteOriginFile: false,
+        filter: compressibleAssetPattern,
       }),
     ].filter(Boolean),
 


### PR DESCRIPTION
## Summary
- Disables `vite-plugin-compression` only for Windows builds, where it writes `.gz` files under `dist/D:/...`.
- Keeps gzip/Brotli precompression enabled for non-Windows production builds, including the GitHub Actions deploy environment.
- Narrows compression to known text-like deploy assets.

## Why
Local Windows builds were producing invalid artifact paths such as `dist/D:/DJ/Scripts/djzeneyer/assets/...gz`, which can pollute build artifacts and confuse deploy inspection.

## Validation
- `npm run build`
- Confirmed no `dist/D:/...` files were generated after the change.
