### PR TITLE
fix(indexnow): add npm script + use npm run in workflow

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -154,7 +154,7 @@ jobs:
         continue-on-error: true
         run: |
           if [ -n "$INDEXNOW_KEY" ]; then
-            node scripts/submit-indexnow.mjs
+            npm run indexnow
           else
             echo "⚠️  INDEXNOW_KEY not set — skipping IndexNow submission."
           fi

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "format": "prettier --write .",
     "perf:baseline": "node scripts/perf-baseline.mjs",
     "perf:budget": "node scripts/check-performance-budget.mjs",
-    "rollback": "node scripts/rollback.js"
+    "rollback": "node scripts/rollback.js",
+    "indexnow": "node scripts/submit-indexnow.mjs"
   },
   "dependencies": {
     "@marsidev/react-turnstile": "^1.5.2",


### PR DESCRIPTION
## Contexto

O commit `a9211fbb` adicionou IndexNow direto no `main` sem PR, com:

- `scripts/submit-indexnow.mjs` — script de submissão completo com tratamento por código HTTP (200/202/400/403/422/429)
- `INDEXNOW_KEY` no env do workflow e geração do key file via `echo -n`
- Step de submissão ao final do deploy

O script funciona, mas ficaram dois itens faltando.

## O que este PR corrige

- **`package.json`**: adiciona `"indexnow": "node scripts/submit-indexnow.mjs"` — o próprio script já documentava `Called via: npm run indexnow` mas a entrada estava ausente
- **`deploy-frontend.yml`**: step de submissão passa a chamar `npm run indexnow` em vez de `node scripts/submit-indexnow.mjs` diretamente, ficando consistente com os outros scripts do projeto

## O que NÃO muda

O script `scripts/submit-indexnow.mjs` está correto como foi commitado e não é alterado aqui.

## Setup necessário

Adicionar o secret `INDEXNOW_KEY` em **GitHub → Settings → Secrets → Actions** com uma string aleatória de 32 caracteres alfanuméricos (letras, números, hífen — sem espaços ou símbolos). O mesmo valor vira nome e conteúdo do arquivo de verificação em `https://djzeneyer.com/<key>.txt`.

## Test plan

- [ ] `npm run indexnow` resolve sem erro (com `INDEXNOW_KEY` definida localmente)  
- [ ] Após merge + deploy, `GET https://djzeneyer.com/<key>.txt` retorna exatamente a chave (sem newline)  
- [ ] O step "Submit URLs to IndexNow" no workflow retorna 200 ou 202 na primeira run com a secret configurada

🤖 Generated with [Claude Code](https://claude.com/claude-code)