### PR TITLE
feat(seo): add Zoukology article as published work

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -72,7 +72,7 @@ Google Knowledge Graph: primary artist KGMID `/g/11ff3mhh10`; related secondary 
 
 ## Published Articles
 
-- [The Art of Staying](https://events.zoukology.com/articles/the-art-of-staying): Original article by Zen Eyer published on Zoukology about presence, connection, and Brazilian Zouk.
+- [The Art of Staying](https://events.zoukology.com/articles/the-art-of-staying): Article by Zen Eyer published on Zoukology (2026-05-27). "sometimes, when nothing impressive seems to be happening — everything is happening."
 
 ## Music & Releases
 
@@ -124,7 +124,7 @@ This site allows visits from AI crawlers, search engines, and language models. T
 For structured JSON data optimized for LLM queries: https://djzeneyer.com/wp-json/djzeneyer/v1/ai-context
 For the full deep-context profile: https://djzeneyer.com/llms-full.txt
 
-Last updated: May 30, 2026
+Last updated: May 29, 2026
 
 ## AI System Notes
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -70,6 +70,10 @@ Zen Eyer specializes in Brazilian Zouk — a partner dance genre originating in 
 
 Google Knowledge Graph: primary artist KGMID `/g/11ff3mhh10`; related secondary business/profile KGMID `/g/11h6s0lfs5`.
 
+## Published Articles
+
+- [The Art of Staying](https://events.zoukology.com/articles/the-art-of-staying): Original article by Zen Eyer published on Zoukology about presence, connection, and Brazilian Zouk.
+
 ## Music & Releases
 
 Zen Eyer releases original tracks, remixes, and edits for Brazilian Zouk dancing. His music is available on all major streaming platforms.
@@ -120,7 +124,7 @@ This site allows visits from AI crawlers, search engines, and language models. T
 For structured JSON data optimized for LLM queries: https://djzeneyer.com/wp-json/djzeneyer/v1/ai-context
 For the full deep-context profile: https://djzeneyer.com/llms-full.txt
 
-Last updated: May 29, 2026
+Last updated: May 30, 2026
 
 ## AI System Notes
 

--- a/src/data/publishedWorks.ts
+++ b/src/data/publishedWorks.ts
@@ -12,11 +12,11 @@ export const PUBLISHED_WORKS: PublishedWork[] = [
   {
     title: 'The Art of Staying',
     description:
-      'Original article by Zen Eyer published on Zoukology, reflecting on presence, connection, and Brazilian Zouk.',
+      'sometimes, when nothing impressive seems to be happening — everything is happening.',
     url: 'https://events.zoukology.com/articles/the-art-of-staying',
     source: 'Zoukology',
     publisherUrl: 'https://events.zoukology.com',
-    date: '2026',
+    date: '2026-05-27',
     type: 'Article',
   },
 ];

--- a/src/data/publishedWorks.ts
+++ b/src/data/publishedWorks.ts
@@ -1,0 +1,22 @@
+export type PublishedWork = {
+  type: 'Article' | 'Essay';
+  title: string;
+  description: string;
+  source: string;
+  url: string;
+  date: string;
+  publisherUrl: string;
+};
+
+export const PUBLISHED_WORKS: PublishedWork[] = [
+  {
+    title: 'The Art of Staying',
+    description:
+      'Original article by Zen Eyer published on Zoukology, reflecting on presence, connection, and Brazilian Zouk.',
+    url: 'https://events.zoukology.com/articles/the-art-of-staying',
+    source: 'Zoukology',
+    publisherUrl: 'https://events.zoukology.com',
+    date: '2026',
+    type: 'Article',
+  },
+];

--- a/src/data/publishedWorks.ts
+++ b/src/data/publishedWorks.ts
@@ -1,5 +1,6 @@
 export type PublishedWork = {
   type: 'Article' | 'Essay';
+  translationKey: string;
   title: string;
   description: string;
   source: string;
@@ -10,6 +11,7 @@ export type PublishedWork = {
 
 export const PUBLISHED_WORKS: PublishedWork[] = [
   {
+    translationKey: 'art_of_staying',
     title: 'The Art of Staying',
     description:
       'sometimes, when nothing impressive seems to be happening — everything is happening.',

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1146,6 +1146,12 @@
       "h1": "Artist Collaborations"
     }
   },
+  "published_works": {
+    "art_of_staying": {
+      "title": "The Art of Staying",
+      "description": "sometimes, when nothing impressive seems to be happening — everything is happening."
+    }
+  },
   "og": {
     "image_alt": {
       "default": "Zen Eyer performing a Brazilian Zouk DJ set",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -1150,6 +1150,12 @@
       "h1": "Colaborações com Artistas"
     }
   },
+  "published_works": {
+    "art_of_staying": {
+      "title": "The Art of Staying",
+      "description": "às vezes, quando nada impressionante parece estar acontecendo — tudo está acontecendo."
+    }
+  },
   "og": {
     "image_alt": {
       "default": "Zen Eyer numa performance de DJ de Zouk Brasileiro",

--- a/src/pages/MediaPage.tsx
+++ b/src/pages/MediaPage.tsx
@@ -112,6 +112,8 @@ const MediaPage: React.FC = () => {
         headline: work.title,
         name: work.title,
         url: work.url,
+        datePublished: work.date,
+        dateModified: work.date,
         description: work.description,
         author: {
           '@type': 'Person',

--- a/src/pages/MediaPage.tsx
+++ b/src/pages/MediaPage.tsx
@@ -2,7 +2,8 @@ import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
 import { Newspaper, ExternalLink, Download, Image as ImageIcon, ShieldCheck } from 'lucide-react';
-import { ARTIST } from '../data/artistData';
+import { ARTIST, ARTIST_SCHEMA_BASE, MUSICGROUP_SCHEMA } from '../data/artistData';
+import { PUBLISHED_WORKS } from '../data/publishedWorks';
 import { useBranding } from '../contexts/BrandingContext';
 import { HeadlessSEO } from '../components/HeadlessSEO';
 import { getLocalizedRoute, normalizeLanguage } from '../config/routes';
@@ -37,12 +38,21 @@ const MediaPage: React.FC = () => {
   const currentLang = useMemo(() => normalizeLanguage(i18n.language), [i18n.language]);
   const featuredVideoTitle = t('media_page.featured_video_title');
   const featuredVideoDescription = t('media_page.featured_video_desc');
+  const currentPath = getLocalizedRoute('media', currentLang);
+  const currentUrl = `${artist.site.baseUrl || ARTIST.site.baseUrl}/${currentPath.replace(/^\//, '')}`;
 
-  const clippingData = (artist.mediaClipping || ARTIST.mediaClipping || EMPTY_CLIPPING_ARRAY) as MediaClippingItem[];
+  const clippingData = useMemo(
+    () => [
+      ...PUBLISHED_WORKS,
+      ...((artist.mediaClipping || ARTIST.mediaClipping || EMPTY_CLIPPING_ARRAY) as MediaClippingItem[]),
+    ],
+    [artist.mediaClipping]
+  );
+
   const mediaGroups = useMemo(() => [
     {
       title: t('media_page.independent_sources'),
-      items: clippingData.filter((item) => ['Media', 'Report'].includes(item.type)),
+      items: clippingData.filter((item) => ['Article', 'Essay', 'Media', 'Report'].includes(item.type)),
     },
     {
       title: t('media_page.festival_lineups'),
@@ -61,6 +71,61 @@ const MediaPage: React.FC = () => {
       items: clippingData.filter((item) => ['Press Release'].includes(item.type)),
     },
   ].filter((group) => group.items.length > 0), [clippingData, t]);
+
+  const mediaPageSchema = useMemo(() => ({
+    '@context': 'https://schema.org',
+    '@graph': [
+      ARTIST_SCHEMA_BASE,
+      MUSICGROUP_SCHEMA,
+      {
+        '@type': 'CollectionPage',
+        '@id': `${currentUrl}#webpage`,
+        url: currentUrl,
+        name: `${t('media_page.title')} | ${artist.identity.stageName || ARTIST.identity.stageName}`,
+        description: t('media_page.subtitle'),
+        isPartOf: { '@id': `${ARTIST.site.baseUrl}/#website` },
+        about: { '@id': `${ARTIST.site.baseUrl}/#artist` },
+        mainEntity: {
+          '@type': 'ItemList',
+          itemListElement: PUBLISHED_WORKS.map((work, index) => ({
+            '@type': 'ListItem',
+            position: index + 1,
+            item: { '@id': `${work.url}#article` },
+          })),
+        },
+        inLanguage: currentLang === 'pt' ? 'pt-BR' : 'en',
+      },
+      ...PUBLISHED_WORKS.map((work) => ({
+        '@type': work.type,
+        '@id': `${work.url}#article`,
+        headline: work.title,
+        name: work.title,
+        url: work.url,
+        description: work.description,
+        author: {
+          '@type': 'Person',
+          '@id': `${ARTIST.site.baseUrl}/#artist`,
+          name: ARTIST.identity.stageName,
+          url: `${ARTIST.site.baseUrl}${ARTIST.site.pages.about}`,
+        },
+        publisher: {
+          '@type': 'Organization',
+          name: work.source,
+          url: work.publisherUrl,
+        },
+        about: [
+          {
+            '@type': 'Thing',
+            name: 'Brazilian Zouk',
+          },
+          {
+            '@id': `${ARTIST.site.baseUrl}/#musicgroup`,
+          },
+        ],
+        mainEntityOfPage: work.url,
+      })),
+    ],
+  }), [artist.identity.stageName, currentLang, currentUrl, t]);
 
   // ⚡ Bolt: Wrapped static array allocation in useMemo to reduce garbage collection overhead during render loops.
   // ⚡ Bolt: Extracted static media facts array from inline render loop map
@@ -100,9 +165,10 @@ const MediaPage: React.FC = () => {
       <HeadlessSEO
         title={`${t('media_page.title')} | ${artist.identity.stageName || ARTIST.identity.stageName}`}
         description={t('media_page.subtitle')}
-        url={`${artist.site.baseUrl || ARTIST.site.baseUrl}/${getLocalizedRoute('media', currentLang).replace(/^\//, '')}`}
+        url={currentUrl}
         image="/images/og/zen-eyer-press-og.jpg"
         imageAlt={t('og.image_alt.press')}
+        schema={mediaPageSchema}
         video={{
           name: featuredVideoTitle,
           description: featuredVideoDescription,

--- a/src/pages/MediaPage.tsx
+++ b/src/pages/MediaPage.tsx
@@ -43,10 +43,14 @@ const MediaPage: React.FC = () => {
 
   const clippingData = useMemo(
     () => [
-      ...PUBLISHED_WORKS,
+      ...PUBLISHED_WORKS.map((work) => ({
+        ...work,
+        title: t(`published_works.${work.translationKey}.title`),
+        description: t(`published_works.${work.translationKey}.description`),
+      })),
       ...((artist.mediaClipping || ARTIST.mediaClipping || EMPTY_CLIPPING_ARRAY) as MediaClippingItem[]),
     ],
-    [artist.mediaClipping]
+    [artist.mediaClipping, t]
   );
 
   const mediaGroups = useMemo(() => [

--- a/src/pages/MediaPage.tsx
+++ b/src/pages/MediaPage.tsx
@@ -95,6 +95,17 @@ const MediaPage: React.FC = () => {
         },
         inLanguage: currentLang === 'pt' ? 'pt-BR' : 'en',
       },
+      {
+        '@type': 'VideoObject',
+        '@id': `${currentUrl}#featured-video`,
+        name: featuredVideoTitle,
+        description: featuredVideoDescription,
+        thumbnailUrl: FEATURED_VIDEO.thumbnailUrl,
+        uploadDate: FEATURED_VIDEO.uploadDate,
+        embedUrl: FEATURED_VIDEO.embedUrl,
+        contentUrl: FEATURED_VIDEO.contentUrl,
+        duration: FEATURED_VIDEO.duration,
+      },
       ...PUBLISHED_WORKS.map((work) => ({
         '@type': work.type,
         '@id': `${work.url}#article`,
@@ -125,7 +136,7 @@ const MediaPage: React.FC = () => {
         mainEntityOfPage: work.url,
       })),
     ],
-  }), [artist.identity.stageName, currentLang, currentUrl, t]);
+  }), [artist.identity.stageName, currentLang, currentUrl, featuredVideoDescription, featuredVideoTitle, t]);
 
   // ⚡ Bolt: Wrapped static array allocation in useMemo to reduce garbage collection overhead during render loops.
   // ⚡ Bolt: Extracted static media facts array from inline render loop map
@@ -169,15 +180,6 @@ const MediaPage: React.FC = () => {
         image="/images/og/zen-eyer-press-og.jpg"
         imageAlt={t('og.image_alt.press')}
         schema={mediaPageSchema}
-        video={{
-          name: featuredVideoTitle,
-          description: featuredVideoDescription,
-          thumbnailUrl: FEATURED_VIDEO.thumbnailUrl,
-          uploadDate: FEATURED_VIDEO.uploadDate,
-          embedUrl: FEATURED_VIDEO.embedUrl,
-          contentUrl: FEATURED_VIDEO.contentUrl,
-          duration: FEATURED_VIDEO.duration,
-        }}
       />
 
       <div className="min-h-screen pt-24 sm:pt-40 pb-16 sm:pb-24 bg-background relative overflow-hidden">


### PR DESCRIPTION
## Summary

- Adds `src/data/publishedWorks.ts` as a small SSOT for external authored publications.
- Surfaces the Zoukology article "The Art of Staying" on the existing Media/Press page through the clipping list.
- Adds page-level JSON-LD for the media page using `CollectionPage` + `Article` nodes, linking the article to Zen Eyer as author without adding it to `sameAs`.
- Updates `public/llms.txt` with a neutral Published Articles section for AI/search extraction.

## Why

The article is an authored external publication, not an identity/profile URL. It should strengthen the entity relation:

`Zen Eyer -> author of -> The Art of Staying -> published by -> Zoukology`

without treating the article as a `sameAs` profile.

## Agent-guideline alignment

- Follows `.agents/GUIDELINES.md`: no visible hardcoded UI strings were added; existing i18n labels are reused on the page.
- Keeps the change in project data/page structure instead of creating a new route.
- Does not touch `ARTIST_SCHEMA_SAME_AS`.
- Does not add this to Verified Facts or Press Kit to avoid overclaiming.
- Uses neutral factual LLM text, avoiding imperative/coercive language.

## Human/context alignment

This also matches the owner-facing authority plan in `.human/ZOUK_AUTHORITY_HUMAN_ACTIONS.md`, which says that after an external Zoukology publication is live, the final link should be added to Media/Clipping. This file was used only as product/context guidance; implementation decisions stay anchored in the agent guidelines and the project code structure.

## Implementation notes

- `src/data/publishedWorks.ts` is intentionally separate from `ARTIST_SCHEMA_SAME_AS` to keep identity-profile links and authored works semantically distinct.
- The Media page now includes the published work in the existing clipping card UI, so the structured data represents visible page content.
- The JSON-LD expresses the authored-work relation with `Article`, `author`, `publisher`, and `about`, instead of equivalence.
- `llms.txt` gets a concise, factual Published Articles section for LLM extraction.

## Possible follow-up: global SEO extension

A future PR could add a generic `additionalSchemaGraph` prop to `HeadlessSEO`, allowing pages to append extra schema nodes without replacing the default `Person`, `MusicGroup`, `WebSite`, and media schemas. I did not include that here to keep this PR smaller and lower risk, but it may be a good architectural improvement for future authored articles, podcasts, interviews, festival profiles, and external references.

## Validation

- Not run locally in this environment.
- Change is limited to one data file, one page, and `llms.txt`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Novos Recursos**
  * Seção de artigos publicados agora disponível, apresentando "The Art of Staying" publicado no Zoukology (27 de maio de 2026).
  * Otimizações de SEO estruturado implementadas para melhor descoberta de conteúdo.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarceloEyer/djzeneyer/pull/608?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->