### PR TITLE
[codex] Add Content Signals to robots.txt

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -37,6 +37,7 @@ Este arquivo registra a memória operacional consolidada do projeto, unindo deci
 - **CSP — nunca fazer unset no .htaccess:** `inc/csp.php` gera a CSP dinâmica com nonce por requisição. `mod_headers` roda APÓS o PHP — qualquer `Header unset Content-Security-Policy` ou `Header always unset Content-Security-Policy` no `.htaccess` remove silenciosamente o header que o PHP acabou de criar. O cliente fica sem CSP.
 - **CORS com credentials — apenas domínios exatos:** `Access-Control-Allow-Credentials: true` com regex ampla de subdomínios é risco de segurança. Aceitar apenas `https://(www\.)?djzeneyer\.com` e `https?://localhost:5173`. Adicionar staging/preview somente quando necessário.
 - **Bing `/cdn-cgi/content` audit noise:** Bing Webmaster Tools can report Cloudflare `/cdn-cgi/content?...` URLs as missing meta/title issues. Treat these as crawl-noise unless they appear in sitemap or first-party links; prioritize fixing real 4xx first-party URLs and missing referenced assets.
+- **Content Signals em robots.txt:** Declare preferências de uso por IA com `Content-Signal: ai-train=no, search=yes, ai-input=no` no bloco `User-agent: *` e também no bloco específico de bots de IA para parsers que consideram apenas o grupo mais específico. Isso permite indexação/search, mas reserva direitos contra treino e RAG/grounding generativo.
 
 ## 🎨 Decisões de Marca & SEO
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,7 +4,7 @@
 
 User-agent: *
 Allow: /
-Content-Signal: ai-train=no, search=yes, ai-input=no
+Content-Signal: ai-train=no, search=yes, ai-input=yes
 Allow: /wp-json/djzeneyer/v1/ai-context
 Disallow: /wp-admin/
 Disallow: /wp-login.php
@@ -165,7 +165,7 @@ User-agent: BraveBot
 User-agent: Qwenbot
 User-agent: MistralBot
 Allow: /
-Content-Signal: ai-train=no, search=yes, ai-input=no
+Content-Signal: ai-train=no, search=yes, ai-input=yes
 Allow: /wp-json/djzeneyer/v1/ai-context
 Disallow: /wp-admin/
 Disallow: /wp-login.php

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,9 +1,10 @@
 # DJ ZEN EYER - ROBOTS.TXT
-# Last updated: 2026-05-26
+# Last updated: 2026-05-28
 # Standard: RFC 9309
 
 User-agent: *
 Allow: /
+Content-Signal: ai-train=no, search=yes, ai-input=no
 Allow: /wp-json/djzeneyer/v1/ai-context
 Disallow: /wp-admin/
 Disallow: /wp-login.php
@@ -164,6 +165,7 @@ User-agent: BraveBot
 User-agent: Qwenbot
 User-agent: MistralBot
 Allow: /
+Content-Signal: ai-train=no, search=yes, ai-input=no
 Allow: /wp-json/djzeneyer/v1/ai-context
 Disallow: /wp-admin/
 Disallow: /wp-login.php


### PR DESCRIPTION
﻿## What changed

- Added `Content-Signal: ai-train=no, search=yes, ai-input=no` to `public/robots.txt`.
- Repeated the directive in both the global `User-agent: *` block and the AI crawler block.
- Recorded the Content Signals convention in `LEARNINGS.md`.

## Why

AgentReady reported no Content Signals in `robots.txt`. The new directives declare that search/indexing is allowed while AI training and AI input/grounding usage are not allowed.

## Validation

- Confirmed `public/robots.txt` contains two matching `Content-Signal` directives.
- Confirmed `public/robots.txt` reads as valid UTF-8.
