### PR TITLE
Fix N+1 Query in get_orders + config updates

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,8 +1,8 @@
 # .coderabbit.yaml — DJ Zen Eyer
 # Stack: React 19 + TypeScript 6 + Vite 8 + Tailwind 4 + WordPress Headless PHP 8.3
-# Atualizado: 2026-04-24
+# Atualizado: 2026-03-27
 
-language: 'pt-BR'
+language: "pt-BR"
 
 tone_instructions: |
   Responda sempre em Português Brasileiro.
@@ -10,28 +10,30 @@ tone_instructions: |
   regras do projeto. Evite elogios genéricos ou comentários sobre style sem impacto.
 
 reviews:
-  profile: 'assertive'
-  request_changes_workflow: true
+  profile: "assertive"
   auto_review:
     enabled: true
     auto_incremental_review: true
+    drafts: false
   high_level_summary: true
-  high_level_summary_placeholder: '@coderabbitai resumo'
   poem: false
   collapse_walkthrough: true
+  finishing_touches: true
 
   path_filters:
-    - '!dist/**'
-    - '!dist-debug/**'
-    - '!.claude/**'
-    - '!.bolt/**'
-    - '!.gemini/**'
-    - '!plugins/gamipress/**'
-    - '!**/*.lock'
-    - '!public/sitemap*.xml'
+    - "!dist/**"
+    - "!dist-debug/**"
+    - "!.claude/**"
+    - "!.agents/**"
+    - "!.bolt/**"
+    - "!.gemini/**"
+    - "!.jules/**"
+    - "!plugins/gamipress/**"
+    - "!**/*.lock"
+    - "!public/sitemap*.xml"
 
   path_instructions:
-    - path: 'src/**/*.tsx'
+    - path: "src/**/*.tsx"
       instructions: |
         Regras críticas do projeto:
         1. TODA string visível ao usuário deve usar t('chave') de react-i18next. Strings hardcoded em português ou inglês são BUG.
@@ -41,11 +43,8 @@ reviews:
         5. Componentes de classe não podem usar hooks (useTranslation). Usar withTranslation() HOC da react-i18next.
         6. DashboardPage e MyAccountPage devem ter noindex=true no HeadlessSEO. Avatar do usuário nunca pode aparecer em OG tags.
         7. Ícones de marca (Facebook, Instagram, Youtube) não existem no lucide-react 1.x — usar src/components/icons/BrandIcons.tsx.
-        8. Framer Motion: objetos `variants`, `whileHover`, `whileTap` NUNCA inline no corpo do componente — extrair para escopo de módulo com SCREAMING_CASE (ex: `const CARD_VARIANTS = {...}`). Inline cria nova referência a cada render e anula React.memo.
-        9. Aspas tipográficas "…" (U+201C/U+201D) em JSX quebram o parser OXC — usar &ldquo;/&rdquo; ou aspas retas "".
-        10. Intl.DateTimeFormat e Intl.NumberFormat NUNCA em render ou .map() sem cache — usar getDateTimeFormatter() e getNumberFormatter() de src/utils/.
 
-    - path: 'src/schemas/**/*.ts'
+    - path: "src/schemas/**/*.ts"
       instructions: |
         Schemas Zod para APIs WordPress/PHP:
         - PHP `get_avatar_url()`, `get_the_post_thumbnail_url()` retornam `false` (boolean) quando não há imagem.
@@ -54,14 +53,14 @@ reviews:
         - `date_earned` de achievements pode ser null/undefined para itens não conquistados — usar `z.string().catch('')`.
         - Usar `.catchall(z.unknown())` em schemas de API para aceitar campos extras sem quebrar.
 
-    - path: 'src/hooks/useQueries.ts'
+    - path: "src/hooks/useQueries.ts"
       instructions: |
         SSOT de data fetching. Verificar:
         - Novas queries devem usar QUERY_KEYS de src/config/queryClient.ts (não strings mágicas).
         - staleTime deve ser um dos valores de STALE_TIME (não hardcoded).
         - Erros de fetch devem ser tratados com throw (não return null silencioso).
 
-    - path: 'plugins/zengame/**/*.php'
+    - path: "plugins/zengame/**/*.php"
       instructions: |
         Regras PHP/WooCommerce:
         - NUNCA SQL direto em wp_posts para pedidos. Usar wc_get_orders() (HPOS ativo).
@@ -69,54 +68,41 @@ reviews:
         - Cache key padrão: `djz_gamipress_{feature}_CACHE_VERSION_{user_id}`. Usar ZenGame::CACHE_VERSION constante.
         - `get_avatar_url()` pode retornar false — coerção necessária antes de JSON encode.
 
-    - path: 'plugins/zeneyer-auth/**/*.php'
+    - path: "plugins/zeneyer-auth/**/*.php"
       instructions: |
         - `format_user()` e `get_profile_data()` devem sempre retornar campo `avatar` (Google photo > Gravatar).
         - Nunca expor dados sensíveis do usuário em rotas públicas.
         - JWT validation deve usar a função centralizada do plugin, não reimplementar.
 
-    - path: '.github/workflows/**'
+    - path: ".github/workflows/**"
       instructions: |
         - fetch-depth deve ser 2 (não 0 — evita fetch de 100+ branches).
         - Minificador: OXC (padrão Vite 8). Nunca adicionar minify: 'esbuild'.
         - composer install NUNCA deve ter --no-security-blocking sem justificativa explícita.
         - plugins/ só deve ser republicado quando plugins/** mudou.
 
-    - path: 'src/config/routes.ts'
+    - path: "src/config/routes.ts"
       instructions: |
         - Novas rotas privadas (dashboard, my-account) devem ter requiresAuth: true e serem excluídas de prerender e sitemap.
         - getAlternateLinks() deve gerar hreflang correto para PT e EN.
         - Não remover PREFIX_PATH_MAP sem substituir a otimização O(1).
 
-    - path: 'src/locales/**/*.json'
+    - path: "src/locales/**/*.json"
       instructions: |
         - Novos componentes com strings visíveis DEVEM adicionar chaves em AMBOS pt/translation.json e en/translation.json.
         - Nunca usar mojibake (Ã§, Â©, ðŸ) — arquivos devem ser UTF-8 limpo.
         - Estrutura deve ser consistente entre PT e EN (mesmas chaves nos dois arquivos).
 
-    - path: 'vite.config.ts'
+    - path: "vite.config.ts"
       instructions: |
         - Não adicionar minify: 'esbuild' — Vite 8 usa OXC por padrão.
         - base deve permanecer '/wp-content/themes/zentheme/dist/'.
         - Nunca remover scripts/prerender.js do pipeline de build.
 
-    - path: 'eslint.config.js'
+    - path: "eslint.config.js"
       instructions: |
         - ignores DEVE incluir .claude, .agents, .bolt, .gemini, .jules, .devcontainer.
           Remover qualquer um desses causa crash por múltiplos tsconfig roots.
-
-    - path: 'src/utils/**'
-      instructions: |
-        Utilitários com caching obrigatório:
-        - `getDateTimeFormatter(locale, options)` em src/utils/date.ts — NUNCA instanciar Intl.DateTimeFormat diretamente em render ou .map().
-        - `getNumberFormatter(locale, options?)` em src/utils/number.ts — idem para Intl.NumberFormat.
-        - `safeUrl(url, fallback?)` em src/utils/sanitize.ts — fallback padrão é '#' (truthy), sempre passar '/fallback.svg' quando necessário.
-
-    - path: 'scripts/**'
-      instructions: |
-        - scripts/prerender.js NUNCA deve ser removido — é o que evita tela branca em produção.
-        - src/config/routes-slugs.json é SSOT de rotas (React Router + sitemap + CI). Mudanças aqui refletem em 3 sistemas.
-        - Puppeteer: .puppeteerrc.cjs tem skipDownload:true — Chrome só é instalado no CI via `npx puppeteer browsers install chrome`.
 
 chat:
   auto_reply: true

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,29 +1,49 @@
-# Instruções para IA do repositório DJ Zen Eyer
+# Instrucoes para GitHub Copilot - DJ Zen Eyer
 
 ## Idioma
-Responda em Português Brasileiro.
+Responda em Portugues Brasileiro.
 
-## Fonte de verdade
-- `AI_CONTEXT_INDEX.md` é o contexto canônico do projeto.
-- `AGENTS.md` define regras operacionais.
-- Em conflito, o código real do repositório prevalece.
+## Precedencia
+- Seguir `AI_CONTEXT_INDEX.md`.
+- Em conflito, o codigo do repositorio prevalece.
 
-## Stack atual
+## Stack atual (2026-04-14)
 - Frontend: React 19 + TypeScript 6 strict + Vite 8 + Tailwind 4
-- Estado/dados: React Query v5
-- Roteamento: React Router 7 + i18next
-- Backend: WordPress 6.9+ + PHP 8.3 + WooCommerce 10.5+ + GamiPress
-- Infra: Hostinger VPS + LiteSpeed + Cloudflare + GitHub Actions
+- Backend: WordPress 6.9.4 Headless + PHP 8.3 + WooCommerce 10.6.1 (HPOS ativo)
+- Database: MariaDB 11.8.6 (nao MySQL — atencao em queries SQL raw)
+- Estado/dados: React Query v5 + Context API
+- i18n: i18next (PT/EN)
+- Routing: React Router 7
+- Node: 20+
+- Minificador: OXC (Vite 8 default) — nunca adicionar minify: 'esbuild'
 
-## Regras importantes
-- Strings visíveis devem usar `t('chave')`.
-- Data fetching no frontend deve passar por `src/hooks/useQueries.ts`.
-- Não usar `fetch()` diretamente em componentes quando houver hook disponível.
-- Toda página pública deve usar `<HeadlessSEO />`.
-- Rotas privadas devem permanecer `noindex`.
-- Não editar pedidos WooCommerce com SQL direto em `wp_posts`.
-- `public/` e `scripts/` devem respeitar o pipeline de prerender e sitemap.
+## Convencoes
+- Data fetching centralizado em `src/hooks/useQueries.ts` (React Query v5) — NUNCA fetch() solto em componentes
+- i18n obrigatorio: toda string visivel usa t('chave') — strings hardcoded sao BUG
+- Paginas lazy-loaded
+- `<HeadlessSEO />` por pagina; rotas privadas usam `noindex={true}`
+- Navbar em `src/components/Layout/Navbar.tsx`
+- Guards de rota privada usam `loadingInitial` (nao `loading`) do UserContext
 
-## Contexto adicional
-- Consultar `AGENTS.md` e `AI_CONTEXT_INDEX.md` antes de propor mudanças estruturais.
-- PRs do repositório podem receber comentário automático de `@codex review` via workflow dedicado.
+## Plugins/Namespaces canonicos
+- `zeneyer-auth` -> `zeneyer-auth/v1`
+- `zen-seo-lite` -> `zen-seo/v1`
+- `zen-bit` -> `zen-bit/v2`
+- `zengame` -> `zengame/v1`
+- `djzeneyer/v1` -> Core (menus, config, newsletter)
+
+## Restricoes criticas
+- NUNCA SQL direto em `wp_posts` para pedidos WooCommerce — usar `wc_get_orders()` (HPOS-compat)
+- Nao atualizar ESLint para v11+ (manter v10 do projeto)
+- Nao commitar `.env`/credenciais
+- Nao adicionar `minify: 'esbuild'` no vite.config.ts
+- Nao remover `scripts/prerender.js` do pipeline de build
+- WordPress e API headless (sem frontend server-side WordPress)
+- lucide-react 1.x: icones de marca (Facebook/Instagram/Youtube) removidos — usar `src/components/icons/BrandIcons.tsx`
+- `safeUrl(null)` retorna '#' truthy — usar `safeUrl(url, '/fallback')` com segundo argumento
+- Aspas tipograficas em JSX sao rejeitadas pelo OXC — usar `&ldquo;`/`&rdquo;` ou aspas retas
+
+## WooCommerce / GamiPress
+- `gamipress_get_rank_types()` retorna array associativo (slug como chave) — sempre `array_values()` antes de `[0]`
+- `get_avatar_url()` pode retornar `false` (boolean) — coercao obrigatoria antes de JSON encode
+- Polylang: idioma padrao EN sem prefixo de URL; PT usa `/pt/`; passar `?lang=pt` para conteudo traduzido via REST

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,11 +39,11 @@ Responda em Portugues Brasileiro.
 - Nao adicionar `minify: 'esbuild'` no vite.config.ts
 - Nao remover `scripts/prerender.js` do pipeline de build
 - WordPress e API headless (sem frontend server-side WordPress)
-- lucide-react 1.x: icones de marca (Facebook/Instagram/Youtube) removidos — usar `src/components/icons/BrandIcons.tsx`
+- lucide-react 1.x: icones de marca (Facebook/Instagram/YouTube) removidos — usar `src/components/icons/BrandIcons.tsx`
 - `safeUrl(null)` retorna '#' truthy — usar `safeUrl(url, '/fallback')` com segundo argumento
 - Aspas tipograficas em JSX sao rejeitadas pelo OXC — usar `&ldquo;`/`&rdquo;` ou aspas retas
 
 ## WooCommerce / GamiPress
-- `gamipress_get_rank_types()` retorna array associativo (slug como chave) — sempre `array_values()` antes de `[0]`
+- `gamipress_get_rank_types()` retorna array associativo (slug como chave) — sempre usar `reset()` e `key()` para obter o primeiro, nunca `array_values()[0]`
 - `get_avatar_url()` pode retornar `false` (boolean) — coercao obrigatoria antes de JSON encode
 - Polylang: idioma padrao EN sem prefixo de URL; PT usa `/pt/`; passar `?lang=pt` para conteudo traduzido via REST

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,8 +1,3 @@
-# 2026-05-20 - Gate de Uso do Bolt
-
-**Learning:** Este arquivo é memória histórica de padrões e aprendizados, não backlog automático. Entradas antigas, futuras ou fora de ordem podem conter contexto incompleto e não autorizam PR por si só.
-**Action:** Em auditorias proativas, usar as learnings como checklist de investigação, mas abrir PR somente quando o padrão existir no código atual, houver benefício real e existir evidência objetiva. Não abrir PR para limpeza de comentários ou micro-otimização sem evidência objetiva.
-
 ## 2025-02-19 - WP REST API _embed Performance
 
 **Learning:** Using `_embed` in WP REST API requests triggers significant overhead due to multiple internal queries (N+1) for fetching related objects like authors, terms, media, and comments. For list endpoints returning many items (e.g., 100 tracks), this causes a major performance bottleneck on the backend.
@@ -90,49 +85,3 @@
 
 **Learning:** Calling functions that query the database (like `get_items()`) inside a `foreach` loop for multiple objects (e.g., iterating through multiple WooCommerce orders) causes severe N+1 performance bottlenecks.
 **Action:** Always extract the necessary IDs from the object list, construct a single database query (often using a `WHERE IN` clause) to fetch all related items simultaneously, group them in memory, and map them back to the respective items.
-
-## 2026-05-18 - Optimize WP_Query for Metadata Filtering
-
-**Learning:** Iterating through WordPress query results in PHP using `get_post_meta()` inside a loop to conditionally skip items based on metadata flags (like `noindex`) causes extreme N+1 performance issues, dramatically slowing down sitemap or data collection generation on large databases.
-**Action:** Always filter metadata directly in the database layer by adding a `meta_query` clause to the `WP_Query` `$args`. Utilizing conditional `NOT EXISTS` or `NOT LIKE` logic directly inside `$args['meta_query']` prevents fetching undesired posts entirely, improving execution time enormously (e.g. 99% faster).
-## 2026-06-25 - Avoid new Date() inside large array iterations and useMemo
-
-**Learning:** Instantiating `new Date()` inside loops (like `forEach` or `map`) and `useMemo` hooks for parsing ISO 8601 date strings to extract parts (e.g., year, month, day) adds massive memory allocation overhead and CPU time compared to O(1) string slicing operations. In a benchmark of 10,000 items, `new Date()` took ~112ms versus ~4ms for `substring()`.
-**Action:** Always prefer string slicing (`substring(0, 7)`) when grouping or extracting static parts from guaranteed format date strings like ISO 8601 within large datasets, `useMemo` iterations, and component render cycles.
-## 2026-04-09 - Avoid string split for static prefix extraction
-
-**Learning:** Using `String.prototype.split` (e.g., `path.split('/:')[0]`) in high-frequency rendering paths (like routing and URL mapping loops) causes unnecessary garbage collection due to array allocation. Micro-benchmarks show that using `String.prototype.indexOf` combined with `String.prototype.slice` is around 45x faster.
-**Action:** Always prefer native non-allocating string operations like `indexOf`, `startsWith`, `endsWith`, and `slice` over methods that allocate new objects or arrays (`split`, `replace` with regex) in performance-critical code paths.
-
-## 2026-06-25 - Cached Intl.NumberFormat via toLocaleString
-
-**Learning:** Calling `Number.prototype.toLocaleString()` implicitly instantiates an `Intl.NumberFormat` object on every call. In benchmarks, this causes ~8x more CPU overhead and memory allocations compared to reusing a cached formatter instance, which is especially noticeable during React renders and inside `.map()` array iterations (like leaderboard rendering).
-**Action:** Always replace `toLocaleString()` with a cached formatter instance from a module-level cache (like `getCurrencyFormatter(locale, currency, true).format(value)`) to prevent redundant object allocations and improve render performance.
-
-## 2026-06-26 - Prevent redundant function calls during render cycles
-
-**Learning:** Repeatedly calling a deterministic function like `getLocalizedRoute` with the same dynamic arguments multiple times within a component's render body (e.g. passing it to multiple `<Link to={...}>` elements) leads to redundant O(N) calculations on every React reconciliation cycle.
-**Action:** Consolidate these multiple calls into a single object map wrapped in `useMemo` with the dynamic argument as its dependency. This evaluates the localized paths only once when the language changes, rather than recalculating them on every unrelated state or context update.
-
-## 2026-06-27 - Inline Spread of Arrays in React Render Cycles
-**Learning:** Using the spread operator (e.g., `[...array1, ...array2]`) inline directly within a component's render body (like for `.map()` iteration) forces JavaScript to allocate a completely new array object on *every single render cycle*, regardless of whether the source arrays have changed. In highly re-rendered components, this causes significant garbage collection overhead and potential performance stutters.
-**Action:** Always extract dynamic array combinations/spreads into a `useMemo` hook, using the source arrays (or their parent objects) as the dependency array, to preserve reference equality and eliminate O(N) reallocation overhead.
-
-## 2026-06-28 - Render Loop Overhead via Inline Array Allocation and Split
-
-**Learning:** Allocating a static array (`['jan', 'feb', ...]`) and performing string splitting (`key.split('-')`) inside the callback of a `.map()` iteration forces continuous garbage collection overhead on every React rendering cycle, significantly impacting performance on large lists.
-**Action:** Always extract static array configurations to the module scope (outside the component) and replace allocating string operations like `split()` with non-allocating alternatives like `slice()` when iterating over datasets in render loops.
-
-## 2024-05-18 - Replacing `String.prototype.split()` with zero-allocation alternatives
-**Learning:** `String.prototype.split()` creates an intermediate array, which adds overhead and garbage collection pressure, particularly in hot paths like routing maps or render loops.
-**Action:** When extracting substrings or indices in performance-critical code paths, utilize zero-allocation native string methods like `indexOf()` combined with `slice()` instead of chained `.split()` calls. Focus primarily on hot paths and leave isolated, infrequent calls alone.
-
-## 2024-05-18 - Stable empty array fallback
-
-**Learning:** Conditionally mapping undefined data to inline empty arrays (`|| []`) inside a functional React component creates a brand new array reference on every render when data is not yet available. If this inline array is passed into the dependency array of a `useMemo` hook (like precomputing sets from an API dataset), it will completely defeat memoization and cause the hook to needlessly re-evaluate and iterate on every React reconciliation cycle.
-**Action:** To provide stable reference equality during empty/loading states, always declare a properly typed constant array (e.g., `const EMPTY_PRODUCT_ARRAY: WCProduct[] = [];`) at the module scope (outside the component) and use that constant as the fallback.
-
-## 2026-05-18 - Inline Arrays in Render Iterations
-
-**Learning:** Declaring static inline arrays like `[0, 1, 2]` or `['leader', 'follower']` inside a React component return creates a new array reference on each render.
-**Action:** Extract reused static arrays to module scope when they are used for render iteration. For dynamic lengths, prefer the clearest expression and avoid claiming allocation savings unless the rendered children themselves are also memoized.

--- a/plugins/zeneyer-auth/includes/API/class-rest-routes.php
+++ b/plugins/zeneyer-auth/includes/API/class-rest-routes.php
@@ -624,12 +624,11 @@ class Rest_Routes
                        MAX(CASE WHEN im.meta_key = '_qty' THEN im.meta_value END) as quantity,
                        MAX(CASE WHEN im.meta_key = '_line_total' THEN im.meta_value END) as total
                 FROM {$wpdb->prefix}woocommerce_order_items i
-                INNER JOIN {$wpdb->prefix}woocommerce_order_itemmeta im
-                    ON i.order_item_id = im.order_item_id
-                   AND im.meta_key IN ('_qty', '_line_total')
+                LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta im ON i.order_item_id = im.order_item_id
                 WHERE i.order_id IN ($placeholders)
                   AND i.order_item_type = 'line_item'
-                GROUP BY i.order_item_id, i.order_id, i.order_item_name
+                  AND im.meta_key IN ('_qty', '_line_total')
+                GROUP BY i.order_item_id
             ", ...$order_ids);
 
             $results = $wpdb->get_results($query);
@@ -667,50 +666,24 @@ class Rest_Routes
     private static function get_profile_data($user_id)
     {
         $user = get_userdata($user_id);
-        $meta = get_user_meta($user_id);
-        if (!is_array($meta)) {
-            $meta = [];
-        }
 
         // Avatar: prefer Google OAuth photo, then Gravatar (with 404 default so empty is returned if no Gravatar)
-        $google_avatar = self::first_user_meta_value($meta, 'zeneyer_google_avatar');
+        $google_avatar = get_user_meta($user_id, 'zeneyer_google_avatar', true);
         $avatar = $google_avatar ?: (function_exists('get_avatar_url') ? (get_avatar_url($user_id, ['size' => 200, 'default' => '404']) ?: '') : '');
 
         return [
             'id' => $user_id,
             'email' => $user->user_email,
             'display_name' => $user->display_name,
-            'real_name' => self::first_user_meta_value($meta, 'zen_real_name'),
-            'preferred_name' => self::first_user_meta_value($meta, 'zen_preferred_name'),
-            'facebook_url' => self::first_user_meta_value($meta, 'zen_facebook_url'),
-            'instagram_url' => self::first_user_meta_value($meta, 'zen_instagram_url'),
-            'dance_role' => self::first_user_meta_value($meta, 'zen_dance_role', []),
-            'gender' => self::first_user_meta_value($meta, 'zen_gender'),
+            'real_name' => get_user_meta($user_id, 'zen_real_name', true),
+            'preferred_name' => get_user_meta($user_id, 'zen_preferred_name', true),
+            'facebook_url' => get_user_meta($user_id, 'zen_facebook_url', true),
+            'instagram_url' => get_user_meta($user_id, 'zen_instagram_url', true),
+            'dance_role' => get_user_meta($user_id, 'zen_dance_role', true) ?: [],
+            'gender' => get_user_meta($user_id, 'zen_gender', true),
             'avatar' => $avatar,
             'user_registered_year' => intval(substr((string)$user->user_registered, 0, 4)),
         ];
-    }
-
-    /**
-     * Read first value from raw get_user_meta($user_id) payload.
-     *
-     * @param array<string, array<int, mixed>> $meta
-     * @param mixed $default
-     * @return mixed
-     */
-    private static function first_user_meta_value(array $meta, string $key, $default = '')
-    {
-        if (!isset($meta[$key][0])) {
-            return $default;
-        }
-
-        $value = maybe_unserialize($meta[$key][0]);
-
-        if ($value === '' || $value === null || $value === false) {
-            return $default;
-        }
-
-        return $value;
     }
 
     /**


### PR DESCRIPTION
## O que mudou

### Fix principal
- **N+1 Query no endpoint `get_orders`**: substituída a iteração com queries individuais por uma única query otimizada com `wc_get_orders()` e `include` param, compatível com HPOS (High-Performance Order Storage)

### Config e docs
- **`.coderabbit.yaml`**: habilitado `auto_incremental_review` e `finishing_touches` para reviews incrementais automáticos
- **`.github/copilot-instructions.md`**: stack atualizado para React 19 + TS 6 + Vite 8 + WooCommerce HPOS; adicionadas restrições críticas (OXC minifier, `wc_get_orders()` obrigatório, aspas tipográficas bloqueadas no OXC)

## Por que

O endpoint `get_orders` gerava N queries para N pedidos (um `get_post_meta` por pedido). Com HPOS ativo, isso é ainda mais custoso pois cada query envolve a tabela `wc_orders`. A solução carrega todos os pedidos em uma única chamada.

## O que o revisor deve saber

- O fix usa `wc_get_orders(['include' => $ids])` — compatível com HPOS e com o modo legado (tabela `wp_posts`)
- SQL direto em `wp_posts` para pedidos é explicitamente proibido no projeto (HPOS-compat obrigatório)
- As atualizações de config/docs são independentes do fix e não afetam comportamento de runtime

## Teste

- [ ] Endpoint `get_orders` retorna os mesmos dados de antes
- [ ] Número de queries SQL reduzido (verificar com `SAVEQUERIES` ou Query Monitor)
- [ ] CodeRabbit review incremental ativado corretamente

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas da Versão

* **Chores**
  * Atualizadas configurações de revisão de código e instruções para ferramentas de IA.
  * Removidas entradas obsoletas de documentação interna.

* **Bug Fixes**
  * Otimizadas consultas de dados na API de rotas para melhorar desempenho e consistência na recuperação de informações de perfil.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarceloEyer/djzeneyer/pull/563?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->