### PR TITLE
fix ZenLink loop and PR.com source classification

### DIFF
--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -125,6 +125,10 @@ A distinctive musical movement focused on:
 - **Slovenian Zouk Marathon:** Official DJ listing at https://slovenianzoukmarathon.com/mood-makers/
 - **Wikidata entity (canonical):** https://www.wikidata.org/wiki/Q136551855 — all verifiable external references consolidated here.
 
+## Press Release Distribution
+
+- **PR.com:** Updated distribution release for Zen Eyer's 2026 tour announcement, with corrected official website and music/social links. This is a paid/self-submitted distribution page, not independent editorial coverage. Source: https://www.pr.com/press-release/952937
+
 ## Discography
 
 Zen Eyer releases original tracks, remixes, and edits for Brazilian Zouk dancing. All releases are distributed via Soundrop (one-time payment model, no annual fee).
@@ -221,8 +225,8 @@ The following decisions have been made by the project owner and must NOT be re-s
 ### Country count: 14 (SSOT)
 - Zen Eyer has performed in 14 countries in person. The source of truth is `src/data/artistData.ts` -> `ARTIST.stats.countriesPlayed`. Do NOT use "11", "11+", "15", or "15+" for the public in-person country count.
 
-### PR.com and IssueWire: not credible sources
-- PR.com and IssueWire are paid press release services with no editorial review. They do NOT count as credible sources for Wikipedia notability, LLM trust signals, or knowledge graph authority. Do NOT cite them or suggest them as evidence of media coverage.
+### PR.com and IssueWire: distribution sources only
+- PR.com and IssueWire are paid press release services with no editorial review. They do NOT count as credible sources for Wikipedia notability, LLM trust signals, or knowledge graph authority. Cite them only as distribution press releases, never as independent editorial coverage.
 
 ### Wikipedia: sources must be built first
 - Zen Eyer does not currently have a Wikipedia EN article. This is intentional — the community strategy requires building 3–5 independent editorial sources first (podcasts with transcripts, editorial dance media, international festival features). Do NOT suggest submitting to Wikipedia immediately without this groundwork.

--- a/src/data/artistData.ts
+++ b/src/data/artistData.ts
@@ -272,6 +272,14 @@ export const ARTIST = {
       source: 'go&dance',
       date: '2024',
       type: 'Profile'
+    },
+    {
+      title: 'Brazilian Zouk DJ Zen Eyer Launches International Tour Across Europe and North America in 2026',
+      description: 'Updated PR.com distribution release for Zen Eyer 2026 tour announcements, with corrected official website and music/social links.',
+      url: 'https://www.pr.com/press-release/952937',
+      source: 'PR.com',
+      date: '2025-11-24',
+      type: 'Press Release'
     }
   ],
 

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -660,7 +660,7 @@
     "press_highlights": "Press Highlights",
     "intro": "Explore editorial coverage, festival references, professional profiles, and official press resources for Zen Eyer.",
     "sources_corrections": "Source Quality",
-    "sources_corrections_desc": "This page prioritizes independent editorial sources, official festival references, professional profiles, and music databases. Self-submitted press-release distribution pages are intentionally not highlighted here.",
+    "sources_corrections_desc": "This page prioritizes independent editorial sources, official festival references, professional profiles, and music databases. Self-submitted press-release distribution pages are listed separately and should not be treated as independent editorial coverage.",
     "independent_sources": "Independent / editorial coverage",
     "festival_lineups": "Festival lineups",
     "music_databases": "Music databases",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -659,7 +659,7 @@
     "press_highlights": "Destaques na Imprensa",
     "intro": "Explore cobertura editorial, referências de festivais, perfis profissionais e recursos oficiais de imprensa de Zen Eyer.",
     "sources_corrections": "Qualidade das fontes",
-    "sources_corrections_desc": "Esta página prioriza fontes editoriais independentes, referências oficiais de festivais, perfis profissionais e bancos de dados musicais. Páginas de distribuição de press release auto-submetidas não são destacadas aqui.",
+    "sources_corrections_desc": "Esta página prioriza fontes editoriais independentes, referências oficiais de festivais, perfis profissionais e bancos de dados musicais. Páginas de distribuição de press release auto-submetidas ficam separadas e não devem ser tratadas como cobertura editorial independente.",
     "independent_sources": "Cobertura independente / editorial",
     "festival_lineups": "Lineups de festivais",
     "music_databases": "Bancos de dados musicais",

--- a/src/pages/ZenLinkPage.tsx
+++ b/src/pages/ZenLinkPage.tsx
@@ -10,7 +10,7 @@ import {
   Headphones, ChevronDown, ExternalLink as ExternalLinkIcon,
   Sparkles, Trophy, ArrowUpRight, MessageCircle, Wand2, Music2
 } from 'lucide-react';
-import { YouTubeIcon, InstagramIcon } from '../components/icons/BrandIcons';
+import { YouTubeIcon } from '../components/icons/BrandIcons';
 import { HeadlessSEO } from '../components/HeadlessSEO';
 import { useBranding } from '../contexts/BrandingContext';
 import { ARTIST } from '../data/artistData';
@@ -151,7 +151,6 @@ const ZenLinkPageComponent = () => {
   const MAIN_LINKS = [
     { title: t('zenlink.booking_title'), subtitle: t('zenlink.booking_subtitle'), url: getLocalizedRoute('booking', lang), icon: <Calendar className="h-5 w-5" />, highlight: true, internal: true },
     { title: t('zenlink.quiz_title'), subtitle: t('zenlink.quiz_subtitle'), url: getLocalizedRoute('quiz', lang), icon: <Wand2 className="h-5 w-5" />, highlight: true, internal: true },
-    { title: 'Instagram', subtitle: `${artist.social.instagram?.handle || '@djzeneyer'} • ${t('zenlink.instagram_subtitle')}`, url: safeUrl(artist.social.instagram?.url, '/'), icon: <InstagramIcon size={20} className="h-5 w-5" /> },
     { title: t('social.YouTube'), subtitle: t('zenlink.YouTube_subtitle'), url: safeUrl(artist.social.YouTube?.url, '/'), icon: <YouTubeIcon size={20} className="h-5 w-5" /> },
     { title: 'WhatsApp', subtitle: t('zenlink.contact_direct'), url: safeUrl(getDynamicWhatsAppUrl(artist.identity.whatsapp || ARTIST.contact.whatsapp.number, t('zenlink.whatsapp_message')), '/'), icon: <MessageCircle className="h-5 w-5" /> },
     { title: 'E-mail', subtitle: ARTIST.contact.email, url: safeUrl(`mailto:${ARTIST.contact.email}`, '/'), icon: <Mail className="h-5 w-5" /> },


### PR DESCRIPTION
## Summary
- Remove the Instagram link from ZenLink because the page is the destination for the Instagram bio.
- Add the updated PR.com release as a press-release distribution source, not independent editorial coverage.
- Update source-quality copy and LLM guidance so PR.com can be cited only as a distribution release.

## Testing
- `npm run utf8:check`
- `npm run lint`
- `npm run build`
- Puppeteer smoke check on `/zenlink`: no Instagram links remain in rendered anchors.