### PR TITLE
Fix i18n parity check across namespaces

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript-typescript' ]
+        language: ['javascript-typescript']
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript-typescript', 'php' ]
+        language: [ 'javascript-typescript' ]
 
     steps:
     - name: Checkout repository

--- a/scripts/check-i18n-parity.mjs
+++ b/scripts/check-i18n-parity.mjs
@@ -112,11 +112,6 @@ const collectUsedKeys = (code) => {
 const en = loadLocaleResources('en');
 const pt = loadLocaleResources('pt');
 
-const allNamespaces = new Set([
-  ...Object.keys(en),
-  ...Object.keys(pt),
-]);
-
 const files = walk(srcDir);
 const usedKeys = new Map();
 
@@ -133,33 +128,43 @@ for (const file of files) {
   }
 }
 
-const hasKey = (resources, key, namespaces) => {
-  if (key.includes(':')) {
-    const [namespace, ...rest] = key.split(':');
-    return hasPath(resources[namespace], rest.join(':'));
-  }
-
-  const candidateNamespaces = new Set(namespaces);
-
-  for (const namespace of allNamespaces) {
-    if (hasPath(resources[namespace], key)) {
-      candidateNamespaces.add(namespace);
-    }
-  }
-
-  for (const namespace of candidateNamespaces) {
-    if (hasPath(resources[namespace], key)) return true;
-  }
-
-  return false;
-};
-
 const missingInPt = [];
 const missingInEn = [];
+const pushMissing = (target, key) => {
+  if (!target.includes(key)) target.push(key);
+};
 
 for (const [key, namespaces] of [...usedKeys.entries()].sort(([a], [b]) => a.localeCompare(b))) {
-  if (!hasKey(pt, key, namespaces)) missingInPt.push(key);
-  if (!hasKey(en, key, namespaces)) missingInEn.push(key);
+  if (key.includes(':')) {
+    const [namespace, ...rest] = key.split(':');
+    const pathKey = rest.join(':');
+
+    if (!hasPath(pt[namespace], pathKey)) pushMissing(missingInPt, key);
+    if (!hasPath(en[namespace], pathKey)) pushMissing(missingInEn, key);
+    continue;
+  }
+
+  let foundInPt = false;
+  let foundInEn = false;
+
+  for (const namespace of namespaces) {
+    const namespacedKey = `${namespace}:${key}`;
+    const existsInPt = hasPath(pt[namespace], key);
+    const existsInEn = hasPath(en[namespace], key);
+
+    if (existsInPt) foundInPt = true;
+    if (existsInEn) foundInEn = true;
+
+    if (existsInPt && !existsInEn) pushMissing(missingInEn, namespacedKey);
+    if (existsInEn && !existsInPt) pushMissing(missingInPt, namespacedKey);
+  }
+
+  if (!foundInPt && !foundInEn) {
+    const [primaryNamespace = 'translation'] = namespaces;
+    const namespacedKey = `${primaryNamespace}:${key}`;
+    pushMissing(missingInPt, namespacedKey);
+    pushMissing(missingInEn, namespacedKey);
+  }
 }
 
 if (missingInPt.length === 0 && missingInEn.length === 0) {

--- a/scripts/check-i18n-parity.mjs
+++ b/scripts/check-i18n-parity.mjs
@@ -48,6 +48,12 @@ const hasPath = (obj, dottedPath) => {
 
 const loadLocaleResources = (lang) => {
   const langDir = path.join(localesDir, lang);
+
+  if (!fs.existsSync(langDir)) {
+    console.error(`[i18n-check] Locale directory not found for "${lang}": ${langDir}`);
+    process.exit(1);
+  }
+
   const resources = {};
 
   for (const entry of fs.readdirSync(langDir, { withFileTypes: true })) {

--- a/scripts/check-i18n-parity.mjs
+++ b/scripts/check-i18n-parity.mjs
@@ -3,8 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const root = process.cwd();
-const enPath = path.join(root, 'src', 'locales', 'en', 'translation.json');
-const ptPath = path.join(root, 'src', 'locales', 'pt', 'translation.json');
+const localesDir = path.join(root, 'src', 'locales');
 const srcDir = path.join(root, 'src');
 
 const readJson = (filePath) => {
@@ -47,6 +46,48 @@ const hasPath = (obj, dottedPath) => {
   return true;
 };
 
+const loadLocaleResources = (lang) => {
+  const langDir = path.join(localesDir, lang);
+  const resources = {};
+
+  for (const entry of fs.readdirSync(langDir, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith('.json')) continue;
+
+    const namespace = path.basename(entry.name, '.json');
+    resources[namespace] = readJson(path.join(langDir, entry.name));
+  }
+
+  return resources;
+};
+
+const getUsedNamespaces = (code) => {
+  const namespaces = new Set(['translation']);
+  const useTranslationCall = /\buseTranslation\(\s*([^)]+?)?\)/g;
+  let m;
+
+  while ((m = useTranslationCall.exec(code)) !== null) {
+    const arg = (m[1] || '').trim();
+    if (!arg) continue;
+
+    const quoted = arg.match(/^['"]([^'"]+)['"]/);
+    if (quoted?.[1]) {
+      namespaces.add(quoted[1]);
+      continue;
+    }
+
+    const array = arg.match(/^\[\s*([\s\S]*?)\s*\]/);
+    if (!array?.[1]) continue;
+
+    const namespaceLiteral = /['"]([^'"]+)['"]/g;
+    let namespaceMatch;
+    while ((namespaceMatch = namespaceLiteral.exec(array[1])) !== null) {
+      namespaces.add(namespaceMatch[1]);
+    }
+  }
+
+  return namespaces;
+};
+
 const collectUsedKeys = (code) => {
   const keys = new Set();
 
@@ -68,29 +109,61 @@ const collectUsedKeys = (code) => {
   return keys;
 };
 
-const en = readJson(enPath);
-const pt = readJson(ptPath);
+const en = loadLocaleResources('en');
+const pt = loadLocaleResources('pt');
+
+const allNamespaces = new Set([
+  ...Object.keys(en),
+  ...Object.keys(pt),
+]);
 
 const files = walk(srcDir);
-const usedKeys = new Set();
+const usedKeys = new Map();
 
 for (const file of files) {
   const code = fs.readFileSync(file, 'utf8');
+  const namespaces = getUsedNamespaces(code);
+
   for (const key of collectUsedKeys(code)) {
-    usedKeys.add(key);
+    if (!usedKeys.has(key)) usedKeys.set(key, new Set());
+    const keyNamespaces = usedKeys.get(key);
+    for (const namespace of namespaces) {
+      keyNamespaces.add(namespace);
+    }
   }
 }
+
+const hasKey = (resources, key, namespaces) => {
+  if (key.includes(':')) {
+    const [namespace, ...rest] = key.split(':');
+    return hasPath(resources[namespace], rest.join(':'));
+  }
+
+  const candidateNamespaces = new Set(namespaces);
+
+  for (const namespace of allNamespaces) {
+    if (hasPath(resources[namespace], key)) {
+      candidateNamespaces.add(namespace);
+    }
+  }
+
+  for (const namespace of candidateNamespaces) {
+    if (hasPath(resources[namespace], key)) return true;
+  }
+
+  return false;
+};
 
 const missingInPt = [];
 const missingInEn = [];
 
-for (const key of [...usedKeys].sort()) {
-  if (!hasPath(pt, key)) missingInPt.push(key);
-  if (!hasPath(en, key)) missingInEn.push(key);
+for (const [key, namespaces] of [...usedKeys.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+  if (!hasKey(pt, key, namespaces)) missingInPt.push(key);
+  if (!hasKey(en, key, namespaces)) missingInEn.push(key);
 }
 
 if (missingInPt.length === 0 && missingInEn.length === 0) {
-  console.log(`[i18n-check] OK: ${usedKeys.size} used keys are present in EN/PT.`);
+  console.log(`[i18n-check] OK: ${usedKeys.size} used keys are present in EN/PT locale namespaces.`);
   process.exit(0);
 }
 

--- a/scripts/test-contracts.ts
+++ b/scripts/test-contracts.ts
@@ -1,4 +1,3 @@
-import { z } from 'zod';
 import { EventsApiResponseSchema } from '../src/schemas/events.js';
 
 const SITE_URL = process.env.SITE_URL || 'https://djzeneyer.com';

--- a/src/locales/en/quiz.json
+++ b/src/locales/en/quiz.json
@@ -82,6 +82,7 @@
     "ui": {
       "question_count": "Question {{current}} of {{total}}",
       "complete": "{{percent}}% Complete",
+      "you_are": "You are...",
       "share_result": "Share Result",
       "take_again": "Take Again",
       "take_quiz_at": "Take the quiz at:",


### PR DESCRIPTION
## Summary

- Updates the i18n parity checker to load all locale namespace JSON files instead of only translation.json.
- Tracks namespaces declared through useTranslation() so namespaced page copy is validated correctly.
- Removes an unused zod import from the contract test script so lint is clean.

## Validation

- npm run i18n:check
- npm run type-check
- npm run lint
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Novo Conteúdo**
  * Adicionada nova string de interface ao quiz: "Você é..."

* **Chores**
  * Otimizado pipeline de análise de código para focar em JavaScript/TypeScript
  * Melhorado sistema de verificação de consistência de traduções com suporte a múltiplos namespaces
  * Limpeza de dependências não utilizadas

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarceloEyer/djzeneyer/pull/582?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->