### PR TITLE
Add music release schema metadata

### DIFF
--- a/plugins/zen-seo-lite/admin/class-zen-seo-meta-box.php
+++ b/plugins/zen-seo-lite/admin/class-zen-seo-meta-box.php
@@ -73,6 +73,8 @@ class Zen_SEO_Meta_Box
 
                 .zen-seo-field input[type="text"],
                 .zen-seo-field input[type="url"],
+                .zen-seo-field input[type="date"],
+                .zen-seo-field select,
                 .zen-seo-field textarea {
                     width: 100%;
                     padding: 8px;
@@ -197,6 +199,95 @@ class Zen_SEO_Meta_Box
                 </div>
             <?php endif; ?>
 
+            <?php if ($post_type === 'post'): ?>
+                <!-- Music release fields for WordPress posts used as Releases -->
+                <hr style="margin: 20px 0;">
+                <h3><?php _e('Music Release Schema', 'zen-seo'); ?></h3>
+                <p class="description">
+                    <?php _e('Optional structured data for release posts. Fill only when this post is a music release.', 'zen-seo'); ?>
+                </p>
+
+                <div class="zen-seo-field">
+                    <label for="zen_seo_release_type">
+                        <?php _e('Release Type', 'zen-seo'); ?>
+                    </label>
+                    <select id="zen_seo_release_type" name="zen_seo[release_type]">
+                        <?php
+                        $release_type = (string) ($meta['release_type'] ?? '');
+                        $release_types = [
+                            '' => __('Not a music release', 'zen-seo'),
+                            'single' => __('Single', 'zen-seo'),
+                            'remix' => __('Remix', 'zen-seo'),
+                            'edit' => __('Edit', 'zen-seo'),
+                            'ep' => __('EP', 'zen-seo'),
+                            'album' => __('Album', 'zen-seo'),
+                        ];
+                        foreach ($release_types as $value => $label):
+                            ?>
+                            <option value="<?php echo \esc_attr($value); ?>" <?php \selected($release_type, $value); ?>>
+                                <?php echo \esc_html($label); ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+
+                <div class="zen-seo-field">
+                    <label for="zen_seo_release_date">
+                        <?php _e('Release Date', 'zen-seo'); ?>
+                    </label>
+                    <input type="date" id="zen_seo_release_date" name="zen_seo[release_date]"
+                        value="<?php echo \esc_attr($meta['release_date'] ?? ''); ?>">
+                </div>
+
+                <div class="zen-seo-field">
+                    <label for="zen_seo_isrc_code">
+                        <?php _e('ISRC Code', 'zen-seo'); ?>
+                    </label>
+                    <input type="text" id="zen_seo_isrc_code" name="zen_seo[isrc_code]"
+                        value="<?php echo \esc_attr($meta['isrc_code'] ?? ''); ?>"
+                        placeholder="BRXXX2500001">
+                    <p class="description">
+                        <?php _e('Optional. Leave empty for unofficial remixes or releases without ISRC.', 'zen-seo'); ?>
+                    </p>
+                </div>
+
+                <div class="zen-seo-field">
+                    <label for="zen_seo_primary_artist">
+                        <?php _e('Primary Artist', 'zen-seo'); ?>
+                    </label>
+                    <input type="text" id="zen_seo_primary_artist" name="zen_seo[primary_artist]"
+                        value="<?php echo \esc_attr($meta['primary_artist'] ?? ''); ?>"
+                        placeholder="Zen Eyer">
+                </div>
+
+                <div class="zen-seo-field">
+                    <label for="zen_seo_contributors">
+                        <?php _e('Contributors', 'zen-seo'); ?>
+                    </label>
+                    <textarea id="zen_seo_contributors" name="zen_seo[contributors]" rows="3"
+                        placeholder="<?php echo \esc_attr__('One name per line: producer, remixer, composer, vocalist...', 'zen-seo'); ?>"><?php echo \esc_textarea($meta['contributors'] ?? ''); ?></textarea>
+                </div>
+
+                <?php
+                $release_urls = [
+                    'spotify_url' => __('Spotify URL', 'zen-seo'),
+                    'apple_music_url' => __('Apple Music URL', 'zen-seo'),
+                    'youtube_url' => __('YouTube URL', 'zen-seo'),
+                    'soundcloud_url' => __('SoundCloud URL', 'zen-seo'),
+                    'musicbrainz_url' => __('MusicBrainz URL', 'zen-seo'),
+                ];
+                foreach ($release_urls as $field => $label):
+                    ?>
+                    <div class="zen-seo-field">
+                        <label for="zen_seo_<?php echo \esc_attr($field); ?>">
+                            <?php echo \esc_html($label); ?>
+                        </label>
+                        <input type="url" id="zen_seo_<?php echo \esc_attr($field); ?>" name="zen_seo[<?php echo \esc_attr($field); ?>]"
+                            value="<?php echo \esc_url($meta[$field] ?? ''); ?>" placeholder="https://...">
+                    </div>
+                <?php endforeach; ?>
+            <?php endif; ?>
+
             <!-- Preview -->
             <hr style="margin: 20px 0;">
             <h3><?php _e('Search Preview', 'zen-seo'); ?></h3>
@@ -281,11 +372,23 @@ class Zen_SEO_Meta_Box
 
                     case 'image':
                     case 'event_ticket':
+                    case 'spotify_url':
+                    case 'apple_music_url':
+                    case 'youtube_url':
+                    case 'soundcloud_url':
+                    case 'musicbrainz_url':
                         $sanitized[$key] = Zen_SEO_Helpers::sanitize_url($value);
                         break;
 
                     case 'desc':
+                    case 'contributors':
                         $sanitized[$key] = \sanitize_textarea_field($value);
+                        break;
+
+                    case 'release_type':
+                        $allowed_release_types = ['single', 'remix', 'edit', 'ep', 'album'];
+                        $release_type = \sanitize_key($value);
+                        $sanitized[$key] = \in_array($release_type, $allowed_release_types, true) ? $release_type : '';
                         break;
 
                     default:

--- a/plugins/zen-seo-lite/includes/class-zen-seo-rest-api.php
+++ b/plugins/zen-seo-lite/includes/class-zen-seo-rest-api.php
@@ -56,6 +56,10 @@ class Zen_SEO_REST_API
                         'type' => 'boolean',
                         'description' => \__('No index flag', 'zen-seo')
                     ],
+                    'music_release' => [
+                        'type' => 'object',
+                        'description' => \__('Music release metadata for structured data', 'zen-seo')
+                    ],
                 ]
             ]
         ]);
@@ -239,6 +243,19 @@ class Zen_SEO_REST_API
     {
         $meta = Zen_SEO_Helpers::get_post_meta($object['id']);
 
+        $music_release = [
+            'release_type' => $meta['release_type'] ?? '',
+            'release_date' => $meta['release_date'] ?? '',
+            'isrc_code' => $meta['isrc_code'] ?? '',
+            'primary_artist' => $meta['primary_artist'] ?? '',
+            'contributors' => $meta['contributors'] ?? '',
+            'spotify_url' => $meta['spotify_url'] ?? '',
+            'apple_music_url' => $meta['apple_music_url'] ?? '',
+            'youtube_url' => $meta['youtube_url'] ?? '',
+            'soundcloud_url' => $meta['soundcloud_url'] ?? '',
+            'musicbrainz_url' => $meta['musicbrainz_url'] ?? '',
+        ];
+
         // Ensure all fields exist
         return [
             'title' => $meta['title'] ?? '',
@@ -248,6 +265,7 @@ class Zen_SEO_REST_API
             'event_date' => $meta['event_date'] ?? '',
             'event_location' => $meta['event_location'] ?? '',
             'event_ticket' => $meta['event_ticket'] ?? '',
+            'music_release' => $music_release,
         ];
     }
 

--- a/plugins/zen-seo-lite/includes/class-zen-seo-schema.php
+++ b/plugins/zen-seo-lite/includes/class-zen-seo-schema.php
@@ -72,6 +72,17 @@ class Zen_SEO_Schema
 
         // Type-specific logic
         switch ($post->post_type) {
+            case 'post':
+                $article_schema = $this->generate_article_schema($post);
+                if ($article_schema) {
+                    $schema['@graph'][] = $article_schema;
+                }
+
+                $music_release_schema = $this->generate_music_release_schema($post);
+                if ($music_release_schema) {
+                    $schema['@graph'][] = $music_release_schema;
+                }
+                break;
             case 'flyers':
                 $event_schema = $this->generate_event_schema($post);
                 if ($event_schema)
@@ -326,6 +337,56 @@ class Zen_SEO_Schema
     }
 
     /**
+     * Generate Article schema for WordPress posts.
+     *
+     * @param \WP_Post $post
+     * @return array
+     */
+    private function generate_article_schema($post)
+    {
+        $meta = Zen_SEO_Helpers::get_post_meta($post->ID);
+
+        $title = !empty($meta['title']) ? $meta['title'] : \get_the_title($post);
+        $description = !empty($meta['desc']) ? $meta['desc'] : Zen_SEO_Helpers::generate_excerpt(\get_post_field(
+            'post_content',
+            $post
+        ));
+        $image = !empty($meta['image']) ? $meta['image'] : Zen_SEO_Helpers::get_featured_image($post->ID);
+        $url = Zen_SEO_Helpers::get_frontend_url(\get_permalink($post));
+
+        $article = [
+            '@type' => 'BlogPosting',
+            '@id' => $url . '#article',
+            'headline' => \sanitize_text_field((string) $title),
+            'description' => \sanitize_text_field((string) $description),
+            'url' => $url,
+            'datePublished' => \str_replace(' ', 'T', $post->post_date_gmt) . '+00:00',
+            'dateModified' => \str_replace(' ', 'T', $post->post_modified_gmt) . '+00:00',
+            'author' => [
+                '@id' => Zen_SEO_Helpers::get_frontend_url(\home_url('/#artist'))
+            ],
+            'publisher' => [
+                '@id' => Zen_SEO_Helpers::get_frontend_url(\home_url('/#artist'))
+            ],
+            'mainEntityOfPage' => [
+                '@id' => $url . '#webpage'
+            ],
+        ];
+
+        if ($image) {
+            $article['image'] = \esc_url((string) ($image ?? ''));
+        }
+
+        if (!empty($meta['release_type'])) {
+            $article['about'] = [
+                '@id' => $url . '#music-release'
+            ];
+        }
+
+        return $article;
+    }
+
+    /**
      * Generate Event schema
      *
      * @param \WP_Post $post
@@ -385,6 +446,119 @@ class Zen_SEO_Schema
         ];
 
         return $event;
+    }
+
+    /**
+     * Generate MusicRecording or MusicAlbum schema for release posts.
+     *
+     * @param \WP_Post $post
+     * @return array|null
+     */
+    private function generate_music_release_schema($post)
+    {
+        $meta = Zen_SEO_Helpers::get_post_meta($post->ID);
+        $release_type = \sanitize_key((string) ($meta['release_type'] ?? ''));
+
+        if (empty($release_type)) {
+            return null;
+        }
+
+        $album_types = ['album', 'ep'];
+        $schema_type = \in_array($release_type, $album_types, true) ? 'MusicAlbum' : 'MusicRecording';
+        $title = !empty($meta['title']) ? $meta['title'] : \get_the_title($post);
+        $description = !empty($meta['desc']) ? $meta['desc'] : Zen_SEO_Helpers::generate_excerpt(\get_post_field(
+            'post_content',
+            $post
+        ));
+        $image = !empty($meta['image']) ? $meta['image'] : Zen_SEO_Helpers::get_featured_image($post->ID);
+        $url = Zen_SEO_Helpers::get_frontend_url(\get_permalink($post));
+        $artist_name = !empty($meta['primary_artist']) ? \sanitize_text_field((string) $meta['primary_artist']) : '';
+
+        $music = [
+            '@type' => $schema_type,
+            '@id' => $url . '#music-release',
+            'name' => \sanitize_text_field((string) $title),
+            'description' => \sanitize_text_field((string) $description),
+            'url' => $url,
+            'datePublished' => !empty($meta['release_date'])
+                ? \sanitize_text_field((string) $meta['release_date'])
+                : \str_replace(' ', 'T', $post->post_date_gmt) . '+00:00',
+            'byArtist' => $artist_name ? [
+                '@type' => 'MusicGroup',
+                'name' => $artist_name,
+            ] : [
+                '@id' => Zen_SEO_Helpers::get_frontend_url(\home_url('/#musicgroup'))
+            ],
+            'mainEntityOfPage' => [
+                '@id' => $url . '#webpage'
+            ],
+        ];
+
+        if ($image) {
+            $music['image'] = \esc_url((string) ($image ?? ''));
+        }
+
+        if (!empty($meta['isrc_code']) && $schema_type === 'MusicRecording') {
+            $music['isrcCode'] = \sanitize_text_field((string) $meta['isrc_code']);
+        }
+
+        $same_as = $this->get_music_release_same_as($meta);
+        if (!empty($same_as)) {
+            $music['sameAs'] = $same_as;
+        }
+
+        $contributors = $this->get_music_release_contributors((string) ($meta['contributors'] ?? ''));
+        if (!empty($contributors)) {
+            $music['contributor'] = $contributors;
+        }
+
+        return $music;
+    }
+
+    /**
+     * Get official release-specific URLs for sameAs.
+     *
+     * @param array $meta
+     * @return array<string>
+     */
+    private function get_music_release_same_as($meta)
+    {
+        $fields = [
+            'spotify_url',
+            'apple_music_url',
+            'youtube_url',
+            'soundcloud_url',
+            'musicbrainz_url',
+        ];
+
+        $urls = [];
+        foreach ($fields as $field) {
+            $value = \trim((string) ($meta[$field] ?? ''));
+            if ($value !== '') {
+                $urls[] = \esc_url($value);
+            }
+        }
+
+        return \array_values(\array_filter(\array_unique($urls)));
+    }
+
+    /**
+     * Normalize line-separated contributor names.
+     *
+     * @param string $contributors
+     * @return array<int, array<string, string>>
+     */
+    private function get_music_release_contributors($contributors)
+    {
+        $contributors = \str_replace(',', "\n", $contributors);
+        $names = \array_filter(\array_map('trim', \explode("\n", $contributors)));
+
+        return \array_values(\array_map(function ($name) {
+            return [
+                '@type' => 'Person',
+                'name' => \sanitize_text_field((string) $name),
+            ];
+        }, $names));
     }
 
     /**


### PR DESCRIPTION
## Summary
- Adds optional Music Release Schema fields to Zen SEO Lite for WordPress posts used as Releases.
- Stores Spotify, Apple Music, YouTube, SoundCloud, MusicBrainz, ISRC, release date, primary artist, contributors, and release type in the existing _zen_seo_data meta structure.
- Exposes release metadata through the existing zen_seo REST field.
- Generates BlogPosting for posts and MusicRecording/MusicAlbum only when release_type is filled.

## Notes
- Releases remain WordPress posts translated with Polylang. This PR only enriches metadata/schema around those posts.
- PHP is not available in this local PATH, so php -l must be run on the server or CI environment before deploying.

## Validation
- git diff --check
- npm run type-check
- npm run lint