### PR TITLE
Expose richer artist profile in REST API and consume it safely in React with fallbacks

### DIFF
--- a/plugins/zen-seo-lite/includes/class-zen-seo-rest-api.php
+++ b/plugins/zen-seo-lite/includes/class-zen-seo-rest-api.php
@@ -320,6 +320,19 @@ class Zen_SEO_REST_API
     {
         $settings = Zen_SEO_Helpers::get_global_settings();
 
+        $parse_list = static function ($value): array {
+            if (!\is_string($value) || $value === '') {
+                return [];
+            }
+
+            $decoded = \json_decode($value, true);
+            if (\is_array($decoded)) {
+                return $decoded;
+            }
+
+            return [];
+        };
+
         // Map data to match React object structure (src/data/artistData.ts)
         $profile = [
             'identity' => [
@@ -351,12 +364,34 @@ class Zen_SEO_REST_API
             'stats' => [
                 'startingYear'    => (int) ($settings['starting_year'] ?? 2015),
                 'countriesPlayed' => (int) ($settings['countries_played'] ?? 10),
+                'lastUpdated' => \current_time('Y-m-d'),
             ],
             'identifiers' => [
                 'isni'        => $settings['isni_code'] ?? '',
                 'musicbrainz' => $settings['musicbrainz'] ?? '',
                 'wikidata'    => $settings['wikidata'] ?? '',
             ],
+            'site' => [
+                'baseUrl' => \home_url(),
+                'defaultDescription' => $settings['default_description'] ?? '',
+                'media' => [
+                    'epkPdf' => $settings['epk_pdf'] ?? '',
+                    'epkPdfPt' => $settings['epk_pdf_pt'] ?? '',
+                    'epkPdfEn' => $settings['epk_pdf_en'] ?? '',
+                    'epkMdPt' => $settings['epk_md_pt'] ?? '',
+                    'epkMdEn' => $settings['epk_md_en'] ?? '',
+                    'photosUrl' => $settings['photos_url'] ?? '',
+                    'logosZip' => $settings['logos_zip'] ?? '',
+                ],
+            ],
+            'contact' => [
+                'email' => $settings['contact_email'] ?? '',
+                'whatsapp' => [
+                    'number' => $settings['whatsapp_number'] ?? '',
+                ],
+            ],
+            'festivals' => $parse_list($settings['festivals_json'] ?? ''),
+            'mediaClipping' => $parse_list($settings['media_clipping_json'] ?? ''),
             'awards' => !empty($settings['awards_list']) ? \array_filter(\array_map('trim', \explode("\n", (string) ($settings['awards_list'] ?? '')))) : []
         ];
 

--- a/src/contexts/BrandingContext.tsx
+++ b/src/contexts/BrandingContext.tsx
@@ -26,11 +26,37 @@ export const BrandingProvider: React.FC<{ children: ReactNode }> = ({ children }
   // Merge dynamic data with static fallback to ensure no breaks
   const artist = useMemo(() => {
     if (!data) return FALLBACK_ARTIST as unknown as ArtistProfile;
-    
+
+    const fallback = FALLBACK_ARTIST as unknown as Record<string, unknown>;
+    const dynamic = data as unknown as Record<string, unknown>;
+
     return {
-      ...data,
-      // Ensure we have at least the critical site fields from fallback if missing
-      site: (FALLBACK_ARTIST as unknown as { site: unknown }).site,
+      ...fallback,
+      ...dynamic,
+      identity: {
+        ...(fallback.identity as Record<string, unknown>),
+        ...(dynamic.identity as Record<string, unknown>),
+      },
+      site: {
+        ...(fallback.site as Record<string, unknown>),
+        ...(dynamic.site as Record<string, unknown>),
+        media: {
+          ...((fallback.site as { media?: Record<string, unknown> })?.media || {}),
+          ...((dynamic.site as { media?: Record<string, unknown> })?.media || {}),
+        },
+      },
+      stats: {
+        ...(fallback.stats as Record<string, unknown>),
+        ...(dynamic.stats as Record<string, unknown>),
+      },
+      contact: {
+        ...(fallback.contact as Record<string, unknown>),
+        ...(dynamic.contact as Record<string, unknown>),
+        whatsapp: {
+          ...((fallback.contact as { whatsapp?: Record<string, unknown> })?.whatsapp || {}),
+          ...((dynamic.contact as { whatsapp?: Record<string, unknown> })?.whatsapp || {}),
+        },
+      },
     };
   }, [data]);
 

--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -8,6 +8,7 @@ import { useEventsQuery, useEventById } from '../hooks/useQueries';
 import { safeUrl, sanitizeHtml } from '../utils/sanitize';
 import { stripHtml } from '../utils/text';
 import { ARTIST } from '../data/artistData';
+import { useBranding } from '../contexts/BrandingContext';
 import { MapPin, Share2, ArrowLeft, Music, Calendar } from 'lucide-react';
 import AddCalendarMenu from '../components/Events/AddCalendarMenu';
 import { getDateTimeFormatter } from '../utils/date';
@@ -172,7 +173,8 @@ const EventDetailContent = ({ id, lang }: { id: string; lang: string }) => {
 
 const EventListContent = ({ lang }: { lang: string }) => {
   const { t } = useTranslation();
-  const origin = typeof window !== 'undefined' ? window.location.origin : ARTIST.site.baseUrl;
+  const { artist } = useBranding();
+  const origin = typeof window !== 'undefined' ? window.location.origin : artist.site.baseUrl;
   const { data: events = [], isLoading, error } = useEventsQuery({
     mode: 'upcoming',
     days: 365,
@@ -368,7 +370,7 @@ const EventsPage: React.FC = () => {
           <h2 className="text-2xl md:text-3xl font-black mb-4 uppercase tracking-tighter relative z-20">{t('home.press_title')}</h2>
           <div className="flex flex-col sm:flex-row justify-center gap-4 relative z-20">
             <Link to={getLocalizedRoute('booking', lang as Language)} className="btn btn-primary px-10 py-3 min-h-[44px] rounded-xl font-bold uppercase text-sm">{t('contact')}</Link>
-            <a href={safeUrl(ARTIST.site.media.epkPdf, '/')} className="btn btn-outline border-white/10 px-10 py-3 min-h-[44px] rounded-xl font-bold text-sm">{t('events.press_kit', { defaultValue: 'Press Kit' })}</a>
+            <a href={safeUrl(artist.site.media.epkPdf || ARTIST.site.media.epkPdf, '/')} className="btn btn-outline border-white/10 px-10 py-3 min-h-[44px] rounded-xl font-bold text-sm">{t('events.press_kit', { defaultValue: 'Press Kit' })}</a>
           </div>
         </section>
       </div>

--- a/src/pages/PressKitPage.tsx
+++ b/src/pages/PressKitPage.tsx
@@ -26,7 +26,7 @@ import {
   Check
 } from 'lucide-react';
 import { InstagramIcon } from '../components/icons/BrandIcons';
-import { ARTIST, CURRENT_YEAR } from '../data/artistData';
+import { ARTIST } from '../data/artistData';
 
 // ⚡ Bolt: Stable module-scoped empty array to prevent unnecessary re-allocations and preserve reference equality in render loops
 const EMPTY_FESTIVAL_ARRAY: { name: string; country: string; date: string; flag: string }[] = [];
@@ -85,11 +85,11 @@ const PressKitPage: React.FC = () => {
   const isPortuguese = i18n.language?.toLowerCase().startsWith('pt') ?? false;
 
   const pressLinks = useMemo(() => ({
-    photos: ARTIST.site.media.photosUrl,
-    epk: isPortuguese ? ARTIST.site.media.epkPdfPt : ARTIST.site.media.epkPdfEn,
-    epkMd: isPortuguese ? ARTIST.site.media.epkMdPt : ARTIST.site.media.epkMdEn,
-    logos: ARTIST.site.media.logosZip,
-  }), [isPortuguese]);
+    photos: artist.site.media.photosUrl || ARTIST.site.media.photosUrl,
+    epk: (isPortuguese ? artist.site.media.epkPdfPt : artist.site.media.epkPdfEn) || (isPortuguese ? ARTIST.site.media.epkPdfPt : ARTIST.site.media.epkPdfEn),
+    epkMd: (isPortuguese ? artist.site.media.epkMdPt : artist.site.media.epkMdEn) || (isPortuguese ? ARTIST.site.media.epkMdPt : ARTIST.site.media.epkMdEn),
+    logos: artist.site.media.logosZip || ARTIST.site.media.logosZip,
+  }), [artist.site.media, isPortuguese]);
 
   const [isCopied, setIsCopied] = useState(false);
   const handleCopyBio = useCallback(() => {
@@ -128,7 +128,7 @@ const PressKitPage: React.FC = () => {
         color: 'bg-gradient-to-br from-blue-500/80 to-blue-700/80'
       },
       {
-        number: `${CURRENT_YEAR - artist.stats.startingYear}+`,
+        number: `${new Date().getFullYear() - artist.stats.startingYear}+`,
         label: t('presskit.stats.years'),
         icon: <Calendar size={32} />,
         color: 'bg-gradient-to-br from-purple-500/80 to-purple-700/80'
@@ -538,4 +538,3 @@ const PressKitPage: React.FC = () => {
 
 // ⚡ Bolt: Wrapped with React.memo to prevent unnecessary React reconciliation loops when parent layout components (like routers) trigger render cycles.
 export default React.memo(PressKitPage);
-


### PR DESCRIPTION
### Motivation

- Provide a more complete single-source-of-truth (SSOT) for the artist by exposing site, media, contact, festivals and clipping data from the WordPress REST endpoint. 
- Ensure the React app consumes dynamic branding safely while preserving static fallback values to avoid UI breakage when some fields are missing.

### Description

- Expanded `get_artist_profile` in `class-zen-seo-rest-api.php` to include `site`, `contact`, `festivals`, `mediaClipping`, and `stats.lastUpdated`, and added a local `parse_list` helper to safely decode JSON lists.
- Kept previous identity, philosophy, social, payment and identifiers mappings while normalizing `awards` into a trimmed array.
- Updated `BrandingContext` to merge the fetched dynamic profile with the `ARTIST` fallback, performing deep merges for nested structures like `identity`, `site.media`, `stats`, and `contact.whatsapp` so missing remote fields fall back to static defaults.
- Updated `EventsPage` to use `useBranding` for `origin` fallback and to prefer `artist.site.media.epkPdf` while keeping `ARTIST` as backup for press kit links.
- Updated `PressKitPage` to use `useBranding` everywhere, falling back to `ARTIST` media fields when necessary, and replaced `CURRENT_YEAR` with `new Date().getFullYear()` for runtime accuracy.

### Testing

- TypeScript compilation and app build were run via the project build process (`yarn build` / `npm run build`) and completed without type errors or build failures.
- Basic dev server smoke-check was performed by launching the app and navigating to the Events and Press Kit pages, which loaded and displayed fallback and dynamic data as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11967acd14832f89957fcfe19bed0c)