### PR TITLE
perf: reduzir padrões N+1 de user meta nas APIs de dashboard e perfil

### DIFF
--- a/plugins/zeneyer-auth/includes/API/class-rest-routes.php
+++ b/plugins/zeneyer-auth/includes/API/class-rest-routes.php
@@ -667,24 +667,47 @@ class Rest_Routes
     private static function get_profile_data($user_id)
     {
         $user = get_userdata($user_id);
+        $meta = get_user_meta($user_id);
 
         // Avatar: prefer Google OAuth photo, then Gravatar (with 404 default so empty is returned if no Gravatar)
-        $google_avatar = get_user_meta($user_id, 'zeneyer_google_avatar', true);
+        $google_avatar = self::first_user_meta_value($meta, 'zeneyer_google_avatar');
         $avatar = $google_avatar ?: (function_exists('get_avatar_url') ? (get_avatar_url($user_id, ['size' => 200, 'default' => '404']) ?: '') : '');
 
         return [
             'id' => $user_id,
             'email' => $user->user_email,
             'display_name' => $user->display_name,
-            'real_name' => get_user_meta($user_id, 'zen_real_name', true),
-            'preferred_name' => get_user_meta($user_id, 'zen_preferred_name', true),
-            'facebook_url' => get_user_meta($user_id, 'zen_facebook_url', true),
-            'instagram_url' => get_user_meta($user_id, 'zen_instagram_url', true),
-            'dance_role' => get_user_meta($user_id, 'zen_dance_role', true) ?: [],
-            'gender' => get_user_meta($user_id, 'zen_gender', true),
+            'real_name' => self::first_user_meta_value($meta, 'zen_real_name'),
+            'preferred_name' => self::first_user_meta_value($meta, 'zen_preferred_name'),
+            'facebook_url' => self::first_user_meta_value($meta, 'zen_facebook_url'),
+            'instagram_url' => self::first_user_meta_value($meta, 'zen_instagram_url'),
+            'dance_role' => self::first_user_meta_value($meta, 'zen_dance_role', []),
+            'gender' => self::first_user_meta_value($meta, 'zen_gender'),
             'avatar' => $avatar,
             'user_registered_year' => intval(substr((string)$user->user_registered, 0, 4)),
         ];
+    }
+
+    /**
+     * Read first value from raw get_user_meta($user_id) payload.
+     *
+     * @param array<string, array<int, mixed>> $meta
+     * @param mixed $default
+     * @return mixed
+     */
+    private static function first_user_meta_value(array $meta, string $key, $default = '')
+    {
+        if (!isset($meta[$key][0])) {
+            return $default;
+        }
+
+        $value = maybe_unserialize($meta[$key][0]);
+
+        if ($value === '' || $value === null) {
+            return $default;
+        }
+
+        return $value;
     }
 
     /**

--- a/plugins/zeneyer-auth/includes/API/class-rest-routes.php
+++ b/plugins/zeneyer-auth/includes/API/class-rest-routes.php
@@ -668,6 +668,9 @@ class Rest_Routes
     {
         $user = get_userdata($user_id);
         $meta = get_user_meta($user_id);
+        if (!is_array($meta)) {
+            $meta = [];
+        }
 
         // Avatar: prefer Google OAuth photo, then Gravatar (with 404 default so empty is returned if no Gravatar)
         $google_avatar = self::first_user_meta_value($meta, 'zeneyer_google_avatar');
@@ -703,7 +706,7 @@ class Rest_Routes
 
         $value = maybe_unserialize($meta[$key][0]);
 
-        if ($value === '' || $value === null) {
+        if ($value === '' || $value === null || $value === false) {
             return $default;
         }
 

--- a/plugins/zengame/includes/API/class-rest-handler.php
+++ b/plugins/zengame/includes/API/class-rest-handler.php
@@ -84,13 +84,15 @@ final class REST_Handler
                 return new WP_Error('engine_off', 'GamiPress not found', ['status' => 503]);
             }
 
+            $streak = (int) \get_user_meta($user_id, 'zen_login_streak', true);
+
             $data = [
                 'user_id' => $user_id,
                 'stats' => [
                     'totalTracks' => self::$engine->get_user_total_tracks($user_id),
                     'eventsAttended' => self::$engine->get_user_events_attended($user_id),
-                    'streak' => (int) \get_user_meta($user_id, 'zen_login_streak', true),
-                    'streakFire' => ((int) \get_user_meta($user_id, 'zen_login_streak', true)) >= 3,
+                    'streak' => $streak,
+                    'streakFire' => $streak >= 3,
                 ],
                 'points' => self::get_user_points($user_id),
                 'rank' => self::get_user_rank_data($user_id),


### PR DESCRIPTION
### Motivation
- 🎯 Reduzir chamadas repetidas a `get_user_meta()` (padrões N+1 / fan-out) em endpoints REST de alta frequência para diminuir round-trips ao banco e latência agregada.
- 🔍 Aplicar uma mudança de baixo risco que preserva contratos da API e melhora desempenho em cargas concorrentes.

### Description
- Em `plugins/zengame/includes/API/class-rest-handler.php` foi extraída a leitura de `zen_login_streak` para `$streak` e reutilizada em `stats.streak` e `stats.streakFire` para evitar leituras duplicadas do mesmo meta por request. 
- Em `plugins/zeneyer-auth/includes/API/class-rest-routes.php` o `get_profile_data()` agora carrega `get_user_meta($user_id)` uma única vez e substitui várias chamadas `get_user_meta(..., key, true)` por leituras locais em memória usando o novo helper `first_user_meta_value()`. 
- Adicionado `first_user_meta_value(array $meta, string $key, $default = '')` que faz leitura segura do payload bruto de `get_user_meta()`, aplica `maybe_unserialize()` e retorna um fallback quando necessário.
- As alterações são isoladas, não mudam o shape do payload retornado pela API e mantêm compatibilidade com o front-end existente.

### Testing
- Executado `php -l plugins/zengame/includes/API/class-rest-handler.php` e a verificação de sintaxe retornou sem erros. 
- Executado `php -l plugins/zeneyer-auth/includes/API/class-rest-routes.php` e a verificação de sintaxe retornou sem erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11960ae2f8832fa5aec19e3a3bfbeb)