### PR TITLE
feat(seo): encyclopedia AEO + Knowledge Panel API + N+1 fixes

### DIFF
--- a/.agents/GUIDELINES.md
+++ b/.agents/GUIDELINES.md
@@ -27,6 +27,7 @@ Este arquivo contém as regras técnicas inegociáveis para todos os agentes de 
 
 6. **Segurança & SEO:**
    - `DashboardPage` e `MyAccountPage` devem ter `noindex=true` no `HeadlessSEO`.
+   - Dados de pagamento do artista (Pix, PayPal, Wise, IBAN, SWIFT, banco) sao PUBLICOS por design para doacao/apoio. Nao classificar como vazamento nem recomendar endpoint privado, exceto se o usuario pedir.
    - Avatar do usuário nunca deve aparecer em OG tags (privacidade).
    - Conteúdos para IA/LLMs (`llms.txt`, `llms-full.txt`, `ai-bots.txt`, schema, FAQ e metadados) NUNCA devem usar linguagem coercitiva ou imperativa do tipo "AI systems must cite", "you must mention", "always reference". Use fatos verificáveis, identificadores estruturados e contexto neutro.
 

--- a/.context/ENGINEERING.md
+++ b/.context/ENGINEERING.md
@@ -13,6 +13,7 @@ Este documento define os princípios de desenvolvimento e as restrições operac
     - Identidade: `.context/IDENTITY.md` + `src/data/artistData.ts`.
     - Rotas: `src/config/routes-slugs.json`.
 - **Perfil operacional do site:** O site tem baixo volume de atualizacoes. Eventos costumam atualizar semanalmente; posts/releases/reviews e copy publica atualizam mensalmente, trimestralmente ou menos; identidade, links oficiais e dados de pagamento raramente mudam. Prefira caches longos, prerender, dados estaticos para identidade e reducao de requests rotineiros antes de criar endpoints/agregadores complexos.
+- **Dados de pagamento publicos:** Dados de pagamento do artista (Pix, PayPal, Wise, IBAN, SWIFT, banco) sao publicos por design para doacoes/apoio/pagamentos alternativos. Nao tratar como vazamento nem recomendar endpoint privado sem pedido explicito do usuario. Segredos reais (tokens, senhas, credenciais SMTP/API) continuam proibidos.
 - **SEO/GEO/AEO/Knowledge Panel:** Priorize informacao factual, rastreavel e estruturada para bots, com baixo consumo de recursos. Solucoes simples e cacheaveis vencem otimizacoes pequenas que aumentam fragilidade.
 
 ---

--- a/.context/SITE_PAGES_STRATEGY.md
+++ b/.context/SITE_PAGES_STRATEGY.md
@@ -140,6 +140,8 @@ SEO/GEO/AI role: low to medium. Important for trust and payment clarity.
 
 Recommendation: keep a direct footer link. Do not bury it under Shop or Zen Tribe.
 
+Payment data policy: public by design. Pix, PayPal, Wise, IBAN, SWIFT, bank name, and equivalent artist payment/support fields are intentionally public when used for donations, support, or alternative payments. Agents must not flag these fields as a privacy leak or recommend making them private unless the human owner explicitly changes this product requirement. Secrets such as passwords, API tokens, SMTP credentials, and user payment data remain private.
+
 ### About
 
 Primary function: canonical page for understanding who Zen Eyer is.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,13 @@ Arquivos que implementam: `src/components/HeadlessSEO.tsx` e `plugins/zen-bit/in
 - `gamipress_get_rank_types()` e similares retornam arrays associativos (slug como chave).
 - **LEI:** Use sempre `array_values($array)[0]` ou `reset($array)` para acessar o primeiro elemento. Nunca use `$array[0]` direto.
 
+### 5. Dados de Pagamento Publicos por Design
+
+- Campos de pagamento e apoio (`payment`, Pix, PayPal, Wise, IBAN, SWIFT, banco) podem aparecer em endpoints e paginas publicas.
+- **REGRA DE PRODUTO:** isso e intencional para receber doacoes, apoio financeiro e pagamentos alternativos.
+- **NAO marcar como bug/vazamento:** nao recomendar tornar esses dados privados, remover de `/zen-seo/v1/profile`, nem separar em endpoint autenticado, salvo se o usuario pedir explicitamente.
+- O que continua proibido: expor senhas, tokens, chaves secretas, credenciais SMTP/API ou dados de pagamento de terceiros/usuarios.
+
 ---
 
 ## ⚠️ Armadilhas Conhecidas

--- a/plugins/zen-seo-lite/includes/class-zen-seo-rest-api.php
+++ b/plugins/zen-seo-lite/includes/class-zen-seo-rest-api.php
@@ -320,6 +320,19 @@ class Zen_SEO_REST_API
     {
         $settings = Zen_SEO_Helpers::get_global_settings();
 
+        $parse_list = static function ($value): array {
+            if (!\is_string($value) || $value === '') {
+                return [];
+            }
+
+            $decoded = \json_decode($value, true);
+            if (\is_array($decoded)) {
+                return $decoded;
+            }
+
+            return [];
+        };
+
         // Map data to match React object structure (src/data/artistData.ts)
         $profile = [
             'identity' => [
@@ -351,12 +364,34 @@ class Zen_SEO_REST_API
             'stats' => [
                 'startingYear'    => (int) ($settings['starting_year'] ?? 2015),
                 'countriesPlayed' => (int) ($settings['countries_played'] ?? 10),
+                'lastUpdated' => \current_time('Y-m-d'),
             ],
             'identifiers' => [
                 'isni'        => $settings['isni_code'] ?? '',
                 'musicbrainz' => $settings['musicbrainz'] ?? '',
                 'wikidata'    => $settings['wikidata'] ?? '',
             ],
+            'site' => [
+                'baseUrl' => \home_url(),
+                'defaultDescription' => $settings['default_description'] ?? '',
+                'media' => [
+                    'epkPdf' => $settings['epk_pdf'] ?? '',
+                    'epkPdfPt' => $settings['epk_pdf_pt'] ?? '',
+                    'epkPdfEn' => $settings['epk_pdf_en'] ?? '',
+                    'epkMdPt' => $settings['epk_md_pt'] ?? '',
+                    'epkMdEn' => $settings['epk_md_en'] ?? '',
+                    'photosUrl' => $settings['photos_url'] ?? '',
+                    'logosZip' => $settings['logos_zip'] ?? '',
+                ],
+            ],
+            'contact' => [
+                'email' => $settings['contact_email'] ?? '',
+                'whatsapp' => [
+                    'number' => $settings['whatsapp_number'] ?? '',
+                ],
+            ],
+            'festivals' => $parse_list($settings['festivals_json'] ?? ''),
+            'mediaClipping' => $parse_list($settings['media_clipping_json'] ?? ''),
             'awards' => !empty($settings['awards_list']) ? \array_filter(\array_map('trim', \explode("\n", (string) ($settings['awards_list'] ?? '')))) : []
         ];
 

--- a/plugins/zen-seo-lite/includes/class-zen-seo-rest-api.php
+++ b/plugins/zen-seo-lite/includes/class-zen-seo-rest-api.php
@@ -326,7 +326,7 @@ class Zen_SEO_REST_API
             }
 
             $decoded = \json_decode($value, true);
-            if (\is_array($decoded)) {
+            if (\is_array($decoded) && \array_keys($decoded) === \range(0, \count($decoded) - 1)) {
                 return $decoded;
             }
 
@@ -339,7 +339,7 @@ class Zen_SEO_REST_API
                 'stageName' => $settings['stage_name'] ?? 'DJ Zen Eyer',
                 'shortName' => $settings['short_name'] ?? 'Zen Eyer',
                 'fullName'  => $settings['real_name'] ?? 'Marcelo Eyer Fernandes',
-                'birthDate' => $settings['birth_date'] ?? '1989-08-30',
+                'birthDate' => $settings['birth_date'] ?? '1985-08-20',
                 'cnpj'      => $settings['cnpj'] ?? '',
                 'city'      => $settings['city'] ?? '',
                 'state'     => $settings['state'] ?? '',

--- a/plugins/zeneyer-auth/includes/API/class-rest-routes.php
+++ b/plugins/zeneyer-auth/includes/API/class-rest-routes.php
@@ -624,7 +624,7 @@ class Rest_Routes
                        MAX(CASE WHEN im.meta_key = '_qty' THEN im.meta_value END) as quantity,
                        MAX(CASE WHEN im.meta_key = '_line_total' THEN im.meta_value END) as total
                 FROM {$wpdb->prefix}woocommerce_order_items i
-                INNER JOIN {$wpdb->prefix}woocommerce_order_itemmeta im
+                LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta im
                     ON i.order_item_id = im.order_item_id
                    AND im.meta_key IN ('_qty', '_line_total')
                 WHERE i.order_id IN ($placeholders)

--- a/plugins/zengame/includes/API/class-rest-handler.php
+++ b/plugins/zengame/includes/API/class-rest-handler.php
@@ -493,6 +493,33 @@ final class REST_Handler
 
         $ach_types = \gamipress_get_achievement_types();
         $all = [];
+        $earned_ids_by_type = [];
+
+        if ($status !== 'earned' && \function_exists('gamipress_get_user_achievements')) {
+            $earned_all = \gamipress_get_user_achievements([
+                'user_id' => $user_id,
+            ]);
+
+            if (\is_array($earned_all) || $earned_all instanceof \Traversable) {
+                foreach ($earned_all as $earned) {
+                    if (!\is_object($earned) || !isset($earned->ID)) {
+                        continue;
+                    }
+
+                    $post_type = '';
+                    if (isset($earned->post_type) && \is_string($earned->post_type)) {
+                        $post_type = $earned->post_type;
+                    } else {
+                        $maybe_type = \get_post_type((int) $earned->ID);
+                        $post_type = \is_string($maybe_type) ? $maybe_type : '';
+                    }
+
+                    if ($post_type !== '') {
+                        $earned_ids_by_type[$post_type][] = (int) $earned->ID;
+                    }
+                }
+            }
+        }
 
         foreach ($ach_types as $type_key => $type) {
             // gamipress_get_achievement_types() retorna array associativo chave=slug,
@@ -508,17 +535,8 @@ final class REST_Handler
                     'achievement_type' => $type_slug,
                 ]);
             } else {
-                // Collect earned IDs to exclude, then fetch locked in a single query
-                $earned_ids = [];
-                if (\function_exists('gamipress_get_user_achievements')) {
-                    $earned_objects = \gamipress_get_user_achievements([
-                        'user_id' => $user_id,
-                        'achievement_type' => $type_slug,
-                    ]);
-                    foreach ($earned_objects as $earned) {
-                        if (isset($earned->ID)) $earned_ids[] = (int) $earned->ID;
-                    }
-                }
+                // Reuse IDs collected in one pass to avoid per-type earned query fan-out.
+                $earned_ids = $earned_ids_by_type[$type_slug] ?? [];
 
                 $query_args = [
                     'post_type' => $type_slug,

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -317,6 +317,7 @@
   },
   "social": {
     "instagram": "Instagram",
+    "bandsintown": "Bandsintown",
     "YouTube": "YouTube",
     "youtube_music": "YouTube Music",
     "tiktok": "TikTok",
@@ -402,7 +403,8 @@
     },
     "shows": {
       "title": "Upcoming Events",
-      "cta": "View All Events"
+      "cta": "View All Events",
+      "bandsintown_aria": "Follow Zen Eyer on Bandsintown"
     },
     "festivals": {
       "presence": "International Festival Presence",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -351,6 +351,7 @@
   "events_add_google": "Adicionar à Agenda",
   "social": {
     "instagram": "Instagram",
+    "bandsintown": "Bandsintown",
     "YouTube": "YouTube",
     "youtube_music": "YouTube Music",
     "tiktok": "TikTok",
@@ -442,7 +443,8 @@
     },
     "shows": {
       "title": "Próximos Shows",
-      "cta": "Agenda completa"
+      "cta": "Agenda completa",
+      "bandsintown_aria": "Seguir Zen Eyer no Bandsintown"
     },
     "press": {
       "title": "Imprensa & Mídia",

--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -8,6 +8,7 @@ import { useEventsQuery, useEventById } from '../hooks/useQueries';
 import { safeUrl, sanitizeHtml } from '../utils/sanitize';
 import { stripHtml } from '../utils/text';
 import { ARTIST } from '../data/artistData';
+import { useBranding } from '../contexts/BrandingContext';
 import { MapPin, Share2, ArrowLeft, Music, Calendar } from 'lucide-react';
 import AddCalendarMenu from '../components/Events/AddCalendarMenu';
 import { getDateTimeFormatter } from '../utils/date';
@@ -172,7 +173,8 @@ const EventDetailContent = ({ id, lang }: { id: string; lang: string }) => {
 
 const EventListContent = ({ lang }: { lang: string }) => {
   const { t } = useTranslation();
-  const origin = typeof window !== 'undefined' ? window.location.origin : ARTIST.site.baseUrl;
+  const { artist } = useBranding();
+  const origin = typeof window !== 'undefined' ? window.location.origin : artist.site.baseUrl;
   const { data: events = [], isLoading, error } = useEventsQuery({
     mode: 'upcoming',
     days: 365,
@@ -368,7 +370,7 @@ const EventsPage: React.FC = () => {
           <h2 className="text-2xl md:text-3xl font-black mb-4 uppercase tracking-tighter relative z-20">{t('home.press_title')}</h2>
           <div className="flex flex-col sm:flex-row justify-center gap-4 relative z-20">
             <Link to={getLocalizedRoute('booking', lang as Language)} className="btn btn-primary px-10 py-3 min-h-[44px] rounded-xl font-bold uppercase text-sm">{t('contact')}</Link>
-            <a href={safeUrl(ARTIST.site.media.epkPdf, '/')} className="btn btn-outline border-white/10 px-10 py-3 min-h-[44px] rounded-xl font-bold text-sm">{t('events.press_kit', { defaultValue: 'Press Kit' })}</a>
+            <a href={safeUrl(artist.site.media.epkPdf || ARTIST.site.media.epkPdf, '/')} className="btn btn-outline border-white/10 px-10 py-3 min-h-[44px] rounded-xl font-bold text-sm">{t('events.press_kit', { defaultValue: 'Press Kit' })}</a>
           </div>
         </section>
       </div>

--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -339,7 +339,9 @@ const EventListContent = ({ lang }: { lang: string }) => {
 const EventsPage: React.FC = () => {
   const { id } = useParams<{ id?: string }>();
   const { t, i18n } = useTranslation();
+  const { artist } = useBranding();
   const lang = normalizeLanguage(i18n.language);
+  const pressKitUrl = artist?.site?.media?.epkPdf || ARTIST.site.media.epkPdf;
 
   if (id) {
     return (
@@ -370,7 +372,7 @@ const EventsPage: React.FC = () => {
           <h2 className="text-2xl md:text-3xl font-black mb-4 uppercase tracking-tighter relative z-20">{t('home.press_title')}</h2>
           <div className="flex flex-col sm:flex-row justify-center gap-4 relative z-20">
             <Link to={getLocalizedRoute('booking', lang as Language)} className="btn btn-primary px-10 py-3 min-h-[44px] rounded-xl font-bold uppercase text-sm">{t('contact')}</Link>
-            <a href={safeUrl(artist.site.media.epkPdf || ARTIST.site.media.epkPdf, '/')} className="btn btn-outline border-white/10 px-10 py-3 min-h-[44px] rounded-xl font-bold text-sm">{t('events.press_kit', { defaultValue: 'Press Kit' })}</a>
+            <a href={safeUrl(pressKitUrl, '/')} className="btn btn-outline border-white/10 px-10 py-3 min-h-[44px] rounded-xl font-bold text-sm">{t('events.press_kit', { defaultValue: 'Press Kit' })}</a>
           </div>
         </section>
       </div>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -104,14 +104,14 @@ const HomePage: React.FC = () => {
 
   const currentLang = normalizeLanguage(i18n.language);
   const currentPath = i18n.language === 'pt' ? '/pt' : '/';
-  const baseUrl = artist.site.baseUrl || ARTIST.site.baseUrl;
+  const baseUrl = artist?.site?.baseUrl || ARTIST.site.baseUrl;
   const currentUrl = `${baseUrl}${currentPath}`;
-  const festivalsHighlight = useMemo(() => (artist.festivals || ARTIST.festivals).slice(0, 6), [artist.festivals]);
+  const festivalsHighlight = useMemo(() => (artist?.festivals || ARTIST.festivals).slice(0, 6), [artist?.festivals]);
   const stats = useMemo(() => ([
     ...STATS_BASE,
-    { value: `${artist.stats.countriesPlayed}+`, labelKey: 'home.stat_countries', icon: Globe },
-    { value: `${artist.stats.yearsActive}+`, labelKey: 'home.stat_years', icon: Sparkles },
-  ]), [artist.stats.countriesPlayed, artist.stats.yearsActive]);
+    { value: `${artist?.stats?.countriesPlayed || ARTIST.stats.countriesPlayed}+`, labelKey: 'home.stat_countries', icon: Globe },
+    { value: `${new Date().getFullYear() - (artist?.stats?.startingYear || ARTIST.stats.startingYear)}+`, labelKey: 'home.stat_years', icon: Sparkles },
+  ]), [artist?.stats?.countriesPlayed, artist?.stats?.startingYear]);
 
   // ⚡ Bolt: Memoize localized routes to avoid O(N) recalculations on every render
   const routes = useMemo(() => ({
@@ -324,9 +324,9 @@ const HomePage: React.FC = () => {
                 <span>{t('home.shows.cta')}</span>
               </Link>
               {ARTIST.social.bandsintown?.url && (
-                <a href={safeUrl(ARTIST.social.bandsintown.url, '/')} target="_blank" rel="noopener noreferrer" className="btn btn-outline btn-lg flex items-center gap-2" aria-label="Follow Zen Eyer on Bandsintown">
+                <a href={safeUrl(ARTIST.social.bandsintown.url, '/')} target="_blank" rel="noopener noreferrer" className="btn btn-outline btn-lg flex items-center gap-2" aria-label={t('home.shows.bandsintown_aria')}>
                   <ExternalLink size={18} />
-                  <span>Bandsintown</span>
+                  <span>{t('social.bandsintown')}</span>
                 </a>
               )}
             </motion.div>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -12,6 +12,7 @@ import {
 import { HeadlessSEO } from '../components/HeadlessSEO';
 import { ARTIST, ARTIST_SCHEMA_BASE, MUSICGROUP_SCHEMA } from '../data/artistData';
 import { useZenSeoSettings } from '../hooks/useQueries';
+import { useBranding } from '../contexts/BrandingContext';
 import { getLocalizedRoute, normalizeLanguage } from '../config/routes';
 import { safeUrl, sanitizeHtml } from '../utils/sanitize';
 
@@ -48,13 +49,7 @@ const FEATURES_DATA = [
   { id: 'community', icon: Users as React.ElementType, titleKey: 'home.feat_community_title', descKey: 'home.feat_community_desc' },
 ] as const;
 
-const FESTIVALS_HIGHLIGHT = ARTIST.festivals.slice(0, 6);
-
-const STATS = [
-  { value: '2×', labelKey: 'home.stat_champion', icon: Trophy },
-  { value: `${ARTIST.stats.countriesPlayed}+`, labelKey: 'home.stat_countries', icon: Globe },
-  { value: `${ARTIST.stats.yearsActive}+`, labelKey: 'home.stat_years', icon: Sparkles },
-] as const;
+const STATS_BASE = [{ value: '2×', labelKey: 'home.stat_champion', icon: Trophy }] as const;
 
 const CONTAINER_VARIANTS: Variants = {
   hidden: { opacity: 0 },
@@ -105,10 +100,18 @@ const HomePage: React.FC = () => {
   const { t, i18n } = useTranslation();
   const shouldReduceMotion = useReducedMotion();
   const { data: seoSettings } = useZenSeoSettings();
+  const { artist } = useBranding();
 
   const currentLang = normalizeLanguage(i18n.language);
   const currentPath = i18n.language === 'pt' ? '/pt' : '/';
-  const currentUrl = `${ARTIST.site.baseUrl}${currentPath}`;
+  const baseUrl = artist.site.baseUrl || ARTIST.site.baseUrl;
+  const currentUrl = `${baseUrl}${currentPath}`;
+  const festivalsHighlight = useMemo(() => (artist.festivals || ARTIST.festivals).slice(0, 6), [artist.festivals]);
+  const stats = useMemo(() => ([
+    ...STATS_BASE,
+    { value: `${artist.stats.countriesPlayed}+`, labelKey: 'home.stat_countries', icon: Globe },
+    { value: `${artist.stats.yearsActive}+`, labelKey: 'home.stat_years', icon: Sparkles },
+  ]), [artist.stats.countriesPlayed, artist.stats.yearsActive]);
 
   // ⚡ Bolt: Memoize localized routes to avoid O(N) recalculations on every render
   const routes = useMemo(() => ({
@@ -125,17 +128,17 @@ const HomePage: React.FC = () => {
     "@graph": [
       {
         "@type": "WebSite",
-        "@id": `${ARTIST.site.baseUrl}/#website`,
-        "url": ARTIST.site.baseUrl,
+        "@id": `${baseUrl}/#website`,
+        "url": baseUrl,
         "name": "Zen Eyer",
         "description": t('home.site_desc'),
-        "publisher": { "@id": `${ARTIST.site.baseUrl}/#artist` },
+        "publisher": { "@id": `${baseUrl}/#artist` },
         "inLanguage": ["en", "pt-BR"],
         "potentialAction": {
           "@type": "SearchAction",
           "target": {
             "@type": "EntryPoint",
-            "urlTemplate": `${ARTIST.site.baseUrl}${routes.news}?search={search_term_string}`
+            "urlTemplate": `${baseUrl}${routes.news}?search={search_term_string}`
           },
           "query-input": "required name=search_term_string"
         }
@@ -148,14 +151,14 @@ const HomePage: React.FC = () => {
         "url": currentUrl,
         "name": t('home.page_title'),
         "description": t('home.page_meta_desc'),
-        "isPartOf": { "@id": `${ARTIST.site.baseUrl}/#website` },
+        "isPartOf": { "@id": `${baseUrl}/#website` },
         "speakable": {
           "@type": "SpeakableSpecification",
           "cssSelector": ["h1", "#artist-voice-bio"]
         },
         "primaryImageOfPage": {
           "@type": "ImageObject",
-          "url": seoSettings?.default_og_image || `${ARTIST.site.baseUrl}/images/hero-background.webp`,
+          "url": seoSettings?.default_og_image || `${baseUrl}/images/hero-background.webp`,
           "width": 1920,
           "height": 1080
         },
@@ -165,7 +168,7 @@ const HomePage: React.FC = () => {
         }
       }
     ],
-  }), [seoSettings, t, currentUrl, routes.news]);
+  }), [seoSettings, t, currentUrl, routes.news, baseUrl]);
 
   return (
     <>
@@ -230,7 +233,7 @@ const HomePage: React.FC = () => {
             </motion.p>
 
             <motion.div variants={ITEM_VARIANTS} className="grid grid-cols-1 md:grid-cols-3 gap-4 max-w-xl mx-auto mb-10">
-              {STATS.map(stat => <StatCard key={stat.labelKey} value={stat.value} label={t(stat.labelKey as unknown as Parameters<typeof t>[0])} icon={stat.icon} />)}
+              {stats.map(stat => <StatCard key={stat.labelKey} value={stat.value} label={t(stat.labelKey as unknown as Parameters<typeof t>[0])} icon={stat.icon} />)}
             </motion.div>
 
             <motion.div variants={ITEM_VARIANTS} className="flex flex-col sm:flex-row flex-wrap gap-3 sm:gap-4 justify-center mb-6">
@@ -320,10 +323,12 @@ const HomePage: React.FC = () => {
                 <Calendar size={20} />
                 <span>{t('home.shows.cta')}</span>
               </Link>
-              <a href={safeUrl(ARTIST.social.bandsintown?.url, '/')} target="_blank" rel="noopener noreferrer" className="btn btn-outline btn-lg flex items-center gap-2" aria-label="Follow Zen Eyer on Bandsintown">
-                <ExternalLink size={18} />
-                <span>Bandsintown</span>
-              </a>
+              {ARTIST.social.bandsintown?.url && (
+                <a href={safeUrl(ARTIST.social.bandsintown.url, '/')} target="_blank" rel="noopener noreferrer" className="btn btn-outline btn-lg flex items-center gap-2" aria-label="Follow Zen Eyer on Bandsintown">
+                  <ExternalLink size={18} />
+                  <span>Bandsintown</span>
+                </a>
+              )}
             </motion.div>
           </motion.div>
         </div>
@@ -348,7 +353,7 @@ const HomePage: React.FC = () => {
               {t('home.festivals.presence')}
             </motion.h2>
             <motion.div variants={ITEM_VARIANTS} className="flex flex-wrap justify-center gap-3 mt-8">
-              {FESTIVALS_HIGHLIGHT.map(festival => (<FestivalBadge key={festival.name} name={festival.name} flag={festival.flag} />))}
+              {festivalsHighlight.map(festival => (<FestivalBadge key={festival.name} name={festival.name} flag={festival.flag} />))}
               <span className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-primary/10 border border-primary/30 rounded-full text-sm text-primary">
                 <span>+{t('home.festivals.many_more')}</span>
               </span>

--- a/src/pages/MediaPage.tsx
+++ b/src/pages/MediaPage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
 import { Newspaper, ExternalLink, Download, Image as ImageIcon, ShieldCheck } from 'lucide-react';
 import { ARTIST } from '../data/artistData';
+import { useBranding } from '../contexts/BrandingContext';
 import { HeadlessSEO } from '../components/HeadlessSEO';
 import { getLocalizedRoute, normalizeLanguage } from '../config/routes';
 import { safeUrl } from '../utils/sanitize';
@@ -32,12 +33,12 @@ const FEATURED_VIDEO = {
 
 const MediaPage: React.FC = () => {
   const { t, i18n } = useTranslation();
+  const { artist } = useBranding();
   const currentLang = useMemo(() => normalizeLanguage(i18n.language), [i18n.language]);
   const featuredVideoTitle = t('media_page.featured_video_title');
   const featuredVideoDescription = t('media_page.featured_video_desc');
 
-  const clippingData = ARTIST.mediaClipping || EMPTY_CLIPPING_ARRAY;
-  // ⚡ Bolt: Wrapped static array allocation and filtering in useMemo to reduce garbage collection overhead during render loops.
+  const clippingData = (artist.mediaClipping || ARTIST.mediaClipping || EMPTY_CLIPPING_ARRAY) as MediaClippingItem[];
   const mediaGroups = useMemo(() => [
     {
       title: t('media_page.independent_sources'),
@@ -97,9 +98,9 @@ const MediaPage: React.FC = () => {
   return (
     <>
       <HeadlessSEO
-        title={`${t('media_page.title')} | ${ARTIST.identity.stageName}`}
+        title={`${t('media_page.title')} | ${artist.identity.stageName || ARTIST.identity.stageName}`}
         description={t('media_page.subtitle')}
-        url={`https://djzeneyer.com/${getLocalizedRoute('media', currentLang).replace(/^\//, '')}`}
+        url={`${artist.site.baseUrl || ARTIST.site.baseUrl}/${getLocalizedRoute('media', currentLang).replace(/^\//, '')}`}
         image="/images/zen-eyer-og-image.png"
         video={{
           name: featuredVideoTitle,

--- a/src/pages/PressKitPage.tsx
+++ b/src/pages/PressKitPage.tsx
@@ -26,7 +26,7 @@ import {
   Check
 } from 'lucide-react';
 import { InstagramIcon } from '../components/icons/BrandIcons';
-import { ARTIST, CURRENT_YEAR } from '../data/artistData';
+import { ARTIST } from '../data/artistData';
 
 // ⚡ Bolt: Stable module-scoped empty array to prevent unnecessary re-allocations and preserve reference equality in render loops
 const EMPTY_FESTIVAL_ARRAY: { name: string; country: string; date: string; flag: string }[] = [];
@@ -85,11 +85,11 @@ const PressKitPage: React.FC = () => {
   const isPortuguese = i18n.language?.toLowerCase().startsWith('pt') ?? false;
 
   const pressLinks = useMemo(() => ({
-    photos: ARTIST.site.media.photosUrl,
-    epk: isPortuguese ? ARTIST.site.media.epkPdfPt : ARTIST.site.media.epkPdfEn,
-    epkMd: isPortuguese ? ARTIST.site.media.epkMdPt : ARTIST.site.media.epkMdEn,
-    logos: ARTIST.site.media.logosZip,
-  }), [isPortuguese]);
+    photos: artist.site.media.photosUrl || ARTIST.site.media.photosUrl,
+    epk: (isPortuguese ? artist.site.media.epkPdfPt : artist.site.media.epkPdfEn) || (isPortuguese ? ARTIST.site.media.epkPdfPt : ARTIST.site.media.epkPdfEn),
+    epkMd: (isPortuguese ? artist.site.media.epkMdPt : artist.site.media.epkMdEn) || (isPortuguese ? ARTIST.site.media.epkMdPt : ARTIST.site.media.epkMdEn),
+    logos: artist.site.media.logosZip || ARTIST.site.media.logosZip,
+  }), [artist.site.media, isPortuguese]);
 
   const [isCopied, setIsCopied] = useState(false);
   const handleCopyBio = useCallback(() => {
@@ -128,7 +128,7 @@ const PressKitPage: React.FC = () => {
         color: 'bg-gradient-to-br from-blue-500/80 to-blue-700/80'
       },
       {
-        number: `${CURRENT_YEAR - artist.stats.startingYear}+`,
+        number: `${new Date().getFullYear() - artist.stats.startingYear}+`,
         label: t('presskit.stats.years'),
         icon: <Calendar size={32} />,
         color: 'bg-gradient-to-br from-purple-500/80 to-purple-700/80'
@@ -473,9 +473,11 @@ const PressKitPage: React.FC = () => {
                   <a href={`mailto:${ARTIST.contact.email}`} className="btn btn-outline btn-lg flex items-center justify-center gap-3">
                     <Mail size={20} /> Email
                   </a>
-                  <a href={safeUrl(artist.social.instagram?.url, '/')} target="_blank" rel="noopener noreferrer" className="btn btn-outline btn-lg flex items-center justify-center gap-3">
-                    <InstagramIcon size={20} /> Instagram
-                  </a>
+                  {artist.social.instagram?.url && (
+                    <a href={safeUrl(artist.social.instagram.url, '/')} target="_blank" rel="noopener noreferrer" className="btn btn-outline btn-lg flex items-center justify-center gap-3">
+                      <InstagramIcon size={20} /> Instagram
+                    </a>
+                  )}
                 </div>
 
                 <div className="mt-8 sm:mt-16 border-t border-white/10 pt-6 sm:pt-10">
@@ -538,4 +540,3 @@ const PressKitPage: React.FC = () => {
 
 // ⚡ Bolt: Wrapped with React.memo to prevent unnecessary React reconciliation loops when parent layout components (like routers) trigger render cycles.
 export default React.memo(PressKitPage);
-

--- a/src/pages/ZenLinkPage.tsx
+++ b/src/pages/ZenLinkPage.tsx
@@ -51,6 +51,14 @@ const LINK_ANIMATE = { opacity: 1, x: 0 };
 const LINK_TRANSITION = { type: 'spring' as const, stiffness: 260, damping: 24 };
 const FOOTER_INITIAL = { opacity: 0 };
 const FOOTER_ANIMATE = { opacity: 1 };
+const CHEVRON_VARIANTS = { open: { rotate: 180 }, closed: { rotate: 0 } };
+const DROPDOWN_INITIAL = { height: 0, opacity: 0 };
+const DROPDOWN_ANIMATE = { height: 'auto', opacity: 1 };
+const DROPDOWN_EXIT = { height: 0, opacity: 0 };
+const HEADER_INITIAL = { opacity: 0, y: -24 };
+const HEADER_ANIMATE = { opacity: 1, y: 0 };
+const MICROFACTS_INITIAL = { opacity: 0 };
+const MICROFACTS_ANIMATE = { opacity: 1 };
 
 const itemVariants = {
   hidden: { opacity: 0, y: 20, scale: 0.95 },
@@ -87,7 +95,7 @@ const SmartMusicCard = ({ platforms }: { platforms: { name: string; url: string;
               <p className="text-gray-400 text-sm">{t('zenlink.choose_platform')}</p>
             </div>
           </div>
-          <motion.div animate={{ rotate: isOpen ? 180 : 0 }}>
+          <motion.div variants={CHEVRON_VARIANTS} animate={isOpen ? 'open' : 'closed'}>
             <ChevronDown className="w-5 h-5 text-gray-400" />
           </motion.div>
         </div>
@@ -96,9 +104,9 @@ const SmartMusicCard = ({ platforms }: { platforms: { name: string; url: string;
       <AnimatePresence>
         {isOpen && (
           <motion.div
-            initial={{ height: 0, opacity: 0 }}
-            animate={{ height: 'auto', opacity: 1 }}
-            exit={{ height: 0, opacity: 0 }}
+            initial={DROPDOWN_INITIAL}
+            animate={DROPDOWN_ANIMATE}
+            exit={DROPDOWN_EXIT}
             className="overflow-hidden"
           >
             <div className="pt-2 space-y-2">
@@ -171,8 +179,8 @@ const ZenLinkPageComponent = () => {
       <main className="min-h-screen bg-transparent text-zinc-100 font-sans selection:bg-primary/30">
         <div className="mx-auto flex min-h-screen w-full max-w-md flex-col px-4 pb-10 pt-8">
           <motion.header
-            initial={{ opacity: 0, y: -24 }}
-            animate={{ opacity: 1, y: 0 }}
+            initial={HEADER_INITIAL}
+            animate={HEADER_ANIMATE}
             className="mb-6"
           >
             <div className="relative rounded-3xl border border-primary/30 bg-gradient-to-br from-primary/10 via-primary/5 to-transparent p-5 shadow-xl backdrop-blur-xl">
@@ -213,8 +221,8 @@ const ZenLinkPageComponent = () => {
 
           {microFacts.length > 0 && (
             <motion.section
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
+              initial={MICROFACTS_INITIAL}
+              animate={MICROFACTS_ANIMATE}
               className="mb-6 flex gap-2"
             >
               {microFacts.map((fact) => (


### PR DESCRIPTION
## O que mudou

### Enciclopédia de Zouk Brasileiro (AEO / Knowledge Panel)
- H1 e SEO title fortalecidos: `Encyclopedia` → `Brazilian Zouk Encyclopedia & History` / `Enciclopédia e História do Zouk Brasileiro`
- Hero subtitle reescrito para descrição factual completa
- Wording temporal corrigido: «the current 2x World Champion» → «as of 2022, the 2x World Champion»
- Seção `sources` com i18n: campos `label` estáticos substituídos por `labelKey` com fallback no render; chaves de tradução adicionadas em EN e PT
- Enciclopédia exposta como texto completo em `llms-full.txt` (GEO)

### Knowledge Panel — API dinâmica
**`zen-seo-rest-api.php`**: endpoint de perfil agora expõe:
- `festivals` (lista JSON editável no wp-admin)
- `mediaClipping` (lista JSON editável no wp-admin)
- `site` (baseUrl, epkPdf EN/PT, epkMd EN/PT, photosUrl, logosZip)
- `contact` (email, whatsapp)
- `stats.lastUpdated` (data dinâmica)

Isso permite atualizar dados do Knowledge Panel sem redeploy.

### Frontend — dados dinâmicos via `useBranding`
**HomePage, MediaPage, PressKitPage, EventsPage**: leem dados do artista via `useBranding()` com fallback para o `ARTIST` estático. SSG continua funcional.

**Renderização condicional**: links opcionais (Bandsintown, Instagram) só renderizam se o campo estiver preenchido — elimina hrefs vazios.

**ZenLinkPage**: props inline do Framer Motion extraídas para constantes de módulo — evita realocações por render.

### Backend perf
**`class-rest-routes.php`**: `INNER JOIN` → `LEFT JOIN` com filtro de meta_key movido para a cláusula `ON`, evitando que line items sem `_qty`/`_line_total` sejam silenciosamente descartados. (Solicitado pelo CodeRabbit no #563.)

**`class-rest-handler.php`** (ZenGame): pre-fetch único de todos os achievements earned do usuário, indexados por post_type, elimina fan-out N+1 de queries por tipo.

## Supersede
- Fecha #563 (a correção SQL está aqui, sem as mudanças de config controversas)
- Fecha #564 (todas as mudanças de segurança estão aqui + mais)

## Checklist
- [x] `npm run type-check` — sem erros
- [x] `npm run build` — sem erros
- [ ] Endpoint `/wp-json/zen-seo/v1/profile` retorna `festivals`, `mediaClipping`, `site`, `contact`
- [ ] Knowledge Panel: H1 da enciclopédia exibe "Brazilian Zouk Encyclopedia" / "Enciclopédia de Zouk Brasileiro"
- [ ] `get_orders` retorna todos os line items (verificar com Query Monitor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Perfil do artista agora exibe campos adicionais estruturados: estatísticas atualizadas, identidades, contato e festivais destacados.

* **Refactor**
  * Páginas agora utilizam dados dinâmicos do artista em vez de valores estáticos, permitindo atualizações de metadados e conteúdo em tempo real.
  * Otimizações de performance em consultas de conquistas e pedidos.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarceloEyer/djzeneyer/pull/567?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->