### PR TITLE
fix(security): protect Zen Mailer health endpoint

### DIFF
--- a/plugins/zen-mailer/includes/class-rest-handler.php
+++ b/plugins/zen-mailer/includes/class-rest-handler.php
@@ -2,7 +2,7 @@
 /**
  * Endpoints REST para diagnóstico e teste de envio.
  *
- * GET  /wp-json/zen-mailer/v1/health      → status da configuração (público)
+ * GET  /wp-json/zen-mailer/v1/health      → status da configuração (admin)
  * POST /wp-json/zen-mailer/v1/send-test   → dispara email de teste (admin)
  *
  * @package Zen_Mailer
@@ -24,7 +24,7 @@ class RestHandler {
         register_rest_route( self::NS, '/health', [
             'methods'             => \WP_REST_Server::READABLE,
             'callback'            => [ __CLASS__, 'health' ],
-            'permission_callback' => '__return_true',
+            'permission_callback' => [ __CLASS__, 'is_admin' ],
         ] );
 
         register_rest_route( self::NS, '/send-test', [


### PR DESCRIPTION
## O que muda

- Torna `/wp-json/zen-mailer/v1/health` visível apenas para usuários com `manage_options`.
- Mantém `/send-test` também restrito a admin.

## Por quê

O endpoint de health não precisa ser público e expõe metadados operacionais de SMTP, como host, porta, usuário SMTP, remetente e criptografia. Não expõe senha, mas aumenta superfície de reconhecimento para spammer/atacante.

## Checklist de validação

- [ ] Logado como admin: `/wp-json/zen-mailer/v1/health` retorna health normalmente.
- [ ] Anônimo: endpoint retorna 401/403.
- [ ] Envio de teste continua funcionando para admin.