### PR TITLE
feat: add Zoukology article "The Art of Staying" to media clipping

### DIFF
--- a/src/data/artistData.ts
+++ b/src/data/artistData.ts
@@ -280,6 +280,14 @@ export const ARTIST = {
       source: 'PR.com',
       date: '2025-11-24',
       type: 'Press Release'
+    },
+    {
+      title: 'The Art of Staying',
+      description: 'sometimes, when nothing impressive seems to be happening — everything is happening.',
+      url: 'https://events.zoukology.com/articles/the-art-of-staying',
+      source: 'Zoukology',
+      date: '2026-05-27',
+      type: 'Article'
     }
   ],
 


### PR DESCRIPTION
Closing in favor of #608, which has the complete implementation: separate SSOT for published works, JSON-LD Article schema with `Person` author attribution, and `llms.txt` update for AI crawlers.

All issues flagged by reviewers (date precision, description text, `datePublished` in JSON-LD) have been fixed in #608.