### PR TITLE
Implement ZoukFestivalsPage with real festival data

### DIFF
--- a/.context/OPERATIONS.md
+++ b/.context/OPERATIONS.md
@@ -68,6 +68,19 @@ gh pr view <number> --json body,comments,reviews,reviewThreads,reviewRequests,me
 - Conteúdo útil para todos os agentes deve ser promovido para `AGENTS.md`, `.agents/GUIDELINES.md`, `.context/OPERATIONS.md` ou `LEARNINGS.md`, conforme a natureza da regra.
 - Arquivos de persona podem resumir e direcionar uso local, mas não devem redefinir hierarquia, stack ou regras globais em conflito com `AI_CONTEXT_INDEX.md`.
 
+## Separação Frontend / Backend
+
+**Backend**: WordPress + WooCommerce em `https://djzeneyer.com/wp-json/` (REST API). Dados dinâmicos (pedidos, membros, WooCommerce, GamiPress) vivem aqui. Nunca mockar dados de backend no frontend — usar os hooks de `src/hooks/useQueries.ts`.
+
+**Frontend**: React SPA (Vite). `src/data/artistData.ts` é dados **estáticos do frontend** — SSOT para identidade do artista, festivais, discografia, links sociais. Esses dados não vêm do WordPress e são mantidos diretamente no TypeScript.
+
+### Regras para `ARTIST.festivals[]`
+
+- `upcoming` é campo **opcional** e pode ficar stale. **Não é fonte de verdade** para categorização.
+- Categorização correta deriva de comparação de `f.date` com a data atual em runtime: `new Date(f.date) >= today`.
+- Ordenação correta: **upcoming → crescente** (mais próximo primeiro); **past → decrescente** (mais recente primeiro).
+- Ao adicionar evento passado: atualizar `date`, omitir `upcoming` ou setar `upcoming: false`. `ZoukFestivalsPage` categoriza automaticamente pela data.
+
 ## Fonte de Verdade
 
 - Este arquivo não substitui o código real, `AI_CONTEXT_INDEX.md`, `.agents/GUIDELINES.md`, `.context/IDENTITY.md` ou `LEARNINGS.md`.

--- a/src/data/artistData.ts
+++ b/src/data/artistData.ts
@@ -124,7 +124,7 @@ export const ARTIST = {
       country: 'Poland',
       flag: '🇵🇱',
       url: 'https://www.facebook.com/zoukatowice/',
-      date: '2024-11-20',
+      date: '2026-03-20',
     },
     {
       name: 'IZC Brazil',
@@ -132,14 +132,6 @@ export const ARTIST = {
       flag: '🇧🇷',
       url: 'https://www.instagram.com/izcbrazil/',
       date: '2024-01-20',
-    },
-    {
-      name: 'Polish Zouk Festival - Katowice',
-      country: 'Poland',
-      flag: '🇵🇱',
-      url: 'https://www.polishzoukfestival.pl/',
-      upcoming: true,
-      date: '2025-11-20',
     },
   ] as Festival[],
 

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1136,7 +1136,8 @@
       "seo_title": "Global Brazilian Zouk Festivals Directory | DJ Zen Eyer",
       "seo_description": "Discover the best Brazilian Zouk festivals and congresses around the world.",
       "breadcrumb": "Festivals",
-      "h1": "Global Zouk Festivals"
+      "h1": "Global Zouk Festivals",
+      "past_editions": "Past Editions"
     },
     "artist_collaborations": {
       "seo_title": "Artist Collaborations & Interviews | DJ Zen Eyer",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -1140,7 +1140,8 @@
       "seo_title": "Diretório de Festivais de Zouk Brasileiro | DJ Zen Eyer",
       "seo_description": "Descubra os melhores festivais e congressos de Zouk Brasileiro ao redor do mundo.",
       "breadcrumb": "Festivais",
-      "h1": "Festivais Globais de Zouk"
+      "h1": "Festivais Globais de Zouk",
+      "past_editions": "Edições Anteriores"
     },
     "artist_collaborations": {
       "seo_title": "Colaborações e Entrevistas com Artistas | DJ Zen Eyer",

--- a/src/pages/ZoukFestivalsPage.tsx
+++ b/src/pages/ZoukFestivalsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { motion, useReducedMotion } from 'framer-motion';
 import { ExternalLink, Globe, MapPin } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -53,26 +53,33 @@ const ZoukFestivalsPage: React.FC = () => {
   const pageUrl = `${ARTIST.site.baseUrl}${getLocalizedRoute('zouk-festivals', currentLang)}`;
 
   const { upcoming, past } = useMemo(() => {
-    const sorted = [...ARTIST.festivals].sort((a, b) => {
-      if (!a.date && !b.date) return 0;
-      if (!a.date) return 1;
-      if (!b.date) return -1;
-      return new Date(b.date).getTime() - new Date(a.date).getTime();
-    });
-    return {
-      upcoming: sorted.filter((f) => f.upcoming),
-      past: sorted.filter((f) => !f.upcoming),
-    };
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    const upcomingFestivals = [...ARTIST.festivals]
+      .filter((f) => f.date && new Date(f.date) >= today)
+      .sort((a, b) => new Date(a.date!).getTime() - new Date(b.date!).getTime());
+
+    const pastFestivals = [...ARTIST.festivals]
+      .filter((f) => !f.date || new Date(f.date) < today)
+      .sort((a, b) => {
+        if (!a.date && !b.date) return 0;
+        if (!a.date) return 1;
+        if (!b.date) return -1;
+        return new Date(b.date).getTime() - new Date(a.date).getTime();
+      });
+
+    return { upcoming: upcomingFestivals, past: pastFestivals };
   }, []);
 
-  const formatYear = (date: string | undefined): string => {
+  const formatYear = useCallback((date: string | undefined): string => {
     if (!date) return '';
     try {
       return getDateTimeFormatter(i18n.language, { year: 'numeric' }).format(new Date(date));
     } catch {
       return '';
     }
-  };
+  }, [i18n.language]);
 
   const opensInNewTab = t('common.opens_in_new_tab');
 

--- a/src/pages/ZoukFestivalsPage.tsx
+++ b/src/pages/ZoukFestivalsPage.tsx
@@ -1,14 +1,80 @@
-import React from 'react';
+import React, { useMemo } from 'react';
+import { motion, useReducedMotion } from 'framer-motion';
+import { ExternalLink, Globe, MapPin } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { HeadlessSEO } from '../components/HeadlessSEO';
-import { ARTIST } from '../data/artistData';
-import { getLocalizedRoute, normalizeLanguage } from '../config/routes';
 import { Breadcrumb } from '../components/Breadcrumb';
+import { HeadlessSEO } from '../components/HeadlessSEO';
+import { getLocalizedRoute, normalizeLanguage } from '../config/routes';
+import { ARTIST } from '../data/artistData';
+import { safeUrl } from '../utils/sanitize';
+import { getDateTimeFormatter } from '../utils/date';
+import type { Festival } from '../types';
+
+const HERO_VARIANTS = {
+  hidden: { opacity: 0, y: 20 },
+  visible: { opacity: 1, y: 0 },
+};
+
+interface FestivalCardProps {
+  festival: Festival;
+  year: string;
+  opensInNewTab: string;
+}
+
+const FestivalCard: React.FC<FestivalCardProps> = React.memo(({ festival, year, opensInNewTab }) => (
+  <a
+    href={safeUrl(festival.url, '/')}
+    target="_blank"
+    rel="noopener noreferrer"
+    aria-label={`${festival.name} (${opensInNewTab})`}
+    className="group flex items-center gap-4 rounded-2xl border border-white/10 bg-surface/35 p-5 transition-colors hover:border-primary/35"
+  >
+    <span className="flex-shrink-0 text-4xl" role="img" aria-label={festival.country}>
+      {festival.flag}
+    </span>
+    <div className="min-w-0 flex-1">
+      <p className="truncate font-display font-bold text-white transition-colors group-hover:text-primary">
+        {festival.name}
+      </p>
+      <p className="flex items-center gap-1 text-sm text-white/50">
+        <MapPin size={12} />
+        {festival.country}
+        {year && <span className="ml-1">· {year}</span>}
+      </p>
+    </div>
+    <ExternalLink size={16} className="flex-shrink-0 text-white/30 transition-colors group-hover:text-primary" />
+  </a>
+));
 
 const ZoukFestivalsPage: React.FC = () => {
   const { t, i18n } = useTranslation();
   const currentLang = normalizeLanguage(i18n.language);
+  const prefersReducedMotion = useReducedMotion();
   const pageUrl = `${ARTIST.site.baseUrl}${getLocalizedRoute('zouk-festivals', currentLang)}`;
+
+  const { upcoming, past } = useMemo(() => {
+    const sorted = [...ARTIST.festivals].sort((a, b) => {
+      if (!a.date && !b.date) return 0;
+      if (!a.date) return 1;
+      if (!b.date) return -1;
+      return new Date(b.date).getTime() - new Date(a.date).getTime();
+    });
+    return {
+      upcoming: sorted.filter((f) => f.upcoming),
+      past: sorted.filter((f) => !f.upcoming),
+    };
+  }, []);
+
+  const formatYear = (date: string | undefined): string => {
+    if (!date) return '';
+    try {
+      return getDateTimeFormatter(i18n.language, { year: 'numeric' }).format(new Date(date));
+    } catch {
+      return '';
+    }
+  };
+
+  const opensInNewTab = t('common.opens_in_new_tab');
 
   return (
     <>
@@ -21,8 +87,58 @@ const ZoukFestivalsPage: React.FC = () => {
       <div className="min-h-screen bg-background px-4 pb-20 pt-24 text-white">
         <div className="container mx-auto max-w-5xl">
           <Breadcrumb items={[{ label: t('hub_pages.zouk_festivals.breadcrumb') }]} className="mb-10" />
-          <h1 className="mb-6 font-display text-4xl font-black md:text-6xl text-primary">{t('hub_pages.zouk_festivals.h1')}</h1>
-          <p className="text-white/70">{t('hub_pages.coming_soon')}</p>
+
+          <motion.header
+            variants={HERO_VARIANTS}
+            initial={prefersReducedMotion ? false : 'hidden'}
+            animate={prefersReducedMotion ? undefined : 'visible'}
+            className="mb-14"
+          >
+            <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-4 py-2 text-xs font-bold uppercase tracking-widest text-primary">
+              <Globe size={14} />
+              {t('hub_pages.zouk_festivals.breadcrumb')}
+            </div>
+            <h1 className="mb-4 font-display text-4xl font-black md:text-6xl">
+              {t('hub_pages.zouk_festivals.h1')}
+            </h1>
+            <p className="max-w-2xl text-lg leading-relaxed text-white/65">
+              {t('hub_pages.zouk_festivals.seo_description')}
+            </p>
+          </motion.header>
+
+          {upcoming.length > 0 && (
+            <section className="mb-12" aria-labelledby="upcoming-festivals">
+              <h2 id="upcoming-festivals" className="mb-5 font-display text-2xl font-black text-white">
+                {t('upcoming_events')}
+              </h2>
+              <div className="grid gap-4 sm:grid-cols-2">
+                {upcoming.map((festival) => (
+                  <FestivalCard
+                    key={festival.name}
+                    festival={festival}
+                    year={formatYear(festival.date)}
+                    opensInNewTab={opensInNewTab}
+                  />
+                ))}
+              </div>
+            </section>
+          )}
+
+          <section aria-labelledby="past-festivals">
+            <h2 id="past-festivals" className="mb-5 font-display text-2xl font-black text-white">
+              {t('hub_pages.zouk_festivals.past_editions')}
+            </h2>
+            <div className="grid gap-4 sm:grid-cols-2">
+              {past.map((festival) => (
+                <FestivalCard
+                  key={festival.name}
+                  festival={festival}
+                  year={formatYear(festival.date)}
+                  opensInNewTab={opensInNewTab}
+                />
+              ))}
+            </div>
+          </section>
         </div>
       </div>
     </>


### PR DESCRIPTION
Replaces the "Content coming soon..." stub with a full page that renders
ARTIST.festivals data (11 international Zouk congresses/marathons) sorted
into Upcoming and Past Editions sections with flag, country, year, and
external links. Adds missing past_editions i18n key (EN + PT).

https://claude.ai/code/session_01JWq3DZMKA2x7ghGunWRdKx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Página de Festivais Zouk agora exibe duas seções: próximos eventos e edições anteriores, com cartões informativos de festivais incluindo bandeira do país, data e link externo.
  * Adicionada animação ao cabeçalho da página com suporte a preferências de movimento reduzido.

* **Documentation**
  * Guia operacional atualizado com diretrizes de separação frontend/backend e regras de categorização de festivais.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->