### PR TITLE
fix(mcp): add GET handler + correct 204 for notifications/initialized

### DIFF
--- a/inc/ai-llm.php
+++ b/inc/ai-llm.php
@@ -25,9 +25,16 @@ class DJZ_AI_Authority
         ]);
 
         register_rest_route('djzeneyer/v1', '/mcp', [
-            'methods' => 'POST',
-            'callback' => [$this, 'handle_mcp_request'],
-            'permission_callback' => '__return_true',
+            [
+                'methods' => 'GET',
+                'callback' => [$this, 'handle_mcp_get'],
+                'permission_callback' => '__return_true',
+            ],
+            [
+                'methods' => 'POST',
+                'callback' => [$this, 'handle_mcp_request'],
+                'permission_callback' => '__return_true',
+            ],
         ]);
 
         register_rest_route('djzeneyer/v1', '/agent-registration', [
@@ -71,6 +78,23 @@ class DJZ_AI_Authority
             'revoked_at' => gmdate('c'),
             'note' => 'Public read tokens are stateless and expire automatically.',
         ]);
+    }
+
+    /**
+     * GET /wp-json/djzeneyer/v1/mcp
+     * Discovery response for clients that probe the endpoint before connecting.
+     */
+    public function handle_mcp_get(): WP_REST_Response
+    {
+        return new WP_REST_Response([
+            'name'     => 'djzeneyer',
+            'version'  => '1.0.0',
+            'protocol' => 'MCP/2025-06-18',
+            'transport' => 'streamable-http',
+            'endpoint' => rest_url('djzeneyer/v1/mcp'),
+            'resources' => count($this->get_mcp_resources()),
+            'tools'    => 0,
+        ], 200);
     }
 
     public function handle_mcp_request($request)
@@ -124,7 +148,8 @@ class DJZ_AI_Authority
                 return $this->mcp_result($id, ['prompts' => []]);
 
             case 'notifications/initialized':
-                return new WP_REST_Response(null, 202);
+                // Notifications are one-way; no response body per MCP spec.
+                return new WP_REST_Response(null, 204);
 
             default:
                 return $this->mcp_error($id, -32601, 'Method not found');


### PR DESCRIPTION
## O que foi descoberto

O servidor MCP **já existe e está completamente implementado** em `inc/ai-llm.php` (classe `DJZ_AI_Authority`). Não é necessário nenhum plugin adicional.

O endpoint `POST /wp-json/djzeneyer/v1/mcp` já suporta:
- `initialize` → retorna `protocolVersion: 2025-06-18` + capabilities
- `resources/list` → lista os 3 recursos (ai-context, llms.txt, llms-full.txt)
- `resources/read` → retorna o conteúdo direto (sem HTTP extra)
- `tools/list` / `prompts/list` → listas vazias
- `ping` → pong

## Fixes aplicados

### 1. GET handler (novo)
Alguns clientes MCP fazem GET no endpoint antes de iniciar sessão. Anteriormente retornava 404 do WordPress. Agora retorna JSON com info básica do servidor.

### 2. `notifications/initialized` → 204 (era 202)
Notificações MCP são unidirecionais — o servidor não deve enviar corpo de resposta. O spec MCP especifica 204 No Content.

## Test plan
- [ ] `curl https://djzeneyer.com/wp-json/djzeneyer/v1/mcp` (GET) retorna 200 com `{"name":"djzeneyer",...}`
- [ ] `curl -X POST https://djzeneyer.com/wp-json/djzeneyer/v1/mcp -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'` retorna `{"jsonrpc":"2.0","id":1,"result":{...}}`
- [ ] `notifications/initialized` retorna 204 sem body

🤖 Generated with [Claude Code](https://claude.com/claude-code)