### PR TITLE
fix(indexnow): preflight key-file check + LiteSpeed cache purge

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -153,8 +153,9 @@ jobs:
           username: ${{ env.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
-            WP_CLI="/usr/local/bin/wp" # or other paths
+            WP_CLI="/usr/local/bin/wp"
             $WP_CLI --path="${{ env.REMOTE_ROOT }}" transient delete --search="djz_vite_manifest" 2>/dev/null || true
+            $WP_CLI --path="${{ env.REMOTE_ROOT }}" litespeed-purge all 2>/dev/null || true
             php -r "opcache_reset();" 2>/dev/null || true
 
       - name: 📡 Submit URLs to IndexNow

--- a/scripts/submit-indexnow.mjs
+++ b/scripts/submit-indexnow.mjs
@@ -21,6 +21,47 @@ if (!KEY) {
   process.exit(0); // soft exit so CI doesn't fail
 }
 
+// ── Key-file readiness check ──────────────────────────────────────────────────
+
+/**
+ * Polls https://<host>/<key>.txt until it responds 200 with the correct key
+ * content, or until MAX_ATTEMPTS is reached.
+ * Needed because LiteSpeed may serve a cached 404 for a few seconds after
+ * a newly-deployed file lands on the server.
+ */
+async function waitForKeyFile(maxAttempts = 6, delayMs = 5000) {
+  const url = `${BASE}/${KEY}.txt`;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const res = await fetch(url, { cache: 'no-store' });
+      if (res.ok) {
+        const body = (await res.text()).trim();
+        if (body === KEY) {
+          console.log(`✅ Key file verified at ${url} (attempt ${attempt})`);
+          return true;
+        }
+        console.warn(`⚠️  Key file content mismatch on attempt ${attempt} — got: "${body.slice(0, 40)}"`);
+      } else {
+        console.warn(`⚠️  Key file not ready (HTTP ${res.status}) — attempt ${attempt}/${maxAttempts}`);
+      }
+    } catch (err) {
+      console.warn(`⚠️  Key file fetch error on attempt ${attempt}: ${err.message}`);
+    }
+    if (attempt < maxAttempts) {
+      console.log(`   Retrying in ${delayMs / 1000}s…`);
+      await new Promise(r => setTimeout(r, delayMs));
+    }
+  }
+  return false;
+}
+
+console.log(`\n🔑 Verifying key file at https://${HOST}/${KEY}.txt…`);
+const keyReady = await waitForKeyFile();
+if (!keyReady) {
+  console.error(`❌ Key file not accessible after all attempts — skipping submission to avoid wasted 403s.`);
+  process.exit(0); // soft exit: don't fail the deploy, but don't submit either
+}
+
 // ── Collect URLs ─────────────────────────────────────────────────────────────
 
 /**

--- a/scripts/submit-indexnow.mjs
+++ b/scripts/submit-indexnow.mjs
@@ -33,7 +33,11 @@ async function waitForKeyFile(maxAttempts = 6, delayMs = 5000) {
   const url = `${BASE}/${KEY}.txt`;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
-      const res = await fetch(url, { cache: 'no-store' });
+      const res = await fetch(url, {
+        cache: 'no-store',
+        signal: AbortSignal.timeout(5000),
+        headers: { 'Cache-Control': 'no-cache' },
+      });
       if (res.ok) {
         const body = (await res.text()).trim();
         if (body === KEY) {


### PR DESCRIPTION
## Problema

O último deploy recebeu **403** da API IndexNow logo após o rsync de `public/`. O arquivo `<key>.txt` estava fisicamente no servidor (confirmado por curl), mas o LiteSpeed ainda servia uma resposta cacheada do estado anterior (path sem arquivo) quando a API tentou verificar a chave — que acontece **imediatamente** ao receber o POST.

Root causes:
- O step de purge limpava WP transients e OPcache, mas **não** o full-page cache do LiteSpeed
- O script não tinha nenhum mecanismo de retry — qualquer falha de verificação descartava o lote inteiro

## Fixes

### `scripts/submit-indexnow.mjs` — `waitForKeyFile()`
Antes de submeter qualquer URL, o script agora faz polling em `https://djzeneyer.com/<key>.txt`:
- Até **6 tentativas** com intervalo de **5 s** entre cada uma (máximo ~30 s de espera)
- Verifica **HTTP 200** e que o **conteúdo do body** seja exatamente a chave (não só que o arquivo existe)
- Se não ficar pronto dentro do limite, encerra com soft exit (não falha o deploy, mas também não submete)

### `deploy-frontend.yml` — purge LiteSpeed
Adiciona `wp litespeed-purge all` no step de cache, garantindo que o LiteSpeed libere o cache completo depois do rsync de `public/` e antes da submissão.

## Resultado esperado no próximo deploy
```
🔑 Verifying key file at https://djzeneyer.com/<key>.txt…
✅ Key file verified at https://djzeneyer.com/<key>.txt (attempt 1)

📡 IndexNow — submitting 71 URLs to api.indexnow.org...
  ✅ Batch 1: 71 URLs received, crawl pending (202 Accepted)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)