### PR TITLE
feat(tests): festival sort + i18n parity — fix 26 missing translation keys

### DIFF
--- a/src/__tests__/i18n/translation-parity.test.ts
+++ b/src/__tests__/i18n/translation-parity.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import en from '../../locales/en/translation.json';
+import pt from '../../locales/pt/translation.json';
+
+type JsonObject = Record<string, unknown>;
+
+function getAllLeafKeys(obj: JsonObject, prefix = ''): string[] {
+  return Object.entries(obj).flatMap(([key, value]) => {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      return getAllLeafKeys(value as JsonObject, path);
+    }
+    return [path];
+  });
+}
+
+function getNestedValue(obj: JsonObject, path: string): unknown {
+  return path.split('.').reduce((cur: unknown, key) => {
+    if (cur !== null && typeof cur === 'object') {
+      return (cur as JsonObject)[key];
+    }
+    return undefined;
+  }, obj as unknown);
+}
+
+describe('i18n translation parity', () => {
+  const enKeys = getAllLeafKeys(en as JsonObject);
+  const ptKeys = getAllLeafKeys(pt as JsonObject);
+
+  it('PT contains every key present in EN', () => {
+    const missing = enKeys.filter((k) => getNestedValue(pt as JsonObject, k) === undefined);
+    expect(missing, `Keys in EN but missing in PT:\n${missing.join('\n')}`).toHaveLength(0);
+  });
+
+  it('EN contains every key present in PT', () => {
+    const missing = ptKeys.filter((k) => getNestedValue(en as JsonObject, k) === undefined);
+    expect(missing, `Keys in PT but missing in EN:\n${missing.join('\n')}`).toHaveLength(0);
+  });
+
+  it('no EN value is empty string', () => {
+    const empty = enKeys.filter((k) => getNestedValue(en as JsonObject, k) === '');
+    expect(empty, `Empty strings in EN:\n${empty.join('\n')}`).toHaveLength(0);
+  });
+
+  it('no PT value is empty string', () => {
+    const empty = ptKeys.filter((k) => getNestedValue(pt as JsonObject, k) === '');
+    expect(empty, `Empty strings in PT:\n${empty.join('\n')}`).toHaveLength(0);
+  });
+});

--- a/src/__tests__/utils/categorizeFestivals.test.ts
+++ b/src/__tests__/utils/categorizeFestivals.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { categorizeFestivals } from '../../utils/festivals';
+import type { Festival } from '../../types';
+
+const TODAY = new Date('2025-06-15T00:00:00.000Z');
+
+const f = (name: string, date?: string): Festival => ({
+  name,
+  country: 'Test',
+  flag: '🏳',
+  url: 'https://example.com',
+  date,
+});
+
+describe('categorizeFestivals', () => {
+  it('puts future festivals in upcoming', () => {
+    const festivals = [f('Future', '2025-12-01')];
+    const { upcoming, past } = categorizeFestivals(festivals, TODAY);
+    expect(upcoming.map((x) => x.name)).toEqual(['Future']);
+    expect(past).toHaveLength(0);
+  });
+
+  it('puts past festivals in past', () => {
+    const festivals = [f('Past', '2025-01-01')];
+    const { upcoming, past } = categorizeFestivals(festivals, TODAY);
+    expect(upcoming).toHaveLength(0);
+    expect(past.map((x) => x.name)).toEqual(['Past']);
+  });
+
+  it('treats today as upcoming (date >= today)', () => {
+    const festivals = [f('Today', '2025-06-15')];
+    const { upcoming, past } = categorizeFestivals(festivals, TODAY);
+    expect(upcoming.map((x) => x.name)).toEqual(['Today']);
+    expect(past).toHaveLength(0);
+  });
+
+  it('sorts upcoming ascending (nearest first)', () => {
+    const festivals = [
+      f('Far', '2025-12-01'),
+      f('Near', '2025-07-01'),
+      f('Medium', '2025-09-01'),
+    ];
+    const { upcoming } = categorizeFestivals(festivals, TODAY);
+    expect(upcoming.map((x) => x.name)).toEqual(['Near', 'Medium', 'Far']);
+  });
+
+  it('sorts past descending (most recent first)', () => {
+    const festivals = [
+      f('Oldest', '2023-01-01'),
+      f('Newer', '2025-03-01'),
+      f('Middle', '2024-06-01'),
+    ];
+    const { past } = categorizeFestivals(festivals, TODAY);
+    expect(past.map((x) => x.name)).toEqual(['Newer', 'Middle', 'Oldest']);
+  });
+
+  it('puts festivals without date at the end of past', () => {
+    const festivals = [f('NoDate'), f('Recent', '2025-05-01'), f('AlsoNoDate')];
+    const { past } = categorizeFestivals(festivals, TODAY);
+    const names = past.map((x) => x.name);
+    expect(names[0]).toBe('Recent');
+    expect(names).toContain('NoDate');
+    expect(names).toContain('AlsoNoDate');
+  });
+
+  it('handles empty input', () => {
+    const { upcoming, past } = categorizeFestivals([], TODAY);
+    expect(upcoming).toHaveLength(0);
+    expect(past).toHaveLength(0);
+  });
+
+  it('does not mutate the input array', () => {
+    const festivals = [f('B', '2025-12-01'), f('A', '2025-07-01')];
+    const original = [...festivals];
+    categorizeFestivals(festivals, TODAY);
+    expect(festivals.map((x) => x.name)).toEqual(original.map((x) => x.name));
+  });
+});

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -17,7 +17,11 @@
     "my_account": "My Account",
     "join_the_tribe": "Join the Tribe",
     "privacy": "Privacy Policy",
-    "terms": "Terms of Use"
+    "terms": "Terms of Use",
+    "close_menu": "Close Menu",
+    "open_menu": "Open Menu",
+    "main_navigation": "Main Navigation",
+    "mobile_navigation": "Mobile Menu"
   },
   "dashboard": {
     "loading": "Syncing with the Zen Universe...",
@@ -178,7 +182,8 @@
     "achievement": "Achievement",
     "startJourney": "Start your journey to unlock achievements!",
     "earnMoreXP": "Earn More XP",
-    "unlock_at": "Unlock at level {{level}}"
+    "unlock_at": "Unlock at level {{level}}",
+    "view_all_stats": "View All Stats"
   },
   "_meta": {
     "version": "2.1.0",
@@ -399,7 +404,9 @@
     },
     "seo": {
       "keywords": "DJ Zen Eyer, Brazilian Zouk DJ, World Champion DJ, Zouk Music Producer, Zen Tribe",
-      "lead_answer": "DJ Zen Eyer is the two-time world champion of Brazilian Zouk, known for his 'creamy' style and focus on the deep connection between music and dance."
+      "lead_answer": "DJ Zen Eyer is the two-time world champion of Brazilian Zouk, known for his 'creamy' style and focus on the deep connection between music and dance.",
+      "title": "Zen Eyer | Two-Time World Brazilian Zouk Champion",
+      "description": "Zen Eyer, two-time world champion focused on Brazilian Zouk."
     },
     "shows": {
       "title": "Upcoming Events",
@@ -442,7 +449,9 @@
     "tags": "Tags",
     "search_label": "Search releases and notes",
     "search_placeholder": "Search releases and notes...",
-    "no_posts_for_filter": "No posts found for this filter yet."
+    "no_posts_for_filter": "No posts found for this filter yet.",
+    "share": "Share",
+    "trending": "Trending"
   },
   "encyclopedia": {
     "nav_label": "Encyclopedia"
@@ -844,7 +853,14 @@
       "no_orders": "Nenhum pedido encontrado",
       "no_orders_desc": "You have not placed any orders in our shop yet.",
       "order_number": "Pedido #{{id}}",
-      "title": "My Order History"
+      "title": "My Order History",
+      "status": {
+        "completed": "Completed",
+        "processing": "Processing",
+        "failed": "Failed",
+        "pending": "Pending",
+        "cancelled": "Cancelled"
+      }
     }
   },
   "not_found": {

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -19,7 +19,9 @@
     "close_menu": "Fechar Menu",
     "open_menu": "Abrir Menu",
     "main_navigation": "Navegação Principal",
-    "mobile_navigation": "Menu Mobile"
+    "mobile_navigation": "Menu Mobile",
+    "privacy": "Política de Privacidade",
+    "terms": "Termos de Uso"
   },
   "dashboard": {
     "loading": "Sincronizando com o Universo Zen...",
@@ -346,7 +348,8 @@
     "micro_champion": "2× Campeão Mundial",
     "micro_island": "Zouk DJ Championship (2022)",
     "micro_years_label": "anos de pista",
-    "whatsapp_message": "Olá Zen! Vi seu link na bio."
+    "whatsapp_message": "Olá Zen! Vi seu link na bio.",
+    "subtitle": "2× Campeão Mundial de Zouk Brasileiro"
   },
   "events_add_google": "Adicionar à Agenda",
   "social": {
@@ -503,7 +506,13 @@
       "single": "Single"
     },
     "discography_schema_name": "Discografia Zen Eyer",
-    "discography_schema_desc": "Lançamentos oficiais do Zen Eyer, incluindo singles, remixes e músicas para dançar Zouk Brasileiro."
+    "discography_schema_desc": "Lançamentos oficiais do Zen Eyer, incluindo singles, remixes e músicas para dançar Zouk Brasileiro.",
+    "dj_tool_kit": "Kit do DJ",
+    "dj_tool_kit_desc": "Acesse downloads de alta qualidade, edições e ferramentas exclusivas para DJs.",
+    "dj_tool_kit_cta": "Acessar Downloads",
+    "collections_title": "Coleção Musical",
+    "collections_desc": "Tracks exclusivas, mixes e playlists curadas por DJ Zen Eyer",
+    "listen_now_on": "Ouça agora em"
   },
   "press": {
     "page_title": "Press Kit",
@@ -1172,5 +1181,8 @@
       "product": "{{name}} por Zen Eyer",
       "zenlink": "Links oficiais de Zen Eyer para música, booking e apoio"
     }
-  }
+  },
+  "events_search_results": "Resultados para",
+  "events_venue": "Local",
+  "quiz_you_are": "Você é..."
 }

--- a/src/pages/ZoukFestivalsPage.tsx
+++ b/src/pages/ZoukFestivalsPage.tsx
@@ -8,6 +8,7 @@ import { getLocalizedRoute, normalizeLanguage } from '../config/routes';
 import { ARTIST } from '../data/artistData';
 import { safeUrl } from '../utils/sanitize';
 import { getDateTimeFormatter } from '../utils/date';
+import { categorizeFestivals } from '../utils/festivals';
 import type { Festival } from '../types';
 
 const HERO_VARIANTS = {
@@ -55,21 +56,7 @@ const ZoukFestivalsPage: React.FC = () => {
   const { upcoming, past } = useMemo(() => {
     const today = new Date();
     today.setHours(0, 0, 0, 0);
-
-    const upcomingFestivals = [...ARTIST.festivals]
-      .filter((f) => f.date && new Date(f.date) >= today)
-      .sort((a, b) => new Date(a.date!).getTime() - new Date(b.date!).getTime());
-
-    const pastFestivals = [...ARTIST.festivals]
-      .filter((f) => !f.date || new Date(f.date) < today)
-      .sort((a, b) => {
-        if (!a.date && !b.date) return 0;
-        if (!a.date) return 1;
-        if (!b.date) return -1;
-        return new Date(b.date).getTime() - new Date(a.date).getTime();
-      });
-
-    return { upcoming: upcomingFestivals, past: pastFestivals };
+    return categorizeFestivals(ARTIST.festivals, today);
   }, []);
 
   const formatYear = useCallback((date: string | undefined): string => {

--- a/src/utils/festivals.ts
+++ b/src/utils/festivals.ts
@@ -1,0 +1,28 @@
+import type { Festival } from '../types';
+
+export interface CategorizedFestivals {
+  upcoming: Festival[];
+  past: Festival[];
+}
+
+/**
+ * Categorizes festivals into upcoming (date >= today, ascending) and
+ * past (date < today or no date, descending). "today" is midnight-normalized
+ * so a festival happening today is still upcoming.
+ */
+export function categorizeFestivals(festivals: Festival[], today: Date): CategorizedFestivals {
+  const upcoming = [...festivals]
+    .filter((f) => f.date && new Date(f.date) >= today)
+    .sort((a, b) => new Date(a.date!).getTime() - new Date(b.date!).getTime());
+
+  const past = [...festivals]
+    .filter((f) => !f.date || new Date(f.date) < today)
+    .sort((a, b) => {
+      if (!a.date && !b.date) return 0;
+      if (!a.date) return 1;
+      if (!b.date) return -1;
+      return new Date(b.date).getTime() - new Date(a.date).getTime();
+    });
+
+  return { upcoming, past };
+}


### PR DESCRIPTION
## O que mudou

### Testes adicionados

**`src/__tests__/utils/categorizeFestivals.test.ts`** — 8 casos
Extrai a lógica de categorização que estava inline no `useMemo` de `ZoukFestivalsPage` para uma função pura testável. Cobre:
- Divisão upcoming/past correta
- Festival hoje → upcoming (boundary condition)
- Upcoming ordenado crescente (mais próximo primeiro)
- Past ordenado decrescente (mais recente primeiro)
- Festival sem data vai ao final do past
- Input vazio
- Imutabilidade do array de entrada

**`src/__tests__/i18n/translation-parity.test.ts`** — 4 casos
Verifica que `en/translation.json` e `pt/translation.json` têm exatamente o mesmo conjunto de chaves e nenhum valor vazio. Qualquer chave adicionada em um arquivo sem o outro é capturada pelo CI antes do merge.

### Refactor

`categorizeFestivals()` extraída para `src/utils/festivals.ts`. O `useMemo` do `ZoukFestivalsPage` delega para essa função — comportamento idêntico, agora testável.

### Bug fixes reais (encontrados pelo teste de paridade)

O teste imediatamente encontrou **26 chaves** que existiam em um idioma mas não no outro — bugs que estavam silenciosos em produção:

**EN estava faltando 14 chaves presentes em PT:**
- `nav.close_menu`, `nav.open_menu`, `nav.main_navigation`, `nav.mobile_navigation`
- `news.share`, `news.trending`
- `gamification.view_all_stats`
- `home.seo.title`, `home.seo.description`
- `account.orders.status.completed/processing/failed/pending/cancelled`

**PT estava faltando 12 chaves presentes em EN:**
- `nav.privacy`, `nav.terms`
- `zenlink.subtitle`
- `music.dj_tool_kit`, `music.dj_tool_kit_desc`, `music.dj_tool_kit_cta`
- `music.collections_title`, `music.collections_desc`, `music.listen_now_on`
- `events_search_results`, `events_venue`, `quiz_you_are`

## Resultado

**68 testes passando** (era 56 antes desta PR).

---
_Generated by [Claude Code](https://claude.ai/code/session_013YLk74E2DBs4fttEktFQky)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded translation support with new strings for navigation, music sections, events, and order statuses in English and Portuguese.

* **Tests**
  * Added test coverage for translation parity validation and festival categorization logic.

* **Refactor**
  * Optimized festival listing with improved categorization and sorting of upcoming and past events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->