### PR TITLE
chore: tune Jules PR guardrails

### DIFF
--- a/.github/workflows/trigger-bot-reviews.yml
+++ b/.github/workflows/trigger-bot-reviews.yml
@@ -1,14 +1,14 @@
-name: 🤖 Trigger All Bot Reviews
+name: 🤖 Trigger Bot Reviews
 
-# CodeRabbit, Codex e Jules precisam de um prompt explícito para revisar.
-# Este workflow garante que os bots recebam prompt em TODOS os PRs,
+# CodeRabbit e Codex precisam de um prompt explícito para revisar.
+# Este workflow garante que os reviewers recebam prompt em TODOS os PRs,
 # incluindo PRs criados por bots (Jules, Bolt).
 #
 # Estrutura:
 # - concurrency: serializa triggers por branch base → evita burst que consome
 #   o rate limit do CodeRabbit quando vários PRs são abertos em sequência.
 # - sleep entre steps: espaça as chamadas dentro de um mesmo PR.
-# - Jules: não recebe @jules em PRs criados pelo próprio Jules (evita loop de noise).
+# - Jules: não é usado como reviewer automático. Jules cria PRs; não revisa PRs de terceiros.
 
 on:
   pull_request_target:
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   trigger-reviews:
-    name: Trigger CodeRabbit + Codex + Jules
+    name: Trigger CodeRabbit + Codex
     runs-on: ubuntu-latest
     steps:
       # ── CodeRabbit ────────────────────────────────────────────────────────
@@ -38,7 +38,7 @@ jobs:
             const marker = '<!-- coderabbit-auto-review -->';
             const { owner, repo } = context.repo;
             const issue_number = context.payload.pull_request.number;
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner,
               repo,
               issue_number,
@@ -76,7 +76,7 @@ jobs:
             const marker = '<!-- codex-auto-review -->';
             const { owner, repo } = context.repo;
             const issue_number = context.payload.pull_request.number;
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner,
               repo,
               issue_number,
@@ -103,47 +103,5 @@ jobs:
                 '- SEO por página com `<HeadlessSEO />`; rotas privadas usam `noindex`',
                 '- safeUrl(null) retorna "#" truthy — sempre passar segundo argumento',
                 '- Consulte `AGENTS.md` e `AI_CONTEXT_INDEX.md` para regras completas',
-              ].join('\n'),
-            });
-
-      # ── Jules ─────────────────────────────────────────────────────────────
-      # Jules NÃO recebe @jules em PRs criados pelo próprio Jules.
-      # Isso evita o loop onde Jules responde ao trigger com check-in nos seus
-      # próprios PRs sem fazer revisão útil.
-      - name: Trigger Jules review (apenas PRs não criados por bots)
-        if: >
-          github.event.pull_request.user.login != 'google-labs-jules' &&
-          github.event.pull_request.user.type != 'Bot'
-        uses: actions/github-script@v9
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const marker = '<!-- jules-auto-review -->';
-            const { owner, repo } = context.repo;
-            const issue_number = context.payload.pull_request.number;
-            const { data: comments } = await github.rest.issues.listComments({
-              owner,
-              repo,
-              issue_number,
-              per_page: 100,
-            });
-
-            if (comments.some((c) => c.body?.includes(marker))) {
-              core.info(`Jules prompt já existe no PR #${issue_number}; pulando.`);
-              return;
-            }
-
-            await github.rest.issues.createComment({
-              owner,
-              repo,
-              issue_number,
-              body: [
-                marker,
-                '@jules Por favor, revise este PR.',
-                '',
-                'Verifique qualidade do código, possíveis bugs, impactos de performance',
-                'e conformidade com as regras do projeto.',
-                'Stack: React 19 + TypeScript 6 + Vite 8 + Tailwind 4 + WordPress Headless PHP 8.3.',
-                'Consulte `.jules/instructions.md` e `AI_CONTEXT_INDEX.md` para regras completas.',
               ].join('\n'),
             });

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,8 @@
+# 2026-05-20 - Gate de Uso do Bolt
+
+**Learning:** Este arquivo é memória histórica de padrões e aprendizados, não backlog automático. Entradas antigas, futuras ou fora de ordem podem conter contexto incompleto e não autorizam PR por si só.
+**Action:** Antes de aplicar qualquer learning, confirmar que o padrão existe no código atual, que há benefício real e que a mudança foi pedida por humano, issue atribuída ou bug reproduzível. Não abrir PR para limpeza de comentários ou micro-otimização sem evidência objetiva.
+
 ## 2025-02-19 - WP REST API _embed Performance
 
 **Learning:** Using `_embed` in WP REST API requests triggers significant overhead due to multiple internal queries (N+1) for fetching related objects like authors, terms, media, and comments. For list endpoints returning many items (e.g., 100 tracks), this causes a major performance bottleneck on the backend.

--- a/.jules/context.md
+++ b/.jules/context.md
@@ -1,0 +1,86 @@
+# Contexto operacional do Jules — DJ Zen Eyer
+
+Este arquivo existe para orientar o Jules antes de planejar ou abrir PR. Leia em conjunto com `AGENTS.md`, `AI_CONTEXT_INDEX.md` e `.jules/instructions.md`.
+
+## Arquitetura resumida
+
+- Projeto headless WordPress + React/Vite.
+- Frontend principal em `src/`, com React 19, TypeScript strict, React Query v5, Tailwind 4 e i18n via `react-i18next`.
+- Backend versionado em `plugins/`, com endpoints REST WordPress e integração WooCommerce/GamiPress quando aplicável.
+- SEO depende de SSR/prerender, `HeadlessSEO.tsx`, rotas localizadas e schemas JSON-LD corretos.
+- A fonte de verdade das rotas é `src/config/routes-slugs.json`.
+
+## Papel esperado do Jules
+
+Jules é executor assíncrono de tarefas específicas. Ele deve criar PRs pequenos e revisáveis apenas quando houver pedido humano, issue atribuída ou bug demonstrável.
+
+Jules não deve atuar como reviewer automático de PRs de terceiros. Essa função pertence a CodeRabbit, Codex e revisão humana.
+
+## O que costuma ser bom para Jules
+
+- Corrigir bug pequeno e reproduzível.
+- Adicionar ou ajustar teste focado.
+- Implementar feature pequena com escopo claro.
+- Fazer refactor local quando simplifica o código sem alterar comportamento.
+- Melhorar performance quando há hot path comprovado e validação antes/depois.
+
+## O que costuma gerar ruído
+
+- PR comment-only para trocar palavras como `FIX`, `CRITICAL`, `TODO` ou comentários históricos.
+- Micro-otimizações de arrays pequenos, menus pequenos ou objetos estáticos sem profiler.
+- PRs de performance PHP que alteram SQL/queries sem fixture, benchmark e revisão humana.
+- Mudanças em SEO/head/SSR/schema sem validar duplicação de tags, status HTTP e guidelines do Google.
+- Abrir múltiplos PRs para a mesma classe de problema.
+
+## Classificação de risco
+
+Baixo risco:
+- Docs pedidas explicitamente.
+- Ajustes pequenos em scripts de build com validação local.
+- Correções pontuais de lint quando não mudam comportamento.
+
+Risco médio:
+- Memoização React, lazy loading e alteração de hooks.
+- Mudanças em prerender, sitemap, robots ou rotas públicas.
+- Refactor em normalizadores PHP sem alteração de contrato.
+
+Risco alto:
+- WooCommerce, GamiPress, autenticação, JWT, permissões, checkout, pagamentos.
+- SEO/head/SSR/canonical/schema JSON-LD.
+- SQL manual, cache priming, query batching e endpoints REST de lista.
+- Workflows de deploy, secrets, SSH, ambiente de produção.
+
+Para risco alto, abra PR somente com pedido humano explícito e validação descrita.
+
+## Validação mínima por domínio
+
+Frontend:
+- `npm run lint`
+- teste específico quando existir
+- revisar i18n e `safeUrl(url, fallback)`
+
+SEO/SSR:
+- `npm run lint`
+- validar que há exatamente um `title`, uma `meta description` e um canonical por página prerenderizada
+- não emitir schema invisível, falso ou sem conteúdo equivalente na página
+
+PHP/WordPress:
+- usar APIs WordPress/WooCommerce antes de SQL direto
+- sanitizar entrada e usar prepared statements quando SQL for inevitável
+- validar contrato REST e compatibilidade HPOS
+
+Workflows:
+- manter mudanças mínimas
+- não tocar secrets
+- explicar o impacto operacional no PR
+
+## Higiene de PR
+
+Antes de abrir PR:
+- listar PRs abertos e procurar duplicatas
+- manter um domínio por PR
+- escrever título honesto
+- incluir validações executadas
+- explicar riscos residuais
+
+Se a melhor conclusão for "não vale PR", diga isso no resumo da tarefa.

--- a/.jules/instructions.md
+++ b/.jules/instructions.md
@@ -1,5 +1,6 @@
 # Instruções Operacionais para Jules — DJ Zen Eyer
-# Última revisão: 2026-03-27
+
+Última revisão: 2026-05-20
 
 ---
 
@@ -10,7 +11,8 @@
 - Não adicione comentários de revisão em PRs que você não criou.
 - Não aprove, solicite mudanças ou faça resumos de PRs de terceiros.
 - A revisão de código é responsabilidade do CodeRabbit (configurado em `.coderabbit.yaml`).
-- Seu papel: identificar melhorias, criar branches, implementar, abrir PR, aguardar revisão.
+- Seu papel: implementar tarefas explicitamente solicitadas, criar branches, abrir PRs focados e aguardar revisão humana/bots.
+- Se encontrar uma oportunidade não solicitada, registre como sugestão no resumo da tarefa. Não abra PR automaticamente.
 
 ---
 
@@ -36,7 +38,29 @@ Em caso de divergência, siga esta ordem:
 - Leia `.jules/context.md` completo.
 - Leia `AI_CONTEXT_INDEX.md`.
 - Verifique a stack real no `package.json` (nunca assuma versões de cabeça).
+- Rode `gh pr list --state open --limit 50` e não crie PR duplicado.
 - Nunca crie PRs que mexam em mais de um domínio ao mesmo tempo (ex: frontend + PHP juntos). Separe em PRs focados.
+- O título do PR deve descrever o que o diff realmente muda. Não use `fix`, `perf` ou `N+1` se o diff só altera comentário, documentação ou lint.
+- A descrição do PR deve listar validações executadas. Se uma validação relevante não foi executada, explique por quê.
+
+---
+
+## 3.1 Gate de criação de PR
+
+Antes de abrir PR, confirme todos os itens:
+
+1. A tarefa veio de pedido humano explícito, issue atribuída ou bug reproduzível no código atual.
+2. O diff resolve uma causa real, não apenas uma hipótese genérica extraída de comentário ou learning.
+3. O PR é pequeno, tem um domínio único e não duplica PR aberto.
+4. Existe validação proporcional ao risco (`npm run lint`, teste específico, diff manual ou benchmark reproduzível).
+
+Não abrir PR automaticamente para:
+
+- Limpeza de comentários, docblocks, changelog ou palavras como `FIX`, `CRITICAL`, `TODO`, salvo pedido humano explícito.
+- Micro-otimizações de renderização sem evidência de profiler, hot path ou regressão visível.
+- Refactors de performance em PHP/GamiPress/WooCommerce sem benchmark, fixture ou revisão manual planejada.
+- Mudanças em arquivos de contexto, workflows, autenticação, SEO/head, rotas ou deploy sem pedido explícito.
+- Alterações geradas apenas por `.jules/bolt.md`. Esse arquivo é memória, não backlog.
 
 ---
 
@@ -99,7 +123,7 @@ Em caso de divergência, siga esta ordem:
 
 - **Vite 8:** nunca `minify: 'esbuild'` — OXC é o padrão.
 - **Prerender:** nunca remover `scripts/prerender.js`.
-- **SSOT de rotas:** ao criar nova rota, atualizar `scripts/routes-config.json`.
+- **SSOT de rotas:** ao criar nova rota, atualizar `src/config/routes-slugs.json`.
 - **fetch-depth no CI:** manter `2`, nunca `0`.
 - **ESLint ignores:** `.claude`, `.agents`, `.bolt`, `.gemini`, `.jules`, `.devcontainer` — nunca remover.
 
@@ -123,7 +147,7 @@ Em caso de divergência, siga esta ordem:
 ## 8. Quando criar PR vs quando não criar
 
 **Criar PR:**
-- Performance: memoização, lazy load, otimização de queries
+- Performance: memoização, lazy load, otimização de queries apenas quando houver gargalo real, hot path ou benchmark reproduzível
 - Refactor focado: um arquivo ou feature por vez
 - Deps: bumps de patch/minor em lotes por categoria (devDeps separado de prodDeps)
 - Novas features pedidas explicitamente em issues
@@ -133,3 +157,16 @@ Em caso de divergência, siga esta ordem:
 - Mudanças em `deploy.yml` que alterem lógica de SSH ou secrets
 - Bumps de versão major sem verificação de compatibilidade
 - Qualquer coisa que toque em rotas de autenticação ou JWT
+- Qualquer alteração comment-only, salvo pedido humano direto
+
+---
+
+## 9. Uso correto de `.jules/bolt.md`
+
+`.jules/bolt.md` é um log de aprendizados. Ele não é fila de tarefas.
+
+- Não use entradas do Bolt como autorização para abrir PR.
+- Não propague datas futuras ou fora de ordem; use apenas a data real do dia.
+- Se uma learning parecer aplicável, primeiro prove que o padrão existe no código atual e que o benefício compensa o risco.
+- Em caso de conflito entre Bolt e código real, o código real vence.
+- Se a mudança for apenas cosmética, comentário ou micro-otimização, deixe como sugestão e aguarde pedido humano.


### PR DESCRIPTION
## Summary
- add the missing .jules/context.md that Jules was already instructed to read
- add PR creation gates so Bolt learnings, comments, and micro-optimizations do not become automatic PRs
- stop auto-tagging @jules as a PR reviewer; CodeRabbit and Codex remain the automatic reviewers
- fix the stale route SSOT reference to src/config/routes-slugs.json

## Validation
- git diff --check
- reviewed the official Jules docs for AGENTS.md, setup, planning, and API behavior

## Notes
This PR intentionally changes only agent/workflow configuration. No product code changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Ajustes realizados em processos internos de revisão e documentação de diretrizes de automação.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarceloEyer/djzeneyer/pull/544?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->