### PR TITLE
Fix route-scoped event prerender data

### DIFF
--- a/.context/API.md
+++ b/.context/API.md
@@ -56,13 +56,21 @@ Alias endpoints also exist under `/auth/*`:
 
 ## Events (`zen-bit/v2`)
 
-- `GET /events`
+- `GET /events?mode=upcoming|past|all&days=1..730&limit=1..200&lang=en|pt`
 - `GET /events/schema`
 - `GET /events/{event_id}`
 - `GET /events/{event_id}/schema`
 - `POST /admin/fetch-now` (admin)
 - `POST /admin/clear-cache` (admin)
 - `GET /admin/health` (admin)
+
+Consumption model:
+
+- `zen-bit` is the SSOT for event selection, date filtering, sorting, canonical paths, cache headers, and MusicEvent schema.
+- Home should request or prerender only the next 3 upcoming events.
+- The public Events page should request or prerender the upcoming list payload, currently capped at 50 events.
+- React may derive render-only fields such as `detailHref`, parsed dates, and display labels, but should not duplicate backend event selection rules.
+- Prerender may inline route-scoped event payloads for bots and first paint. The frontend must treat those as initial cache data, not as a global complete event store.
 
 ## Gamification (`zengame/v1`)
 

--- a/.context/ARCHITECTURE.md
+++ b/.context/ARCHITECTURE.md
@@ -37,6 +37,18 @@ Arquivos que precisam ficar na raiz do site em produção devem ter origem em `p
 - SEO headless: plugin `zen-seo-lite`.
 - Gamificacao: plugin `zengame`.
 
+## Eventos, prerender e consumo de recursos
+
+`zen-bit` e a fonte de verdade para eventos. O plugin decide selecao, modo (`upcoming`, `past`, `all`), janela de dias, limite, ordenacao, canonical path, cache HTTP e schema MusicEvent. O frontend consome `zen-bit/v2/events` via `useEventsQuery` e so adiciona campos de renderizacao, como `detailHref` e datas ja parseadas para os cards.
+
+O prerender existe principalmente para SEO, GEO, AEO, Knowledge Panel e first paint. Ele pode injetar `window.__PRERENDER_DATA__` como cache inicial por rota, mas esse payload deve ser pequeno e escopado:
+
+- Home: apenas os 3 proximos eventos.
+- Events: lista publica maior, atualmente limitada a 50 eventos.
+- Outras rotas: sem lista de eventos, exceto quando a propria rota dinamica do evento precisar de dados para renderizacao.
+
+Essa divisao evita over-fetch, reduz HTML inutil em paginas sem eventos, preserva dados estruturados para bots e mantem o plugin como SSOT.
+
 ## Fluxo operacional
 
 1. O usuario acessa a SPA.

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -24,6 +24,8 @@ Este arquivo registra a memória operacional consolidada do projeto, unindo deci
 - **Events SSOT:** `zen-bit/v2/events` is the source of truth for event selection, sorting, date windows, canonical paths, cache headers, and schema. React can add render-only fields, but should not duplicate backend filtering logic.
 - **Events prerender data:** `window.__PRERENDER_DATA__.events` must go through the same `_processed` enrichment as live API events. Components such as the home `EventsList` rely on `_processed.detailHref` and `_processed.day`; returning raw prerender items makes the home show "No events found" while `/events` still works.
 - **Route-scoped prerender payloads:** Home should inline only the next 3 events, `/zouk-events` should inline the list payload, and unrelated routes should not inline events. Track `eventsMode`, `eventsDays`, and `eventsLimit` so SPA navigation or different queries fetch `zen-bit` instead of reusing an incompatible inline cache.
+- **Prerender menu payloads:** Include both `menu.en` and `menu.pt` in every prerender payload. SPA language switches can otherwise fall back to the route locale menu and show the wrong navigation language.
+- **Prerender cache matching:** Normalize query defaults before comparing with `window.__PRERENDER_DATA__` metadata. For example, an omitted `days` parameter that defaults to 365 should still match a prerender payload tagged with `eventsDays: 365`.
 
 ## 🎨 Decisões de Marca & SEO
 

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -21,6 +21,9 @@ Este arquivo registra a memória operacional consolidada do projeto, unindo deci
 - **Vite Build:** Use sempre o minificador OXC (Vite 8 padrão). Nunca remover assets hashados antigos de `dist/assets` durante o deploy para evitar `ChunkLoadError`.
 - **safeUrl fallback:** `safeUrl(null)` retorna `'#'` (truthy). O padrão `safeUrl(url) || fallback` nunca funciona. Sempre: `safeUrl(url, '/fallback.svg')` para imagens, `safeUrl(url, '/')` para links.
 - **artistData.ts chaves capitalizadas:** As chaves `YouTube` e `YouTubeMusic` no objeto `social` são escritas com capital Y e T. Não usar `youtube` ou `youtubeMusic` (lowercase) — essas chaves não existem.
+- **Events SSOT:** `zen-bit/v2/events` is the source of truth for event selection, sorting, date windows, canonical paths, cache headers, and schema. React can add render-only fields, but should not duplicate backend filtering logic.
+- **Events prerender data:** `window.__PRERENDER_DATA__.events` must go through the same `_processed` enrichment as live API events. Components such as the home `EventsList` rely on `_processed.detailHref` and `_processed.day`; returning raw prerender items makes the home show "No events found" while `/events` still works.
+- **Route-scoped prerender payloads:** Home should inline only the next 3 events, `/zouk-events` should inline the list payload, and unrelated routes should not inline events. Track `eventsMode`, `eventsDays`, and `eventsLimit` so SPA navigation or different queries fetch `zen-bit` instead of reusing an incompatible inline cache.
 
 ## 🎨 Decisões de Marca & SEO
 

--- a/scripts/prerender.js
+++ b/scripts/prerender.js
@@ -11,7 +11,10 @@ const BANDSINTOWN_ARTIST_ID = process.env.BANDSINTOWN_ARTIST_ID || 'id_15619775'
 const BANDSINTOWN_APP_ID = process.env.BANDSINTOWN_APP_ID || 'f8f1216ea03be95a3ea91c7ebe7117e7';
 const SITE_BASE_URL = process.env.SITE_BASE_URL || 'https://djzeneyer.com';
 const PRERENDER_PORT = parsePrerenderPort(process.env.PRERENDER_PORT);
-const INTERNAL_API_EVENTS = `${SITE_BASE_URL}/wp-json/zen-bit/v2/events?mode=upcoming&days=365`;
+const PRERENDER_HOME_EVENTS_LIMIT = 3;
+const PRERENDER_EVENTS_LIST_LIMIT = 50;
+const PRERENDER_EVENTS_DAYS = 365;
+const INTERNAL_API_EVENTS = `${SITE_BASE_URL}/wp-json/zen-bit/v2/events?mode=upcoming&days=${PRERENDER_EVENTS_DAYS}&limit=${PRERENDER_EVENTS_LIST_LIMIT}`;
 const EVENTS_ROUTE_EN = '/zouk-events';
 const EVENTS_ROUTE_PT = '/pt/eventos-zouk';
 const bandsintownArtistEndpoint = `https://rest.bandsintown.com/artists/${BANDSINTOWN_ARTIST_ID}/events?app_id=${BANDSINTOWN_APP_ID}&date=upcoming`;
@@ -236,6 +239,52 @@ function buildCanonicalPath(event, lang = 'en') {
   return `${base}/${eventDate}-${titlePart}-${event.event_id}`;
 }
 
+function localizeCanonicalPath(event, lang = 'en') {
+  const existingPath = safeText(event?.canonical_path);
+  if (!existingPath) return buildCanonicalPath(event, lang);
+
+  if (lang === 'pt') {
+    if (existingPath.startsWith(`${EVENTS_ROUTE_PT}/`)) return existingPath;
+    if (existingPath.startsWith(`${EVENTS_ROUTE_EN}/`)) {
+      return `${EVENTS_ROUTE_PT}${existingPath.slice(EVENTS_ROUTE_EN.length)}`;
+    }
+  }
+
+  if (existingPath.startsWith(`${EVENTS_ROUTE_EN}/`)) return existingPath;
+  if (existingPath.startsWith(`${EVENTS_ROUTE_PT}/`)) {
+    return `${EVENTS_ROUTE_EN}${existingPath.slice(EVENTS_ROUTE_PT.length)}`;
+  }
+
+  return buildCanonicalPath(event, lang);
+}
+
+function normalizeZenBitEvent(raw, lang = 'en') {
+  const normalized = {
+    ...raw,
+    event_id: String(raw?.event_id ?? raw?.id ?? ''),
+    title: safeText(raw?.title) || 'DJ Zen Eyer',
+    starts_at: safeText(raw?.starts_at || raw?.datetime || ''),
+    timezone: raw?.timezone || undefined,
+    location: {
+      venue: safeText(raw?.location?.venue),
+      city: safeText(raw?.location?.city),
+      region: safeText(raw?.location?.region),
+      country: safeText(raw?.location?.country),
+      latitude: raw?.location?.latitude ? String(raw.location.latitude) : undefined,
+      longitude: raw?.location?.longitude ? String(raw.location.longitude) : undefined,
+    },
+    source_url: safeText(raw?.source_url || raw?.url),
+  };
+
+  const canonical_path = localizeCanonicalPath(normalized, lang);
+
+  return {
+    ...normalized,
+    canonical_path,
+    canonical_url: `${SITE_BASE_URL}${canonical_path}`,
+  };
+}
+
 function normalizeBandsintownEvent(raw, lang = 'en') {
   const venue = raw?.venue || {};
   const startsAt = raw?.datetime || raw?.starts_at || '';
@@ -340,11 +389,11 @@ async function fetchEvents() {
 
     const items = Array.isArray(raw) ? raw : [];
     
-    // Se vier da API interna, já está normalizado. Mas passamos pelo normalizeBandsintownEvent 
-    // novamente para garantir que a estrutura 'detailById' (en/pt) seja criada corretamente
-    // se o prerender precisar de campos específicos de tradução.
-    const eventsEn = items.map(item => normalizeBandsintownEvent(item, 'en')).filter(e => e.event_id);
-    const eventsPt = items.map(item => normalizeBandsintownEvent(item, 'pt')).filter(e => e.event_id);
+    // Internal API events are already normalized by zen-bit. Only normalize raw
+    // Bandsintown fallback payloads from scratch.
+    const normalizer = source === 'INTERNAL_API' ? normalizeZenBitEvent : normalizeBandsintownEvent;
+    const eventsEn = items.map(item => normalizer(item, 'en')).filter(e => e.event_id);
+    const eventsPt = items.map(item => normalizer(item, 'pt')).filter(e => e.event_id);
     const detailById = Object.fromEntries(eventsEn.map((event, index) => [event.event_id, { en: event, pt: eventsPt[index] }]));
 
     const payload = {
@@ -439,6 +488,40 @@ async function fetchMenuData() {
   return result;
 }
 
+function getRouteLang(route) {
+  return route === '/pt' || route.startsWith('/pt/') ? 'pt' : 'en';
+}
+
+function isHomeRoute(route) {
+  return route === '/' || route === '' || route === '/pt';
+}
+
+function isEventsListRoute(route) {
+  return route === EVENTS_ROUTE_EN || route === EVENTS_ROUTE_PT;
+}
+
+function buildPrerenderPayloadForRoute(route, bandsintownData, menuData) {
+  const lang = getRouteLang(route);
+  const payload = {
+    menu: { [lang]: menuData[lang] || [] },
+    fetchedAt: bandsintownData.fetchedAt,
+  };
+
+  if (isHomeRoute(route)) {
+    payload.events = { [lang]: (bandsintownData.list?.[lang] || []).slice(0, PRERENDER_HOME_EVENTS_LIMIT) };
+    payload.eventsLimit = PRERENDER_HOME_EVENTS_LIMIT;
+    payload.eventsMode = 'upcoming';
+    payload.eventsDays = PRERENDER_EVENTS_DAYS;
+  } else if (isEventsListRoute(route)) {
+    payload.events = { [lang]: bandsintownData.list?.[lang] || [] };
+    payload.eventsLimit = PRERENDER_EVENTS_LIST_LIMIT;
+    payload.eventsMode = 'upcoming';
+    payload.eventsDays = PRERENDER_EVENTS_DAYS;
+  }
+
+  return payload;
+}
+
 async function prerender() {
   let browser = null;
   try {
@@ -464,13 +547,7 @@ async function prerender() {
       args: ['--no-sandbox', '--disable-setuid-sandbox'],
     });
 
-    const prerenderPayloadObj = {
-      events: bandsintownData.list,
-      menu: menuData,
-      fetchedAt: bandsintownData.fetchedAt,
-    };
-
-    const createPrerenderPage = async () => {
+    const createPrerenderPage = async (routePayload) => {
       const page = await browser.newPage();
 
       // 🛡️ API INTERCEPTION: Global for all pages
@@ -478,7 +555,7 @@ async function prerender() {
       // Isso elimina os fetches de events e menu do critical path de carregamento.
       await page.evaluateOnNewDocument((payload) => {
         window.__PRERENDER_DATA__ = payload;
-      }, prerenderPayloadObj);
+      }, routePayload);
 
       await page.setRequestInterception(true);
       page.on('request', request => {
@@ -588,7 +665,8 @@ async function prerender() {
           unlinkSync(outputPath);
         }
 
-        page = await createPrerenderPage();
+        const prerenderPayloadObj = buildPrerenderPayloadForRoute(route, bandsintownData, menuData);
+        page = await createPrerenderPage(prerenderPayloadObj);
         await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 });
 
         try {
@@ -614,7 +692,12 @@ async function prerender() {
             : html.replace('<head>', `<head>\n<meta name="prerender-generated" content="true">`);
 
           // Injeta antes do </head> (garante que está disponível antes do JS principal)
-          if (!finalHtml.includes('window.__PRERENDER_DATA__')) {
+          if (finalHtml.includes('window.__PRERENDER_DATA__')) {
+            finalHtml = finalHtml.replace(
+              /<script>window\.__PRERENDER_DATA__=.*?<\/script>/s,
+              prerenderInlineScript
+            );
+          } else {
             finalHtml = finalHtml.replace('</head>', `${prerenderInlineScript}\n</head>`);
           }
 

--- a/scripts/prerender.js
+++ b/scripts/prerender.js
@@ -503,7 +503,10 @@ function isEventsListRoute(route) {
 function buildPrerenderPayloadForRoute(route, bandsintownData, menuData) {
   const lang = getRouteLang(route);
   const payload = {
-    menu: { [lang]: menuData[lang] || [] },
+    menu: {
+      en: menuData.en || [],
+      pt: menuData.pt || [],
+    },
     fetchedAt: bandsintownData.fetchedAt,
   };
 

--- a/src/components/EventsList.tsx
+++ b/src/components/EventsList.tsx
@@ -53,6 +53,7 @@ function EventsListInner({ limit = 10, showTitle = true, variant = 'full' }: Eve
   // React Query: v2 defaults
   const { data: events = [], isLoading: loading, error } = useEventsQuery({
     mode: 'upcoming',
+    days: 365,
     limit,
     lang
   });

--- a/src/components/HeadlessSEO.tsx
+++ b/src/components/HeadlessSEO.tsx
@@ -312,7 +312,6 @@ export const HeadlessSEO = React.memo<HeadlessSEOProps>(({
 
     // 4.3 Event Schema (Single-pass MusicEvent mapping)
     if (events && events.length > 0) {
-      // eslint-disable-next-line react-hooks/purity
       const now = Date.now();
       const threeHoursMs = 3 * 60 * 60 * 1000;
       const musicEvents: Record<string, unknown>[] = [];

--- a/src/hooks/useQueries.ts
+++ b/src/hooks/useQueries.ts
@@ -299,6 +299,10 @@ const withProcessedEvents = (
 
   return events.map(event => {
     const eventDate = new Date(event.starts_at);
+    if (!Number.isFinite(eventDate.getTime())) {
+      return null;
+    }
+
     const identifier = event.canonical_path
       ? event.canonical_path.split('/').pop() || event.event_id
       : event.event_id;
@@ -311,7 +315,7 @@ const withProcessedEvents = (
         detailHref: generatePath(eventsDetailRoute, { id: identifier })
       }
     };
-  });
+  }).filter((event): event is ZenBitEventListItem => event !== null);
 };
 
 export const fetchMenuFn = async (lang: string): Promise<MenuItem[]> => {
@@ -358,12 +362,13 @@ export const fetchEventsFn = async ({
   const prerenderEvents = getPrerenderEvents(lang);
   const prerenderEventsLimit = window.__PRERENDER_DATA__?.eventsLimit;
   const requestedMode = mode ?? (upcomingOnly === false ? 'all' : 'upcoming');
+  const requestedDays = date === undefined ? (days ?? 365) : undefined;
   const prerenderEventsMode = window.__PRERENDER_DATA__?.eventsMode;
   const prerenderEventsDays = window.__PRERENDER_DATA__?.eventsDays;
   const canUsePrerenderEvents =
     requestedMode === prerenderEventsMode &&
     date === undefined &&
-    days === prerenderEventsDays &&
+    requestedDays === prerenderEventsDays &&
     prerenderEventsLimit !== undefined &&
     limit <= prerenderEventsLimit;
   if (canUsePrerenderEvents && prerenderEvents && prerenderEvents.length > 0) {

--- a/src/hooks/useQueries.ts
+++ b/src/hooks/useQueries.ts
@@ -263,6 +263,9 @@ declare global {
         en?: WPPost[];
         pt?: WPPost[];
       };
+      eventsLimit?: number;
+      eventsMode?: FetchEventsParams['mode'];
+      eventsDays?: number;
       fetchedAt?: string;
     };
   }
@@ -287,6 +290,30 @@ const getPrerenderData = <T>(
 const getPrerenderEvents = (lang?: string) => getPrerenderData<ZenBitEventListItem[]>(lang, 'events');
 const getPrerenderMenu = (lang?: string) => getPrerenderData<MenuItem[]>(lang, 'menu');
 const getPrerenderNews = (lang?: string) => getPrerenderData<WPPost[]>(lang, 'news');
+
+const withProcessedEvents = (
+  events: ZenBitEventListItem[],
+  lang?: string
+): ZenBitEventListItem[] => {
+  const eventsDetailRoute = getLocalizedRoute('events-detail', (lang || 'en') as Language);
+
+  return events.map(event => {
+    const eventDate = new Date(event.starts_at);
+    const identifier = event.canonical_path
+      ? event.canonical_path.split('/').pop() || event.event_id
+      : event.event_id;
+
+    return {
+      ...event,
+      _processed: {
+        eventDate,
+        day: eventDate.getDate(),
+        detailHref: generatePath(eventsDetailRoute, { id: identifier })
+      }
+    };
+  });
+};
+
 export const fetchMenuFn = async (lang: string): Promise<MenuItem[]> => {
   const prerenderMenu = getPrerenderMenu(lang);
   if (prerenderMenu && prerenderMenu.length > 0) return prerenderMenu;
@@ -329,8 +356,18 @@ export const fetchEventsFn = async ({
   upcomingOnly,
 }: FetchEventsParams = {}): Promise<ZenBitEventListItem[]> => {
   const prerenderEvents = getPrerenderEvents(lang);
-  if (prerenderEvents && prerenderEvents.length > 0) {
-    return prerenderEvents.slice(0, limit);
+  const prerenderEventsLimit = window.__PRERENDER_DATA__?.eventsLimit;
+  const requestedMode = mode ?? (upcomingOnly === false ? 'all' : 'upcoming');
+  const prerenderEventsMode = window.__PRERENDER_DATA__?.eventsMode;
+  const prerenderEventsDays = window.__PRERENDER_DATA__?.eventsDays;
+  const canUsePrerenderEvents =
+    requestedMode === prerenderEventsMode &&
+    date === undefined &&
+    days === prerenderEventsDays &&
+    prerenderEventsLimit !== undefined &&
+    limit <= prerenderEventsLimit;
+  if (canUsePrerenderEvents && prerenderEvents && prerenderEvents.length > 0) {
+    return withProcessedEvents(prerenderEvents.slice(0, limit), lang);
   }
 
   try {
@@ -363,23 +400,7 @@ export const fetchEventsFn = async ({
     }
 
     // Optimization: Pre-process dates and IDs at fetch time to avoid O(N) on render
-    const eventsDetailRoute = getLocalizedRoute('events-detail', (lang || 'en') as Language);
-    
-    return events.map(event => {
-      const eventDate = new Date(event.starts_at);
-      const identifier = event.canonical_path
-        ? event.canonical_path.split('/').pop() || event.event_id
-        : event.event_id;
-
-      return {
-        ...event,
-        _processed: {
-          eventDate,
-          day: eventDate.getDate(),
-          detailHref: generatePath(eventsDetailRoute, { id: identifier })
-        }
-      };
-    });
+    return withProcessedEvents(events, lang);
   } catch (err) {
     console.error('Fetch Events failed:', err);
     return [];

--- a/src/pages/MyAccountPage.tsx
+++ b/src/pages/MyAccountPage.tsx
@@ -36,24 +36,24 @@ interface UserStats {
   recentAchievements: number;
 }
 
+interface ProfileForm {
+  realName: string;
+  preferredName: string;
+  facebookUrl: string;
+  instagramUrl: string;
+  danceRole: string[];
+  gender: '' | 'male' | 'female' | 'non-binary';
+}
+
 const MyAccountContent: React.FC = () => {
   const { t, i18n } = useTranslation();
-  const { user, loading, logout } = useUser();
+  const { user, loadingInitial, logout } = useUser();
   const currentLang = useMemo(() => normalizeLanguage(i18n.language), [i18n.language]);
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
-  const initialTab = searchParams.get('tab') || 'overview';
-  const [activeTab, setActiveTab] = useState(initialTab);
+  const activeTab = searchParams.get('tab') || 'overview';
 
   const { data: gamipress, loading: loadingGP, error: errorGP } = useGamiPressContext();
-
-  // Sync state correctly if parameter changes externally while page is mounted
-  useEffect(() => {
-    const tab = searchParams.get('tab');
-    if (tab && tab !== activeTab) {
-      setActiveTab(tab);
-    }
-  }, [searchParams, activeTab]);
 
   // ⚡ Bolt: Memoize combined achievements array to prevent O(N) reallocation during every component re-render
   const allAchievements = useMemo(() => [
@@ -63,19 +63,11 @@ const MyAccountContent: React.FC = () => {
 
   // Handle manual tab switching and URL update
   const handleTabChange = React.useCallback((tabId: string) => {
-    setActiveTab(tabId);
     setSearchParams({ tab: tabId });
   }, [setSearchParams]);
 
   // Profile form state
-  const [profileForm, setProfileForm] = useState({
-    realName: user?.name || '',
-    preferredName: '',
-    facebookUrl: '',
-    instagramUrl: '',
-    danceRole: [] as string[],
-    gender: '' as '' | 'male' | 'female' | 'non-binary'
-  });
+  const [profileDraft, setProfileDraft] = useState<Partial<ProfileForm>>({});
   const [savingProfile, setSavingProfile] = useState(false);
   const [profileSaved, setProfileSaved] = useState(false);
 
@@ -115,10 +107,10 @@ const MyAccountContent: React.FC = () => {
 
   // Redirect se não logado
   useEffect(() => {
-    if (!loading && !loadingGP && !user?.isLoggedIn) {
+    if (!loadingInitial && !loadingGP && !user?.isLoggedIn) {
       navigate(getLocalizedRoute('', currentLang));
     }
-  }, [user, loading, loadingGP, navigate, currentLang]);
+  }, [user, loadingInitial, loadingGP, navigate, currentLang]);
 
   // React Query Hooks
   const { data: profileData } = useProfileQuery(user?.token);
@@ -127,19 +119,19 @@ const MyAccountContent: React.FC = () => {
   const updateNewsletter = useUpdateNewsletterMutation(user?.token);
   const { data: orders = [], isLoading: loadingOrders } = useUserOrdersQuery(user?.id, user?.token, 5);
 
-  // Sync profile data to form state
-  useEffect(() => {
-    if (profileData) {
-      setProfileForm({
-        realName: profileData.real_name || user?.name || '',
-        preferredName: profileData.preferred_name || '',
-        facebookUrl: profileData.facebook_url || '',
-        instagramUrl: profileData.instagram_url || '',
-        danceRole: profileData.dance_role || EMPTY_STRING_ARRAY,
-        gender: profileData.gender || '',
-      });
-    }
-  }, [profileData, user?.name]);
+  const profileDefaults = useMemo<ProfileForm>(() => ({
+    realName: profileData?.real_name || user?.name || '',
+    preferredName: profileData?.preferred_name || '',
+    facebookUrl: profileData?.facebook_url || '',
+    instagramUrl: profileData?.instagram_url || '',
+    danceRole: profileData?.dance_role || EMPTY_STRING_ARRAY,
+    gender: profileData?.gender || '',
+  }), [profileData, user?.name]);
+
+  const profileForm = useMemo<ProfileForm>(() => ({
+    ...profileDefaults,
+    ...profileDraft,
+  }), [profileDefaults, profileDraft]);
 
 
   const handleLogout = React.useCallback(() => {
@@ -152,8 +144,8 @@ const MyAccountContent: React.FC = () => {
     }
   }, [logout, navigate, currentLang]);
 
-  const handleProfileChange = React.useCallback((field: string, value: string | string[]) => {
-    setProfileForm(prev => ({ ...prev, [field]: value }));
+  const handleProfileChange = React.useCallback((field: keyof ProfileForm, value: string | string[]) => {
+    setProfileDraft(prev => ({ ...prev, [field]: value }));
     setProfileSaved(false);
   }, []);
 
@@ -184,7 +176,7 @@ const MyAccountContent: React.FC = () => {
     { id: 'settings', label: t('account.tabs.settings'), icon: Settings, color: 'secondary' },
   ], [t]);
 
-  if (loading || (user?.isLoggedIn && loadingGP)) {
+  if (loadingInitial || (user?.isLoggedIn && loadingGP)) {
     return (
       <div className="min-h-screen flex items-center justify-center pt-24">
         <div className="text-center">


### PR DESCRIPTION
## Summary
- keep `zen-bit/v2/events` as the SSOT for event selection, sorting, canonical paths, cache headers, and schema
- make prerender inline only route-scoped event payloads: 3 events for Home, up to 50 for `/zouk-events`, none for unrelated routes
- enrich prerendered events through the same `_processed` path as live API events so Home no longer renders the empty state
- guard inline event cache reuse with `eventsMode`, `eventsDays`, and `eventsLimit`
- document the event/prerender responsibility split in `.context/API.md`, `.context/ARCHITECTURE.md`, and `LEARNINGS.md`

## Verification
- `npm run type-check`
- `npm run lint`
- `git diff --check`
- `npm run build`
- `npm run prerender` -> 68/68 routes
- Local preview with Puppeteer:
  - Home: 3 event links, no empty event state
  - `/zouk-events/`: 15 event rows from inline payload, `eventsLimit=50`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Otimização na seleção e carregamento de eventos conforme o tipo de página, limitando dados carregados ao necessário para cada seção.
  * Melhorias no pré-processamento e enriquecimento de dados de eventos para melhor performance e consistência entre navegações.

* **Documentation**
  * Atualizada documentação sobre manipulação, seleção, parametrização e consumo de dados de eventos.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarceloEyer/djzeneyer/pull/551?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->