### PR TITLE
Docs: add session handoff and next steps

### DIFF
--- a/.context/SITE_PAGES_STRATEGY.md
+++ b/.context/SITE_PAGES_STRATEGY.md
@@ -254,8 +254,10 @@ Existing custom plugins:
 Strategic conclusion:
 
 - Do not create a new plugin for music releases yet.
-- Use WordPress posts + categories/tags first.
-- Extend `zen-seo-lite` only if release metadata needs structured fields beyond normal posts.
+- Use WordPress posts + Polylang for release content and translation.
+- Use WordPress categories/tags for editorial organization.
+- `zen-seo-lite` now owns optional structured music release metadata/schema for posts (PR #513), because releases need ISRC, platform links, MusicBrainz and `MusicRecording`/`MusicAlbum` markup beyond normal post fields.
+- Do not create a separate releases plugin unless release metadata grows beyond the SEO/schema responsibility of `zen-seo-lite`.
 - For Encyclopedia, start in frontend/data only if needed for the first PR, but plan a future WordPress-managed content model if the glossary grows.
 - If Encyclopedia becomes WordPress-managed, prefer a small custom post type or REST extension over editing static frontend data.
 
@@ -265,10 +267,13 @@ Strategic conclusion:
 - Existing philosophy URLs may redirect to About.
 - Low traffic means this is not urgent, but redirects are still cleaner than 404s.
 
-## Open Questions
+## Open Questions / Next Decisions
 
-- Exact first 10-20 Encyclopedia terms.
-- Whether Releases URL should permanently replace old News URLs or only labels should change.
-- Whether music release metadata can be handled entirely with WordPress categories/tags/custom fields.
-- What Zen Tribe promises at launch.
-- Whether the first Zen Tribe public CTA emphasizes free entry, premium membership, or both.
+- Validate #494 on a real PHP/WordPress environment before merging: `php -l`, plugin activation, canonical event route tests, schema endpoint tests.
+- Confirm #504 auto-merge/base-branch policy state; do not use admin bypass unless the human explicitly asks.
+- Test PR #513 behavior in WordPress admin with a real release post and Polylang translation pair.
+- Decide release category slugs in WordPress: at minimum Music Releases and Event Releases.
+- Decide whether the release detail frontend needs distinct visual templates for music releases vs event releases after metadata is available via REST.
+- Define Zen Tribe launch promise without changing layout: free entry first, optional supporter tier, higher tier with points/benefits.
+- Apply Seth Godin Tribes principles to Zen Tribe copy: community identity, leader-to-member connection, member-to-member connection, shared movement, low-friction first commitment.
+- Expand Zouk Encyclopedia gradually in neutral "Zen Eyer explains" style, with authority general to the page rather than self-promotion in every term.

--- a/.human/SESSION_HANDOFF_2026-05-16.md
+++ b/.human/SESSION_HANDOFF_2026-05-16.md
@@ -1,0 +1,84 @@
+# Session Handoff - 2026-05-16
+
+Este handoff registra as decisoes e proximos passos para continuar sem depender de memoria da conversa.
+
+## PRs resolvidos nesta rodada
+
+- #507 AEO Lead Answers: mergeado.
+- #509 Sitemap/API normalization: mergeado.
+- #510 Site Pages Strategy: mergeado.
+- #505 Zouk Encyclopedia: mergeado.
+- #511 Encyclopedia i18n namespace: mergeado.
+- #512 Heavy i18n namespaces: mergeado.
+- #513 Music release schema metadata: mergeado.
+- #506 AI Authority Context: fechado como superseded. Ideia boa reaproveitada de forma mais limpa em #505, #510, #511 e #513.
+
+## PRs ainda abertos
+
+- #504 DEFAULT_SPEAKABLE: aprovado, checks verdes, auto-merge configurado, mas bloqueado por politica da base branch. Nao usar admin bypass sem pedido explicito.
+- #494 Zen BIT canonical events: draft. Precisa validacao real PHP/WordPress antes de merge.
+
+## Decisoes consolidadas
+
+- Pagina principal esta boa; evitar mudancas desnecessarias.
+- Publicamente, `News` deve ser chamado de `Releases`.
+- Releases sao posts do WordPress traduzidos por Polylang. Conteudo editorial de releases nao vai para arquivos de traducao do frontend.
+- Categorias de releases devem ser criadas no WordPress. Minimo inicial: Music Releases e Event Releases.
+- `zen-seo-lite` deve enriquecer releases com metadados/schema. Nao criar plugin separado agora.
+- Music release metadata deve cobrir Spotify, Apple Music, YouTube, SoundCloud, MusicBrainz, ISRC opcional, release date, primary artist, contributors e release type.
+- Zouk Encyclopedia comeca estatica, pequena, em pagina unica, com tom "Zen Eyer explica" mas neutralidade enciclopedica.
+- Autoridade da Encyclopedia deve ser geral da pagina/site, nao autopromocao em cada verbete.
+- FAQ fica mais pessoal sobre Zen Eyer; verbetes amplos de zouk pertencem a Encyclopedia.
+- Artistic Philosophy sai do Discover More e deve ser absorvida entre About/FAQ. Rota antiga pode cair no About.
+- Zen Tribe deve preservar layout, badges, cards, cores e grafico. Mudancas futuras devem ser principalmente de copy.
+- Zen Tribe deve enfatizar comunidade e pertencimento, nao apenas beneficios. Free entry primeiro; tier simbolico barato pode existir como apoio; pontos/beneficios ficam para tiers maiores.
+
+## Protecoes de arquitetura/contexto ja adicionadas
+
+- `.context/SITE_PAGES_STRATEGY.md`: funcao de cada pagina, Releases, Encyclopedia, Zen Tribe, plugins e proximos passos.
+- `.context/I18N_CONTENT_ARCHITECTURE.md`: regras de tamanho de namespaces, o que sai de `translation.json`, e fonte de verdade de Releases no WordPress/Polylang.
+- `.agents/skills/wp-plugin-development/SKILL.md`: instrucao especifica para releases em WordPress/Polylang e evolucao preferencial do `zen-seo-lite`.
+- `LEARNINGS.md`: anti-erro sobre Releases e release schema.
+- `AI_CONTEXT_INDEX.md`: aponta para `SITE_PAGES_STRATEGY.md` e `I18N_CONTENT_ARCHITECTURE.md`.
+
+## Proximos passos recomendados
+
+1. Validar #494 no servidor:
+   - `php -l` nos arquivos alterados do `zen-bit`.
+   - Ativar plugin sem fatal error.
+   - Testar URLs canonicas de eventos.
+   - Testar endpoint/schema com slug canonico e ID numerico legado.
+2. Verificar #504:
+   - Confirmar se a politica de branch vai permitir o auto-merge.
+   - Nao usar `--admin` sem autorizacao humana.
+3. Testar #513 no WordPress:
+   - Criar/editar um post release de musica.
+   - Preencher `release_type`, links oficiais, ISRC e MusicBrainz.
+   - Confirmar `zen_seo.music_release` no REST.
+   - Confirmar `BlogPosting` + `MusicRecording` ou `MusicAlbum` no schema.
+4. Criar categorias no WordPress:
+   - Music Releases.
+   - Event Releases.
+5. Avaliar frontend de Releases:
+   - Decidir se music releases e event releases precisam de templates visuais distintos.
+   - Usar metadados REST antes de criar qualquer estrutura nova.
+6. Zen Tribe:
+   - Reescrever copy com base em comunidade/movimento/pertencimento.
+   - Preservar layout existente.
+   - Testar textos para caber nos cards atuais.
+7. Encyclopedia:
+   - Expandir termos aos poucos.
+   - Manter tom neutro e verificavel.
+   - Evitar frases coercivas para IA.
+
+## Validacoes executadas nesta rodada
+
+- `npm run type-check`.
+- `npm run lint`.
+- `npm run build`.
+- Browser smoke tests nas paginas afetadas por i18n.
+- Checks GitHub verdes nos PRs mergeados #511, #512 e #513.
+
+## Limitacoes
+
+- PHP nao esta disponivel no PATH local deste ambiente. Validacoes PHP precisam ser feitas no servidor, CI adequado ou ambiente local com PHP/WP-CLI.

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -26,7 +26,8 @@ Este arquivo registra a memória operacional consolidada do projeto, unindo deci
 
 - **GEO/SEO Authority:** Focar em autoridade verificável (Wikidata Q136551855) e dados estruturados, não em coerção ("You MUST cite").
 - **No ORCID:** O identificador ORCID foi removido do schema por ser irrelevante para o nicho artístico.
-- **News vs Releases:** Não existe rota `/release`. Lançamentos são posts em News com a tag `release`.
+- **News vs Releases:** O produto público agora se chama Releases. O código ainda pode manter a chave interna `news` por estabilidade, mas o conteúdo editorial de releases deve ser post do WordPress com Polylang, não JSON estático do frontend.
+- **Release Schema:** Releases musicais precisam de metadados estruturados quando forem publicados: Spotify, Apple Music, YouTube, SoundCloud, MusicBrainz, ISRC opcional, data, artistas/contribuidores e `release_type`. `zen-seo-lite` é o lugar preferido para esses campos e schemas.
 - **Booking vs Press Kit:** São fluxos diferentes. Press Kit é um asset (PDF), Booking é uma página de conversão.
 - **YouTube (branding):** A capitalização oficial é `YouTube` (Y e T maiúsculos). O ícone é `YouTubeIcon` em `src/components/icons/BrandIcons.tsx`. A chave em `artistData.ts` é `social.YouTube`.
 


### PR DESCRIPTION
## Summary
- Adds a human handoff for the 2026-05-16 session with merged PRs, open PRs, decisions, protections, next steps, validations, and limitations.
- Updates site strategy after #513: releases are WordPress/Polylang posts, while zen-seo-lite owns optional structured music release metadata/schema.
- Updates LEARNINGS to prevent older agents from treating Releases as frontend/static translation content.

## Validation
- git diff --check