### PR TITLE
fix(scripts): wrap Phase 4 tag-stripper in do-while — closes last CodeQL alert #69

### DIFF
--- a/scripts/generate-markdown.mjs
+++ b/scripts/generate-markdown.mjs
@@ -189,6 +189,7 @@ function htmlToMarkdown(html) {
 
   // ── Phase 4: Strip remaining block/inline tags ───────────────────────────────
 
+  // Phase 4a: semantic replacements (li → bullet, br/block-elements → newlines)
   content = content
     .replace(/<li[^>]*>([\s\S]*?)<\/li>/gi, (_, text) => {
       const item = normalizeWhitespace(decodeHtml(stripTags(text)));
@@ -196,9 +197,17 @@ function htmlToMarkdown(html) {
     })
     .replace(/<br\s*\/?>/gi, '\n')
     .replace(/<\/(p|div|section|article|main|aside|ul|ol|blockquote)>/gi, '\n')
-    .replace(/<(p|div|section|article|main|aside|ul|ol|blockquote)[^>]*>/gi, '\n')
+    .replace(/<(p|div|section|article|main|aside|ul|ol|blockquote)[^>]*>/gi, '\n');
+
+  // Phase 4b: general tag stripper in a loop-until-stable so that reconstituted
+  // tags (e.g. <<script>script> → <script> after inner removal) are also removed.
+  // CodeQL requires the loop to be explicit and per-pattern to verify fixed-point.
+  let prevTagStrip;
+  do {
+    prevTagStrip = content;
     // Strip remaining inline tags (e.g. <strong>, <em>) without leaving extra spaces
-    .replace(/<(?:[^>"']|"[^"]*"|'[^']*')*>/g, '');
+    content = content.replace(/<(?:[^>"']|"[^"]*"|'[^']*')*>/g, '');
+  } while (content !== prevTagStrip);
 
   // ── Phase 5: Belt-and-suspenders — re-run script/style loops after tag strip ─
   // The general tag stripper in Phase 4 may have exposed new sequences; two


### PR DESCRIPTION
## Summary

- **Closes alert #69** (`js/incomplete-multi-character-sanitization`, lines 192–201): the general-tag-stripper `.replace(/<(?:[^>"']|"[^"]*"|'[^']*')*>/g, '')` was running only once (single `.replace()` call, no loop). A crafted input like `<<script>script>` survives a single pass — the inner `<script>` is removed, reconstituting an outer `<script>`.

- Split Phase 4 into:
  - **4a** — semantic replacements (`<li>`, `<br>`, block elements) — chained as before, no reconstitution risk
  - **4b** — general tag stripper wrapped in an explicit `do-while` loop-until-stable, which gives CodeQL the fixed-point proof it requires

This is the last open CodeQL alert in `scripts/generate-markdown.mjs`. With this PR the file should reach **0 open security alerts**.

## Test plan
- [ ] `npm run generate-markdown` still produces `.md` files correctly from `dist/` HTML
- [ ] CodeQL re-scan on main after merge reports **0 open alerts** in `generate-markdown.mjs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)