### PR TITLE
fix(seo): noindex on hub pages pending content — resolve Soft 404 + duplicate canonical

### DIFF
--- a/src/pages/ArtistCollaborationsPage.tsx
+++ b/src/pages/ArtistCollaborationsPage.tsx
@@ -16,6 +16,7 @@ const ArtistCollaborationsPage: React.FC = () => {
         title={t('hub_pages.artist_collaborations.seo_title')}
         description={t('hub_pages.artist_collaborations.seo_description')}
         url={pageUrl}
+        noindex
       />
       <div className="min-h-screen bg-background px-4 pb-20 pt-24 text-white">
         <div className="container mx-auto max-w-5xl">

--- a/src/pages/ZoukFestivalsPage.tsx
+++ b/src/pages/ZoukFestivalsPage.tsx
@@ -16,6 +16,7 @@ const ZoukFestivalsPage: React.FC = () => {
         title={t('hub_pages.zouk_festivals.seo_title')}
         description={t('hub_pages.zouk_festivals.seo_description')}
         url={pageUrl}
+        noindex
       />
       <div className="min-h-screen bg-background px-4 pb-20 pt-24 text-white">
         <div className="container mx-auto max-w-5xl">

--- a/src/pages/ZoukHistoryPage.tsx
+++ b/src/pages/ZoukHistoryPage.tsx
@@ -16,6 +16,7 @@ const ZoukHistoryPage: React.FC = () => {
         title={t('hub_pages.zouk_history.seo_title')}
         description={t('hub_pages.zouk_history.seo_description')}
         url={pageUrl}
+        noindex
       />
       <div className="min-h-screen bg-background px-4 pb-20 pt-24 text-white">
         <div className="container mx-auto max-w-5xl">

--- a/src/pages/ZoukMusicalityPage.tsx
+++ b/src/pages/ZoukMusicalityPage.tsx
@@ -16,6 +16,7 @@ const ZoukMusicalityPage: React.FC = () => {
         title={t('hub_pages.zouk_musicality.seo_title')}
         description={t('hub_pages.zouk_musicality.seo_description')}
         url={pageUrl}
+        noindex
       />
       <div className="min-h-screen bg-background px-4 pb-20 pt-24 text-white">
         <div className="container mx-auto max-w-5xl">


### PR DESCRIPTION
## Problema

Google Search Console reporta dois problemas nessas 4 páginas:
- **Soft 404** — retornam HTTP 200 mas contêm apenas `t('hub_pages.coming_soon')` = "Content coming soon…"
- **Duplicate without user-selected canonical** — versões EN/PT sem conteúdo real não estabelecem canonical definitivo

### Páginas afetadas
- `/brazilian-zouk-history` (`ZoukHistoryPage`)
- `/zouk-musicality-guide` (`ZoukMusicalityPage`)
- `/zouk-festivals-directory` (`ZoukFestivalsPage`)
- `/artist-collaborations` (`ArtistCollaborationsPage`)

## Fix

Adiciona `noindex` ao `<HeadlessSEO>` de cada página, gerando:
```html
<meta name="robots" content="noindex, nofollow">
```

Isso remove as páginas do índice de forma limpa enquanto o conteúdo não está pronto. Quando conteúdo real for publicado, basta remover o prop `noindex` e solicitar revalidação no Search Console.

**PhilosophyPage foi revisada e excluída** — tem 290+ linhas de conteúdo real com apenas uma seção parcial "coming soon", portanto não é Soft 404.

## Test plan
- [ ] Build sem erros TypeScript: `npm run build:full`
- [ ] `curl -s https://djzeneyer.com/brazilian-zouk-history | grep robots` retorna `noindex, nofollow`
- [ ] Mesmo teste para `/zouk-musicality-guide`, `/zouk-festivals-directory`, `/artist-collaborations`
- [ ] Após deploy: solicitar revalidação no Google Search Console para as 4 URLs

## Próximo passo (amanhã)
Quando o conteúdo real for publicado nessas páginas, remover o prop `noindex` e abrir novo PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)