### PR TITLE
Normalize sitemap base URLs, use env REST URL; centralize API URL in UserContext; minor cleanup

### DIFF
--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Sitemap Generator v7.0 - SIMPLIFIED
+ * Sitemap Generator v8.0 - EVENTS SUPPORT
  * Gera sitemaps baseado em arquivo JSON estático
  */
 
@@ -11,7 +11,7 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const normalizeBaseUrl = (url) => url.replace(/\/+$/, '');
+const normalizeBaseUrl = (url) => String(url || '').replace(/\/+$/, '');
 
 const BASE_URL = normalizeBaseUrl(process.env.SITE_BASE_URL || 'https://djzeneyer.com');
 const REST_BASE_URL = normalizeBaseUrl(

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -11,8 +11,12 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const BASE_URL = 'https://djzeneyer.com';
-const API_URL = 'https://djzeneyer.com/wp-json/zen-bit/v2/events';
+const normalizeBaseUrl = (url) => url.replace(/\/+$/, '');
+
+const BASE_URL = normalizeBaseUrl(process.env.SITE_BASE_URL || 'https://djzeneyer.com');
+const REST_BASE_URL = normalizeBaseUrl(
+  process.env.WP_REST_URL || process.env.VITE_WP_REST_URL || `${BASE_URL}/wp-json`
+);
 const PUBLIC_DIR = path.resolve(__dirname, '../public');
 const ROUTES_DATA_PATH = path.resolve(__dirname, '../src/config/routes-slugs.json');
 
@@ -58,7 +62,7 @@ async function fetchEvents() {
 
   // 1. Tentar API Interna do WordPress (Recomendado)
   try {
-    const INTERNAL_API_EVENTS = `${BASE_URL}/wp-json/zen-bit/v2/events?mode=upcoming&days=365`;
+    const INTERNAL_API_EVENTS = `${REST_BASE_URL}/zen-bit/v2/events?mode=upcoming&days=365`;
     console.log(`📡 Fetching events from internal API: ${INTERNAL_API_EVENTS}...`);
     const res = await fetch(INTERNAL_API_EVENTS, { headers: { 'Accept': 'application/json' } });
     if (res.ok) {

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -1,6 +1,7 @@
 // src/contexts/UserContext.tsx - VERSÃO ATUALIZADA COM TURNSTILE
 import React, { createContext, useState, useContext, useEffect, ReactNode, useMemo, useCallback } from 'react';
 import { clearAllCache, queryClient, QUERY_KEYS } from '../config/queryClient';
+import { buildApiUrl } from '../config/api';
 import { fetchAuthSessionFn } from '../hooks/useQueries';
 
 interface WordPressUser {
@@ -42,7 +43,7 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
   const [loadingInitial, setLoadingInitial] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const API_URL = `${window.location.origin}/wp-json/zeneyer-auth/v1`;
+  const API_URL = useMemo(() => buildApiUrl('zeneyer-auth/v1'), []);
 
   // ========================================================================
   // HELPERS & LOGOUT (HOISTED FOR INITIALIZATION)

--- a/src/pages/MyAccountPage.tsx
+++ b/src/pages/MyAccountPage.tsx
@@ -50,7 +50,6 @@ const MyAccountContent: React.FC = () => {
   useEffect(() => {
     const tab = searchParams.get('tab');
     if (tab && tab !== activeTab) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setActiveTab(tab);
     }
   }, [searchParams, activeTab]);
@@ -130,7 +129,6 @@ const MyAccountContent: React.FC = () => {
   // Sync profile data to form state
   useEffect(() => {
     if (profileData) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setProfileForm({
         realName: profileData.real_name || user?.name || '',
         preferredName: profileData.preferred_name || '',


### PR DESCRIPTION
### Motivation
- Make the sitemap generator resilient to trailing slashes and environment-configured base/REST URLs while adding events support.
- Centralize construction of API endpoints in the user context to avoid depending on `window.location.origin` and to support different runtime configs.
- Clean up a couple of unnecessary ESLint suppression comments in the account page to keep the codebase tidy.

### Description
- Add `normalizeBaseUrl` helper and read `SITE_BASE_URL` / `WP_REST_URL` / `VITE_WP_REST_URL` to derive `BASE_URL` and `REST_BASE_URL` in `scripts/generate-sitemap.js`, and switch internal events fetch to use `REST_BASE_URL`; also bump the sitemap generator message to v8.0.
- Replace ad-hoc API URL construction in `src/contexts/UserContext.tsx` with a memoized call to `buildApiUrl('zeneyer-auth/v1')` by importing `buildApiUrl` from `src/config/api`.
- Remove a couple of `// eslint-disable-next-line react-hooks/set-state-in-effect` comments in `src/pages/MyAccountPage.tsx` where state is intentionally updated inside effects, improving code cleanliness.

### Testing
- Ran TypeScript type-check with `tsc --noEmit` which completed successfully.
- Ran linting with `eslint .` which reported no new errors.
- Verified the sitemap script changes by exercising the sitemap generator in a development environment (no automated test), and the internal events fallback logic was exercised manually and behaved as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07638091c4832fb0168b5f3e245b98)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notas de Versão

* **New Features**
  * Suporte a eventos no sitemap (indexação/geração atualizada).

* **Refactor**
  * Padronização da construção de URLs de API via helper centralizado.
  * Ajuste na composição dinâmica de URLs do gerador de sitemap para variáveis de ambiente.

* **Style**
  * Remoção de comentários de linter desnecessários no código.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarceloEyer/djzeneyer/pull/509?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->