### PR TITLE
Reduce routine public page requests

### DIFF
--- a/.context/ENGINEERING.md
+++ b/.context/ENGINEERING.md
@@ -12,6 +12,8 @@ Este documento define os princípios de desenvolvimento e as restrições operac
 - **SSOT (Single Source of Truth):**
     - Identidade: `.context/IDENTITY.md` + `src/data/artistData.ts`.
     - Rotas: `src/config/routes-slugs.json`.
+- **Perfil operacional do site:** O site tem baixo volume de atualizacoes. Eventos costumam atualizar semanalmente; posts/releases/reviews e copy publica atualizam mensalmente, trimestralmente ou menos; identidade, links oficiais e dados de pagamento raramente mudam. Prefira caches longos, prerender, dados estaticos para identidade e reducao de requests rotineiros antes de criar endpoints/agregadores complexos.
+- **SEO/GEO/AEO/Knowledge Panel:** Priorize informacao factual, rastreavel e estruturada para bots, com baixo consumo de recursos. Solucoes simples e cacheaveis vencem otimizacoes pequenas que aumentam fragilidade.
 
 ---
 

--- a/.context/SITE_PAGES_STRATEGY.md
+++ b/.context/SITE_PAGES_STRATEGY.md
@@ -22,6 +22,13 @@ Core navigation model:
 - Discover More: About, Releases, Encyclopedia, Media, FAQ.
 - Support / Donation: keep directly accessible in the footer as its own important payment/support path.
 
+Operational preference:
+
+- The site is intentionally low-update and cache-friendly. Events usually update weekly; Releases/news/reviews and public text update monthly, quarterly, or less; artist identity, official links, and payment data are effectively static.
+- For SEO, GEO, AEO, and Knowledge Panel support, prefer prerendered/static factual surfaces, long-lived caches, and simple WordPress REST queries over complex runtime aggregation.
+- Public pages should avoid routine runtime requests when the same information can be shipped statically or prerendered without harming freshness.
+- Query-string filters are useful for users, but they are weaker SEO surfaces than canonical indexable routes or well-structured evergreen pages. Create indexable category/tag/term pages only when there is enough unique, durable content to justify them.
+
 The former Artistic Philosophy page should not be treated as a permanent standalone destination. Its content should be redistributed across About, FAQ, Music, Work With Me, and Encyclopedia.
 
 ## Page Roles

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -27,6 +27,7 @@ Este arquivo registra a memória operacional consolidada do projeto, unindo deci
 - **Prerender menu payloads:** Include both `menu.en` and `menu.pt` in every prerender payload. SPA language switches can otherwise fall back to the route locale menu and show the wrong navigation language.
 - **Prerender cache matching:** Normalize query defaults before comparing with `window.__PRERENDER_DATA__` metadata. For example, an omitted `days` parameter that defaults to 365 should still match a prerender payload tagged with `eventsDays: 365`.
 - **Low-update public site:** Prefer long-lived cache and removing routine runtime requests over adding complex aggregation layers. For stable identity data, `artistData.ts` can be a deliberate static SSOT; for ordinary WordPress posts, avoid fetching taxonomies on detail pages unless filters are visible.
+- **Frontend stale times:** Public posts/releases and products can use 24h React Query `staleTime` because updates are rare. Keep cart and authenticated/user-specific data on shorter TTLs because those reflect active user actions.
 
 ## 🎨 Decisões de Marca & SEO
 

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -26,6 +26,7 @@ Este arquivo registra a memória operacional consolidada do projeto, unindo deci
 - **Route-scoped prerender payloads:** Home should inline only the next 3 events, `/zouk-events` should inline the list payload, and unrelated routes should not inline events. Track `eventsMode`, `eventsDays`, and `eventsLimit` so SPA navigation or different queries fetch `zen-bit` instead of reusing an incompatible inline cache.
 - **Prerender menu payloads:** Include both `menu.en` and `menu.pt` in every prerender payload. SPA language switches can otherwise fall back to the route locale menu and show the wrong navigation language.
 - **Prerender cache matching:** Normalize query defaults before comparing with `window.__PRERENDER_DATA__` metadata. For example, an omitted `days` parameter that defaults to 365 should still match a prerender payload tagged with `eventsDays: 365`.
+- **Low-update public site:** Prefer long-lived cache and removing routine runtime requests over adding complex aggregation layers. For stable identity data, `artistData.ts` can be a deliberate static SSOT; for ordinary WordPress posts, avoid fetching taxonomies on detail pages unless filters are visible.
 
 ## 🎨 Decisões de Marca & SEO
 

--- a/src/config/queryClient.ts
+++ b/src/config/queryClient.ts
@@ -32,11 +32,11 @@ const STALE_TIME = {
   /** Eventos: 30 minutos — agenda sincronizada via prerender; detalhe muda raramente */
   EVENTS: 30 * 60 * 1000,
 
-  /** News/Posts: 15 minutos — conteúdo editorial, não em tempo real */
-  POSTS: 15 * 60 * 1000,
+  /** News/Posts: 24 horas - conteudo editorial muda mensalmente ou menos */
+  POSTS: 24 * 60 * 60 * 1000,
 
-  /** Produtos: 30 minutos (catálogo estável durante a sessão) */
-  PRODUCTS: 30 * 60 * 1000,
+  /** Produtos: 24 horas - catalogo estavel; carrinho continua separado e curto */
+  PRODUCTS: 24 * 60 * 60 * 1000,
 
   /** Carrinho: 30 segundos (muda frequentemente) */
   CART: 30 * 1000,

--- a/src/contexts/BrandingContext.tsx
+++ b/src/contexts/BrandingContext.tsx
@@ -1,7 +1,6 @@
 import React, { createContext, useContext, ReactNode, useMemo } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { fetchArtistProfileFn, ArtistProfile } from '../hooks/useQueries';
-import { ARTIST as FALLBACK_ARTIST } from '../data/artistData';
+import { ARTIST } from '../data/artistData';
+import type { ArtistProfile } from '../hooks/useQueries';
 
 interface BrandingContextType {
   artist: ArtistProfile;
@@ -12,33 +11,18 @@ interface BrandingContextType {
 const BrandingContext = createContext<BrandingContextType | undefined>(undefined);
 
 /**
- * BrandingProvider manages the "Source of Truth" for the artist identity.
- * It fetches the latest data from WordPress (Zen SEO Identity settings)
- * and falls back to the static artistData.ts if necessary.
+ * BrandingProvider exposes the static artist identity.
+ * This project updates artist identity rarely, so artistData.ts remains the
+ * runtime SSOT and avoids a global REST request on every public page view.
  */
 export const BrandingProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
-  const { data, isLoading, error } = useQuery({
-    queryKey: ['artist-profile'],
-    queryFn: fetchArtistProfileFn,
-    staleTime: 1000 * 60 * 60, // 1 hour - branding data is stable
-  });
-
-  // Merge dynamic data with static fallback to ensure no breaks
-  const artist = useMemo(() => {
-    if (!data) return FALLBACK_ARTIST as unknown as ArtistProfile;
-    
-    return {
-      ...data,
-      // Ensure we have at least the critical site fields from fallback if missing
-      site: (FALLBACK_ARTIST as unknown as { site: unknown }).site,
-    };
-  }, [data]);
+  const artist = useMemo(() => ARTIST as unknown as ArtistProfile, []);
 
   const value = useMemo(() => ({
     artist,
-    isLoading,
-    error: error as Error | null,
-  }), [artist, isLoading, error]);
+    isLoading: false,
+    error: null,
+  }), [artist]);
 
   return (
     <BrandingContext.Provider value={value}>

--- a/src/contexts/BrandingContext.tsx
+++ b/src/contexts/BrandingContext.tsx
@@ -1,9 +1,8 @@
 import React, { createContext, useContext, ReactNode, useMemo } from 'react';
 import { ARTIST } from '../data/artistData';
-import type { ArtistProfile } from '../hooks/useQueries';
 
 interface BrandingContextType {
-  artist: ArtistProfile;
+  artist: typeof ARTIST;
   isLoading: boolean;
   error: Error | null;
 }
@@ -16,13 +15,11 @@ const BrandingContext = createContext<BrandingContextType | undefined>(undefined
  * runtime SSOT and avoids a global REST request on every public page view.
  */
 export const BrandingProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
-  const artist = useMemo(() => ARTIST as unknown as ArtistProfile, []);
-
   const value = useMemo(() => ({
-    artist,
+    artist: ARTIST,
     isLoading: false,
     error: null,
-  }), [artist]);
+  }), []);
 
   return (
     <BrandingContext.Provider value={value}>

--- a/src/hooks/useQueries.ts
+++ b/src/hooks/useQueries.ts
@@ -869,7 +869,10 @@ export const useZenGameLeaderboard = (limit = 10) => {
 // USER PROFILE & NEWSLETTER (AUTHENTICATED)
 // ============================================================================
 
-export const useProfileQuery = (token?: string) => {
+export const useProfileQuery = (
+  token?: string,
+  options: { enabled?: boolean } = {}
+) => {
   return useQuery<UserProfile | null>({
     queryKey: ['user', 'profile', !!token],
     queryFn: async (): Promise<UserProfile | null> => {
@@ -888,13 +891,18 @@ export const useProfileQuery = (token?: string) => {
       }
       return parsed.data as UserProfile;
     },
-    enabled: !!token,
+    enabled: Boolean(token) && (options.enabled ?? true),
     staleTime: STALE_TIME.USER_PROFILE,
   });
 };
 
 
-export const useUserOrdersQuery = (userId?: number, token?: string, limit = 5) => {
+export const useUserOrdersQuery = (
+  userId?: number,
+  token?: string,
+  limit = 5,
+  options: { enabled?: boolean } = {}
+) => {
   return useQuery<WCOrder[]>({
     queryKey: [...QUERY_KEYS.user.orders(userId, limit), !!token],
     queryFn: async (): Promise<WCOrder[]> => {
@@ -912,7 +920,7 @@ export const useUserOrdersQuery = (userId?: number, token?: string, limit = 5) =
       }
       return [];
     },
-    enabled: Boolean(token && userId),
+    enabled: Boolean(token && userId) && (options.enabled ?? true),
     staleTime: STALE_TIME.USER_PROFILE,
     retry: false,
   });
@@ -937,7 +945,10 @@ export const useUpdateProfileMutation = (token?: string) => {
   });
 };
 
-export const useNewsletterStatusQuery = (token?: string) => {
+export const useNewsletterStatusQuery = (
+  token?: string,
+  options: { enabled?: boolean } = {}
+) => {
   return useQuery<boolean | null>({
     queryKey: ['user', 'newsletter', !!token],
     queryFn: async (): Promise<boolean | null> => {
@@ -950,7 +961,7 @@ export const useNewsletterStatusQuery = (token?: string) => {
       const data = await res.json();
       return data.success ? (data.subscribed as boolean) : false;
     },
-    enabled: !!token,
+    enabled: Boolean(token) && (options.enabled ?? true),
     staleTime: STALE_TIME.USER_PROFILE,
   });
 };

--- a/src/hooks/useQueries.ts
+++ b/src/hooks/useQueries.ts
@@ -573,7 +573,10 @@ export const useNewsQuery = (
   });
 };
 
-export const useNewsTaxonomiesQuery = (lang?: string) => {
+export const useNewsTaxonomiesQuery = (
+  lang?: string,
+  options: { enabled?: boolean } = {}
+) => {
   return useQuery({
     queryKey: QUERY_KEYS.posts.taxonomies(lang),
     queryFn: async () => {
@@ -584,6 +587,7 @@ export const useNewsTaxonomiesQuery = (lang?: string) => {
       return { categories, tags };
     },
     staleTime: STALE_TIME.POSTS,
+    enabled: options.enabled,
   });
 };
 

--- a/src/pages/MyAccountPage.tsx
+++ b/src/pages/MyAccountPage.tsx
@@ -113,11 +113,20 @@ const MyAccountContent: React.FC = () => {
   }, [user, loadingInitial, loadingGP, navigate, currentLang]);
 
   // React Query Hooks
-  const { data: profileData } = useProfileQuery(user?.token);
-  const { data: newsletterEnabled } = useNewsletterStatusQuery(user?.token);
+  const shouldLoadSettingsData = activeTab === 'settings';
+  const shouldLoadOrdersData = activeTab === 'orders';
+
+  const { data: profileData } = useProfileQuery(user?.token, {
+    enabled: shouldLoadSettingsData,
+  });
+  const { data: newsletterEnabled } = useNewsletterStatusQuery(user?.token, {
+    enabled: shouldLoadSettingsData,
+  });
   const updateProfile = useUpdateProfileMutation(user?.token);
   const updateNewsletter = useUpdateNewsletterMutation(user?.token);
-  const { data: orders = [], isLoading: loadingOrders } = useUserOrdersQuery(user?.id, user?.token, 5);
+  const { data: orders = [], isLoading: loadingOrders } = useUserOrdersQuery(user?.id, user?.token, 5, {
+    enabled: shouldLoadOrdersData,
+  });
 
   const profileDefaults = useMemo<ProfileForm>(() => ({
     realName: profileData?.real_name || user?.name || '',

--- a/src/pages/NewsPage.tsx
+++ b/src/pages/NewsPage.tsx
@@ -73,7 +73,9 @@ const NewsPage: React.FC = () => {
   }), [searchParams]);
   const hasActiveFilter = Boolean(selectedFilterSlugs.category || selectedFilterSlugs.tag || selectedFilterSlugs.search);
 
-  const { data: taxonomiesData } = useNewsTaxonomiesQuery(normalizedLanguage);
+  const { data: taxonomiesData } = useNewsTaxonomiesQuery(normalizedLanguage, {
+    enabled: !slug,
+  });
   const selectedFilters = useMemo(() => {
     const selectedCategory = taxonomiesData?.categories.find(term => term.slug === selectedFilterSlugs.category);
     const selectedTag = taxonomiesData?.tags.find(term => term.slug === selectedFilterSlugs.tag);


### PR DESCRIPTION
## Summary
- Stop fetching news taxonomies on article detail routes where the filters are not rendered.
- Keep rtistData.ts as the runtime branding SSOT and remove the global zen-seo/v1/profile request from BrandingProvider.
- Document the low-update-site caching/request-reduction decision in LEARNINGS.md.

## Validation
- 
pm run type-check
- 
pm run lint
- git diff --check
- 
pm run build

## Notes
This intentionally avoids larger backend aggregation work because the site updates rarely and the measurable win here is removing routine requests without increasing architecture complexity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Menos requisições em páginas de detalhe de posts e carregamento condicional por aba na conta, reduzindo latência.
  * Posts e produtos usam cache mais longo (24h), melhorando responsividade em páginas públicas.

* **Comportamento**
  * Dados de identidade/branding agora são servidos estaticamente, removendo estados de carregamento visíveis.

* **Documentação**
  * Diretrizes de arquitetura e preferência por conteúdo estático/prérenderizado atualizadas.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarceloEyer/djzeneyer/pull/552?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->