### PR TITLE
Perf: hoist default speakable selectors

### DIFF
--- a/src/components/HeadlessSEO.tsx
+++ b/src/components/HeadlessSEO.tsx
@@ -16,6 +16,8 @@ import { stripHtml } from '../utils/text';
 // 1. INTERFACES
 // ============================================================================
 
+const DEFAULT_SPEAKABLE = ['h1', '[data-speakable]'];
+
 export interface HrefLang {
   lang: string;
   url: string;
@@ -439,7 +441,6 @@ export const HeadlessSEO = React.memo<HeadlessSEOProps>(({
   if (!schema) {
     // Speakable spec — injeta seletores CSS para Google Assistant / LLMs de voz
     // Sanitiza: trim + remove strings vazias + fallback para defaults se array vazio
-    const DEFAULT_SPEAKABLE = ['h1', '[data-speakable]'];
     const normalizedSpeakableSelectors = Array.isArray(speakable)
       ? speakable.map((s) => s.trim()).filter(Boolean)
       : DEFAULT_SPEAKABLE;


### PR DESCRIPTION
## Summary
- Reapplies the useful part of #504 on a clean branch from current main.
- Moves the static DEFAULT_SPEAKABLE selector array out of HeadlessSEO render scope.

## Validation
- npm run type-check
- npm run lint
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Refator**
  * Otimização interna do código sem alterações visíveis ao usuário. O comportamento em tempo de execução permanece inalterado.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarceloEyer/djzeneyer/pull/515?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->