### PR TITLE
Feat: AEO Lead Answers

### DIFF
--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -185,7 +185,7 @@ const AboutPage: React.FC = () => {
         type="profile"
         schema={ABOUT_SCHEMA}
         keywords={t('about.seo.keywords')}
-        leadAnswer={t('about.seo.lead_answer') || t('about.hero.subtitle')}
+        leadAnswer={t('about.seo.lead_answer')}
       />
 
       {/* Layout visual */}

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -185,7 +185,7 @@ const AboutPage: React.FC = () => {
         type="profile"
         schema={ABOUT_SCHEMA}
         keywords={t('about.seo.keywords')}
-        leadAnswer={t('about.seo.lead_answer')}
+        leadAnswer={t('about.seo.lead_answer') || t('about.hero.subtitle')}
       />
 
       {/* Layout visual */}

--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -82,6 +82,7 @@ const EventDetailContent = ({ id, lang }: { id: string; lang: string }) => {
         url={`${origin}${getLocalizedRoute('events', lang as Language)}/${id}`}
         image={event.image || undefined}
         events={[event]}
+        leadAnswer={event.description?.substring(0, 300) || undefined}
       />
 
       <Breadcrumb

--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -6,6 +6,7 @@ import { useParams, Link, generatePath } from 'react-router-dom';
 import { normalizeLanguage, getLocalizedRoute, type Language } from '../config/routes';
 import { useEventsQuery, useEventById } from '../hooks/useQueries';
 import { sanitizeHtml } from '../utils/sanitize';
+import { stripHtml } from '../utils/text';
 import { ARTIST } from '../data/artistData';
 import { MapPin, Share2, ArrowLeft, Music, Calendar } from 'lucide-react';
 import AddCalendarMenu from '../components/Events/AddCalendarMenu';
@@ -63,6 +64,7 @@ const EventDetailContent = ({ id, lang }: { id: string; lang: string }) => {
   const eventDate = new Date(event.starts_at);
   const isValidDate = !isNaN(eventDate.getTime());
   const loc = event.location;
+  const cleanDescription = stripHtml(event.description || '');
 
   const share = () => {
     const canonical = event.canonical_url || `${window.location.origin}${getLocalizedRoute('events', lang as Language)}/${event.event_id}`;
@@ -78,11 +80,11 @@ const EventDetailContent = ({ id, lang }: { id: string; lang: string }) => {
     <div className="max-w-6xl mx-auto animate-in fade-in slide-in-from-bottom-4 duration-700">
       <HeadlessSEO
         title={event.title}
-        description={event.description?.substring(0, 160) || ''}
+        description={cleanDescription.substring(0, 160)}
         url={`${origin}${getLocalizedRoute('events', lang as Language)}/${id}`}
         image={event.image || undefined}
         events={[event]}
-        leadAnswer={event.description?.substring(0, 300) || undefined}
+        leadAnswer={cleanDescription ? cleanDescription.substring(0, 300) : undefined}
       />
 
       <Breadcrumb

--- a/src/pages/PhilosophyPage.tsx
+++ b/src/pages/PhilosophyPage.tsx
@@ -88,7 +88,7 @@ const PhilosophyPage: React.FC = () => {
         description={t('philosophy.cremosidade_desc')}
         url={pageUrl}
         schema={philosophySchema}
-        leadAnswer={t('philosophy.cremosidade_desc')}
+        leadAnswer={t('philosophy.cremosidade_desc') || t('philosophy_page.hero_subtitle')}
       />
 
       <div className="min-h-screen bg-background text-white">

--- a/src/pages/PhilosophyPage.tsx
+++ b/src/pages/PhilosophyPage.tsx
@@ -88,7 +88,7 @@ const PhilosophyPage: React.FC = () => {
         description={t('philosophy.cremosidade_desc')}
         url={pageUrl}
         schema={philosophySchema}
-        leadAnswer={t('philosophy.cremosidade_desc') || t('philosophy_page.hero_subtitle')}
+        leadAnswer={t('philosophy_page.hero_subtitle')}
       />
 
       <div className="min-h-screen bg-background text-white">


### PR DESCRIPTION
Replacement for #502 after #492 was merged and its base branch was deleted.\n\nThis PR standardizes leadAnswer usage across key pages for AEO.\n\nStatus: needs follow-up on HTML sanitization for SEO metadata and possible leadAnswer/description duplication.