### PR TITLE
chore: clean obsolete fix wording in comments

### DIFF
--- a/plugins/zen-bit/includes/class-zen-bit-sitemap.php
+++ b/plugins/zen-bit/includes/class-zen-bit-sitemap.php
@@ -4,14 +4,14 @@
  *
  * Exposes /sitemap-events.xml with SEO-optimised canonical URLs.
  *
- * CRITICAL FIX (v3.1.0):
+ * Canonical URL Implementation (v3.1.0):
  *   The sitemap previously pointed to `/events/{event_id}` — a URL that only
  *   exists as a short-form alias and is NOT what the React router renders.
  *   The canonical URL is `/zouk-events/{yyyy-mm-dd}-{slug}-{event_id}`, built by
  *   Zen_BIT_Normalizer::normalize_list_item(). Feeding search engines the wrong
  *   URL caused index misses and potential duplicate-content signals.
  *
- *   Fix: normalise each raw event through the Normalizer before writing <loc>,
+ *   Implementation: normalise each raw event through the Normalizer before writing <loc>,
  *   so the sitemap always matches the URL the React SPA actually renders.
  *
  * Cache strategy:
@@ -141,7 +141,7 @@ class Zen_BIT_Sitemap
     /**
      * Fetches upcoming events from Bandsintown and builds the XML string.
      *
-     * CANONICAL URL FIX:
+     * Canonical URL Handling:
      *   Each raw event is passed through Zen_BIT_Normalizer::normalize_list_item()
      *   which calls build_canonical_path() internally:
      *     /zouk-events/{yyyy-mm-dd}-{slug}-{event_id}

--- a/src/components/HeadlessSEO.tsx
+++ b/src/components/HeadlessSEO.tsx
@@ -1,5 +1,4 @@
 // src/components/HeadlessSEO.tsx
-// VERSÃO 8.3.0 - FIX: HTML LANG DYNAMIC & SOCIAL FALLBACK
 
 import React from 'react';
 import { Helmet } from 'react-helmet-async';
@@ -605,7 +604,7 @@ export const HeadlessSEO = React.memo<HeadlessSEOProps>(({
       {isProfileType && <meta property="profile:last_name" content={authorLastName} />}
       {isProfileType && <meta property="profile:username" content="djzeneyer" />}
 
-      {/* Twitter Cards (X) - FIX: Adicionado summary_large_image explicitamente */}
+      {/* Twitter Cards (X) */}
       <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:title" content={finalTitle} />
       <meta name="twitter:description" content={truncatedDesc} />


### PR DESCRIPTION
## Summary

Consolidates the useful low-risk cleanup from the duplicate Jules PRs into one small PR.

## Changes

- Removes an obsolete version/changelog comment from `HeadlessSEO.tsx`.
- Simplifies the Twitter Cards comment without changing any tags.
- Rewords `zen-bit` sitemap comments to avoid task-trigger wording while preserving the technical context.

## Notes

Intentionally did not remove the `react-hooks/purity` suppression around `Date.now()` because lint still requires it. Also did not apply PR #537 because that comment explains a real defensive cast in the sitemap/robots integration.

## Validation

- `npm run lint`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Melhorias internas na documentação do código relacionada à normalização de URLs canônicas e cards de redes sociais.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarceloEyer/djzeneyer/pull/543?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->