### PR TITLE
Quiet Vite compression plugin output

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,6 +19,7 @@ export default defineConfig(({ command, mode }) => {
         ext: '.gz',
         threshold: 1024, // Só comprime arquivos > 1KB
         deleteOriginFile: false,
+        verbose: false,
         filter: compressibleAssetPattern,
       }),
       // Brotli compression (melhor taxa para Cloudflare/CDN)
@@ -27,6 +28,7 @@ export default defineConfig(({ command, mode }) => {
         ext: '.br',
         threshold: 1024,
         deleteOriginFile: false,
+        verbose: false,
         filter: compressibleAssetPattern,
       }),
     ].filter(Boolean),


### PR DESCRIPTION
## Summary
- set `verbose: false` for gzip and Brotli compression plugins
- keep generated `.gz` and `.br` assets unchanged while removing noisy absolute-path compression logs from CI

## Verification
- npm run build
- npm run lint

## Notes
The deploy log showed normal rsync paths under `dist/`, so this treats the `dist//home/runner/...` entries as plugin output noise rather than an artifact layout problem.