### PR TITLE
fix(seo): trailing slash em currentUrl do MediaPage para integridade do grafo JSON-LD

### DIFF
--- a/src/pages/MediaPage.tsx
+++ b/src/pages/MediaPage.tsx
@@ -39,7 +39,7 @@ const MediaPage: React.FC = () => {
   const featuredVideoTitle = t('media_page.featured_video_title');
   const featuredVideoDescription = t('media_page.featured_video_desc');
   const currentPath = getLocalizedRoute('media', currentLang);
-  const currentUrl = `${artist.site.baseUrl || ARTIST.site.baseUrl}/${currentPath.replace(/^\//, '')}`;
+  const currentUrl = `${artist.site.baseUrl || ARTIST.site.baseUrl}/${currentPath.replace(/^\//, '')}/`;
 
   const clippingData = useMemo(
     () => [


### PR DESCRIPTION
$(cat <<'EOF'
## Problema

`currentUrl` em `MediaPage.tsx` é usado diretamente para construir os `@id` dos nós JSON-LD:

```typescript
'@id': `${currentUrl}#webpage`    // linha 86
url:    currentUrl,                // linha 87
'@id': `${currentUrl}#featured-video`  // linha 104
```

`HeadlessSEO` aplica `ensureTrailingSlash` internamente ao computar `finalUrl`. Resultado:

| Nó | `@id` antes do fix | `@id` após o fix |
|---|---|---|
| WebPage (schema customizado) | `…/media#webpage` | `…/media/#webpage` |
| WebPage (HeadlessSEO auto) | `…/media/#webpage` | `…/media/#webpage` |
| VideoObject | `…/media#featured-video` | `…/media/#featured-video` |

Sem a trailing slash, o schema customizado e o WebPage gerado automaticamente ficam como **dois nós desconectados** no grafo JSON-LD em vez de um único nó consolidado. O Google Search Console reportaria isso como schema inconsistente.

## Fix

```diff
- const currentUrl = `${base}/${path}/`;
+ const currentUrl = `${base}/${path}/`;
```

Uma linha. Nenhuma lógica alterada, nenhuma interface mudada.

## Testes

56 testes passando. Nenhum teste quebrado.
EOF
)"

---
_Generated by [Claude Code](https://claude.ai/code/session_013YLk74E2DBs4fttEktFQky)_