### PR TITLE
[codex] Add UTF-8 content audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "type-check": "tsc --noEmit",
     "context:sync": "node scripts/sync-context-versions.mjs",
     "i18n:check": "node scripts/check-i18n-parity.mjs",
+    "utf8:check": "node scripts/check-utf8-content.mjs",
     "format": "prettier --write .",
     "perf:baseline": "node scripts/perf-baseline.mjs",
     "perf:budget": "node scripts/check-performance-budget.mjs",

--- a/scripts/check-utf8-content.mjs
+++ b/scripts/check-utf8-content.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const root = path.resolve(__dirname, '..');
+
+const filesToCheck = [
+  'public/llms.txt',
+  'public/llms-full.txt',
+  'public/robots.txt',
+  'public/ai-bots.txt',
+  'public/.well-known/ai-bots.txt',
+  'public/.well-known/ai-plugin.json',
+  '.context/IDENTITY.md',
+  'AI_CONTEXT_INDEX.md',
+  'AGENTS.md',
+];
+
+const suspiciousPatterns = [
+  /\uFFFD/,
+  /Ã[\x80-\xBF]/,
+  /Â[\x80-\xBF]/,
+  /â[€\x80-\xBF]/,
+  /ðŸ/,
+];
+
+const failures = [];
+
+for (const relativePath of filesToCheck) {
+  const absolutePath = path.join(root, relativePath);
+  if (!fs.existsSync(absolutePath)) {
+    failures.push(`${relativePath}: missing`);
+    continue;
+  }
+
+  const content = fs.readFileSync(absolutePath, 'utf8');
+  for (const pattern of suspiciousPatterns) {
+    const match = content.match(pattern);
+    if (match?.index !== undefined) {
+      const line = content.slice(0, match.index).split(/\r?\n/).length;
+      failures.push(`${relativePath}:${line}: suspicious text marker "${match[0]}"`);
+      break;
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error('[utf8-content-check] Suspicious UTF-8/mojibake markers found:');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log(`[utf8-content-check] OK: ${filesToCheck.length} files checked.`);


### PR DESCRIPTION
## Summary
- Adds `npm run utf8:check` to scan AI/SEO context files for replacement characters and common mojibake markers.
- Uses Node so the check works even where Python is missing locally.

## Why
The audit raised concern about UTF-8 cleanliness in `llms.txt`, `llms-full.txt`, robots, and context files. Those files are read directly by crawlers and LLM systems, so corrupted characters can damage entity clarity.

## Validation
- `npm run utf8:check`
- `npm run type-check`
