### PR TITLE
Fix high-impact SEO, routing, and sitemap issues

### DIFF
--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -105,7 +105,7 @@ async function fetchEvents() {
         console.warn(`⚠️ Bandsintown respondeu ${response.status}: ${errorText.slice(0, 100)}`);
       }
     } catch (error) {
-      console.warn('\n❌ SITEMAP ERROR: Could not fetch events:', error.message);
+      console.warn('\n❌ SITEMAP ERROR: Could not fetch events:', error instanceof Error ? error.message : String(error));
     }
   }
 
@@ -121,30 +121,47 @@ async function fetchEvents() {
   }));
 }
 
-async function fetchPosts() {
+/**
+ * Fetches all published posts for a given language with pagination.
+ * NOTE: noindex filtering relies on the WP server-side sitemap class since
+ * the _zen_seo_data field is not exposed by default in the REST API.
+ * status=publish is explicit to avoid drafts/scheduled posts.
+ */
+async function fetchPostsForLang(lang) {
   const fields = 'id,date,modified,slug,link,featured_image_src,featured_image_src_full';
-  const result = { en: [], pt: [] };
-
-  await Promise.all(['en', 'pt'].map(async (lang) => {
+  const posts = [];
+  let page = 1;
+  while (true) {
+    const url = `${REST_BASE_URL}/wp/v2/posts?lang=${lang}&per_page=100&page=${page}&status=publish&orderby=modified&order=desc&_fields=${encodeURIComponent(fields)}`;
+    let res;
     try {
-      const postsUrl = `${REST_BASE_URL}/wp/v2/posts?per_page=100&lang=${lang}&_fields=${encodeURIComponent(fields)}`;
-      console.log(`📡 Fetching posts (${lang}) from ${postsUrl}...`);
-      const res = await fetch(postsUrl, { headers: { Accept: 'application/json' } });
-
-      if (!res.ok) {
-        console.warn(`⚠️ Posts (${lang}): API respondeu ${res.status}.`);
-        return;
-      }
-
-      const data = await res.json();
-      result[lang] = Array.isArray(data) ? data.filter(post => post?.slug) : [];
-      console.log(`✅ Posts (${lang}): ${result[lang].length} items`);
+      res = await fetch(url, { headers: { Accept: 'application/json' } });
     } catch (error) {
-      console.warn(`⚠️ Posts (${lang}): falha ao buscar — ${error.message}`);
+      console.warn(`⚠️ Error fetching posts (lang=${lang}, page=${page}):`, error instanceof Error ? error.message : String(error));
+      break;
     }
-  }));
+    if (!res.ok) {
+      console.warn(`⚠️ Posts (${lang}): API respondeu ${res.status}.`);
+      break;
+    }
+    const data = await res.json();
+    if (!Array.isArray(data) || data.length === 0) break;
+    posts.push(...data.filter(post => post?.slug));
+    const totalPages = parseInt(res.headers.get('X-WP-TotalPages') || '1', 10);
+    if (page >= totalPages) break;
+    page++;
+  }
+  return posts;
+}
 
-  return result;
+async function fetchPosts() {
+  console.log('📡 Fetching posts from WP REST API...');
+  const [en, pt] = await Promise.all([
+    fetchPostsForLang('en'),
+    fetchPostsForLang('pt'),
+  ]);
+  console.log(`✅ Posts loaded: ${en.length} EN, ${pt.length} PT`);
+  return { en, pt };
 }
 
 async function generateSitemaps() {
@@ -154,7 +171,7 @@ async function generateSitemaps() {
 
     // 1. Pages Sitemap
     let pagesXml = `<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" 
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:xhtml="http://www.w3.org/1999/xhtml"
         xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">`;
 
@@ -164,10 +181,10 @@ async function generateSitemaps() {
     const getSitemapUrl = (lang, slug) => {
       const parts = [BASE_URL];
       if (lang === 'pt') parts.push('pt');
-      
+
       const cleanSlug = (slug || '').replace(/^\/+|\/+$/g, '');
       if (cleanSlug) parts.push(cleanSlug);
-      
+
       let url = parts.join('/');
       // Garante trailing slash em tudo (padrão do projeto)
       if (!url.endsWith('/')) url += '/';
@@ -201,7 +218,7 @@ async function generateSitemaps() {
         console.warn(`⚠️ Encyclopedia: propriedade 'terms' ausente ou inválida em ${ENCYCLOPEDIA_TERMS_PATH}`);
       }
     } catch (e) {
-      console.warn(`⚠️ Encyclopedia: falha ao ler ${ENCYCLOPEDIA_TERMS_PATH}: ${e.message}`);
+      console.warn(`⚠️ Encyclopedia: falha ao ler ${ENCYCLOPEDIA_TERMS_PATH}: ${e instanceof Error ? e.message : String(e)}`);
     }
     if (encyclopediaRoute && encyclopediaTerms.length > 0) {
       console.log(`📚 Encyclopedia: ${encyclopediaTerms.length} termos carregados.`);
@@ -223,7 +240,7 @@ async function generateSitemaps() {
 
     // 2. Events Sitemap
     const events = await fetchEvents();
-    
+
     // Obter slugs canônicos de eventos do routes-slugs.json
     const eventsRoute = routesData.routes.find(r => r.key === 'events');
     if (!eventsRoute?.en || !eventsRoute?.pt) {
@@ -248,7 +265,7 @@ async function generateSitemaps() {
 
     let eventCount = 0;
     let eventsXml = `<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" 
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:xhtml="http://www.w3.org/1999/xhtml"
         xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">`;
 
@@ -256,7 +273,7 @@ async function generateSitemaps() {
       for (const event of events) {
         // Extração robusta do slug final (ID ou path real)
         let relativePath = event.canonical_path || String(event.event_id);
-        
+
         // Remove prefixos conhecidos para isolar o ID/Slug final do evento
         relativePath = relativePath
           .replace(/^https?:\/\/[^\/]+/, '') // Remove domínio se vier absoluto
@@ -296,7 +313,7 @@ async function generateSitemaps() {
 
     let postCount = 0;
     let postsXml = `<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" 
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:xhtml="http://www.w3.org/1999/xhtml"
         xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">`;
 
@@ -307,16 +324,22 @@ async function generateSitemaps() {
       if (!canonicalPost) continue;
 
       const lastmod = canonicalPost.modified || canonicalPost.date || date;
-      const image = canonicalPost.featured_image_src_full || canonicalPost.featured_image_src || DEFAULT_IMAGE;
+      const image = canonicalPost.featured_image_src_full || canonicalPost.featured_image_src || null;
       const enUrl = getSitemapUrl('en', `${newsRoute.en}/${slug}`);
       const ptUrl = getSitemapUrl('pt', `${newsRoute.pt}/${slug}`);
 
-      if (enPost) {
+      if (enPost && ptPost) {
+        // Both languages exist — emit with hreflang alternates
         postsXml += buildUrlEntry(enUrl, lastmod, '0.7', ptUrl, image, true);
-        postCount++;
-      }
-      if (ptPost) {
         postsXml += buildUrlEntry(ptUrl, lastmod, '0.7', enUrl, image, false);
+        postCount += 2;
+      } else if (enPost) {
+        // EN only — no alternates
+        postsXml += buildUrlEntry(enUrl, lastmod, '0.7', null, image, true);
+        postCount++;
+      } else if (ptPost) {
+        // PT only — no alternates
+        postsXml += buildUrlEntry(ptUrl, lastmod, '0.7', null, image, false);
         postCount++;
       }
     }
@@ -346,7 +369,7 @@ async function generateSitemaps() {
     console.log('════════════════════════════════════════\n');
 
   } catch (error) {
-    console.error('❌ Error:', error);
+    console.error('❌ Error:', error instanceof Error ? error.message : String(error));
     process.exit(1);
   }
 }

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
- * Sitemap Generator v8.0 - EVENTS SUPPORT
- * Gera sitemaps baseado em arquivo JSON estático
+ * Sitemap Generator v8.1 - EVENTS + POSTS SUPPORT
+ * Gera sitemaps baseado em arquivo JSON estático e conteúdo público do WordPress
  */
 
 import fs from 'fs';
@@ -21,7 +21,7 @@ const PUBLIC_DIR = path.resolve(__dirname, '../public');
 const ROUTES_DATA_PATH = path.resolve(__dirname, '../src/config/routes-slugs.json');
 const ENCYCLOPEDIA_TERMS_PATH = path.resolve(__dirname, '../src/config/encyclopedia-term-slugs.json');
 
-console.log('🗺️  Sitemap Generator v8.0 - EVENTS SUPPORT\n');
+console.log('🗺️  Sitemap Generator v8.1 - EVENTS + POSTS SUPPORT\n');
 
 const DEFAULT_IMAGE = `${BASE_URL}/images/zen-eyer-og-image.png`;
 
@@ -114,14 +114,37 @@ async function fetchEvents() {
   console.log(`✅ Events loaded via ${source}: ${raw.length} items`);
 
   // Mapeia para o formato que o gerador espera
-  return raw.map(ev => {
-    const venue = ev.venue || {};
-    return {
-      event_id: String(ev.id || ev.event_id || ''),
-      image: ev.artist?.image_url || ev.artist?.thumb_url || ev.image || DEFAULT_IMAGE,
-      canonical_path: ev.canonical_path
-    };
-  });
+  return raw.map(ev => ({
+    event_id: String(ev.id || ev.event_id || ''),
+    image: ev.artist?.image_url || ev.artist?.thumb_url || ev.image || DEFAULT_IMAGE,
+    canonical_path: ev.canonical_path
+  }));
+}
+
+async function fetchPosts() {
+  const fields = 'id,date,modified,slug,link,featured_image_src,featured_image_src_full';
+  const result = { en: [], pt: [] };
+
+  await Promise.all(['en', 'pt'].map(async (lang) => {
+    try {
+      const postsUrl = `${REST_BASE_URL}/wp/v2/posts?per_page=100&lang=${lang}&_fields=${encodeURIComponent(fields)}`;
+      console.log(`📡 Fetching posts (${lang}) from ${postsUrl}...`);
+      const res = await fetch(postsUrl, { headers: { Accept: 'application/json' } });
+
+      if (!res.ok) {
+        console.warn(`⚠️ Posts (${lang}): API respondeu ${res.status}.`);
+        return;
+      }
+
+      const data = await res.json();
+      result[lang] = Array.isArray(data) ? data.filter(post => post?.slug) : [];
+      console.log(`✅ Posts (${lang}): ${result[lang].length} items`);
+    } catch (error) {
+      console.warn(`⚠️ Posts (${lang}): falha ao buscar — ${error.message}`);
+    }
+  }));
+
+  return result;
 }
 
 async function generateSitemaps() {
@@ -258,7 +281,51 @@ async function generateSitemaps() {
     fs.writeFileSync(path.join(PUBLIC_DIR, 'sitemap-events.xml'), eventsXml);
     console.log(`✅ sitemap-events.xml created (${eventCount} URLs)`);
 
-    // 3. Index Sitemap
+    // 3. Posts Sitemap
+    const posts = await fetchPosts();
+    const newsRoute = routesData.routes.find(r => r.key === 'news');
+    if (!newsRoute?.en || !newsRoute?.pt) {
+      throw new Error('routes-slugs.json precisa conter a rota "news" com slugs EN/PT antes de gerar o sitemap de posts.');
+    }
+
+    const postsByLang = {
+      en: new Map(posts.en.map(post => [post.slug, post])),
+      pt: new Map(posts.pt.map(post => [post.slug, post])),
+    };
+    const postSlugs = [...new Set([...postsByLang.en.keys(), ...postsByLang.pt.keys()])];
+
+    let postCount = 0;
+    let postsXml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" 
+        xmlns:xhtml="http://www.w3.org/1999/xhtml"
+        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">`;
+
+    for (const slug of postSlugs) {
+      const enPost = postsByLang.en.get(slug);
+      const ptPost = postsByLang.pt.get(slug);
+      const canonicalPost = enPost || ptPost;
+      if (!canonicalPost) continue;
+
+      const lastmod = canonicalPost.modified || canonicalPost.date || date;
+      const image = canonicalPost.featured_image_src_full || canonicalPost.featured_image_src || DEFAULT_IMAGE;
+      const enUrl = getSitemapUrl('en', `${newsRoute.en}/${slug}`);
+      const ptUrl = getSitemapUrl('pt', `${newsRoute.pt}/${slug}`);
+
+      if (enPost) {
+        postsXml += buildUrlEntry(enUrl, lastmod, '0.7', ptUrl, image, true);
+        postCount++;
+      }
+      if (ptPost) {
+        postsXml += buildUrlEntry(ptUrl, lastmod, '0.7', enUrl, image, false);
+        postCount++;
+      }
+    }
+
+    postsXml += '\n</urlset>';
+    fs.writeFileSync(path.join(PUBLIC_DIR, 'sitemap-posts.xml'), postsXml);
+    console.log(`✅ sitemap-posts.xml created (${postCount} URLs)`);
+
+    // 4. Index Sitemap
     let sitemapIndex = `<?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`;
 
@@ -266,13 +333,15 @@ async function generateSitemaps() {
 
     sitemapIndex += buildSitemapIndexEntry(`${BASE_URL}/sitemap-events.xml`, date);
 
+    sitemapIndex += buildSitemapIndexEntry(`${BASE_URL}/sitemap-posts.xml`, date);
+
     sitemapIndex += '\n</sitemapindex>';
     fs.writeFileSync(path.join(PUBLIC_DIR, 'sitemap.xml'), sitemapIndex);
     console.log('✅ sitemap.xml index created');
 
     console.log('\n════════════════════════════════════════');
     console.log('✅ Sitemap generation complete!');
-    console.log(`📄 Total: ${pageCount + eventCount} URLs`);
+    console.log(`📄 Total: ${pageCount + eventCount + postCount} URLs`);
     console.log(`📍 Location: ${PUBLIC_DIR}`);
     console.log('════════════════════════════════════════\n');
 

--- a/scripts/submit-indexnow.mjs
+++ b/scripts/submit-indexnow.mjs
@@ -82,19 +82,22 @@ function parseLocsFromFile(filePath) {
 // Read pages sitemap (static routes in both EN + PT)
 const pagesFile  = path.resolve(__dirname, '../public/sitemap-pages.xml');
 const eventsFile = path.resolve(__dirname, '../public/sitemap-events.xml');
+const postsFile  = path.resolve(__dirname, '../public/sitemap-posts.xml');
 
 const pageUrls  = parseLocsFromFile(pagesFile);
 const eventUrls = parseLocsFromFile(eventsFile);
+const postUrls  = parseLocsFromFile(postsFile);
 
 // Always include the sitemap index itself
 const extraUrls = [
   `${BASE}/sitemap.xml`,
   `${BASE}/sitemap-pages.xml`,
   `${BASE}/sitemap-events.xml`,
+  `${BASE}/sitemap-posts.xml`,
 ];
 
 // Deduplicate
-const allUrls = [...new Set([...pageUrls, ...eventUrls, ...extraUrls])];
+const allUrls = [...new Set([...pageUrls, ...eventUrls, ...postUrls, ...extraUrls])];
 
 if (allUrls.length === 0) {
   console.warn('⚠️  No URLs found to submit — sitemap files might be missing.');

--- a/src/components/AppRoutes.tsx
+++ b/src/components/AppRoutes.tsx
@@ -1,4 +1,4 @@
-import type { ComponentType } from 'react';
+import { ComponentType, Suspense } from 'react';
 import { useRoutes, RouteObject } from 'react-router-dom';
 import MainLayout from '../layouts/MainLayout';
 import ErrorBoundary from './common/ErrorBoundary';
@@ -14,7 +14,9 @@ const STANDALONE_ROUTE_KEYS = new Set(['zenlink']);
 
 const wrapRouteElement = (Component: ComponentType) => (
   <ErrorBoundary>
-    <Component />
+    <Suspense fallback={null}>
+      <Component />
+    </Suspense>
   </ErrorBoundary>
 );
 

--- a/src/components/AppRoutes.tsx
+++ b/src/components/AppRoutes.tsx
@@ -1,22 +1,26 @@
+import type { ComponentType } from 'react';
 import { useRoutes, RouteObject } from 'react-router-dom';
 import MainLayout from '../layouts/MainLayout';
 import ErrorBoundary from './common/ErrorBoundary';
-import { lazyWithRetry } from '../utils/lazyWithRetry';
-
-const ZenLinkPage = lazyWithRetry(
-  () => import('../pages/ZenLinkPage').then(m => ({ default: m.ZenLinkPage })),
-  'route:zenlink-standalone'
-);
-// CORREÇÃO: Apontando para o local correto onde você definiu suas rotas
 import {
   ROUTES_CONFIG,
   NOT_FOUND_COMPONENT,
-  Language
+  Language,
+  buildFullPath,
+  getLocalizedPaths,
 } from '../config/routes';
+
+const wrapRouteElement = (Component: ComponentType) => (
+  <ErrorBoundary>
+    <Component />
+  </ErrorBoundary>
+);
 
 // Função auxiliar robusta para gerar rotas do React Router v6
 const generateRoutes = (lang: Language): RouteObject[] => {
   return ROUTES_CONFIG.flatMap((route) => {
+    if (route.standalone) return [];
+
     // 1. Acessa diretamente a propriedade do idioma (en ou pt)
     const rawPath = route.paths[lang];
 
@@ -30,11 +34,7 @@ const generateRoutes = (lang: Language): RouteObject[] => {
       if (route.isIndex || path === '') {
         return {
           index: true,
-          element: (
-            <ErrorBoundary>
-              <Component />
-            </ErrorBoundary>
-          ),
+          element: wrapRouteElement(Component),
         };
       }
 
@@ -42,23 +42,38 @@ const generateRoutes = (lang: Language): RouteObject[] => {
       // Nota: Não colocamos '/' antes, pois é relativo ao pai (/pt)
       return {
         path: path,
-        element: (
-          <ErrorBoundary>
-            <Component />
-          </ErrorBoundary>
-        ),
+        element: wrapRouteElement(Component),
         // Suporte para rotas com * (wildcard) como na Loja
         children: route.hasWildcard ? [
           {
             path: '*',
-            element: (
-              <ErrorBoundary>
-                <Component />
-              </ErrorBoundary>
-            )
+            element: wrapRouteElement(Component),
           }
         ] : undefined
       };
+    });
+  });
+};
+
+const generateStandaloneRoutes = (): RouteObject[] => {
+  const seen = new Set<string>();
+
+  return ROUTES_CONFIG.flatMap((route) => {
+    if (!route.standalone) return [];
+
+    const Component = route.component;
+
+    return (['en', 'pt'] as Language[]).flatMap((lang) => {
+      return getLocalizedPaths(route, lang).flatMap((path) => {
+        const fullPath = buildFullPath(path, lang);
+        if (seen.has(fullPath)) return [];
+        seen.add(fullPath);
+
+        return [{
+          path: fullPath,
+          element: wrapRouteElement(Component),
+        }];
+      });
     });
   });
 };
@@ -68,6 +83,9 @@ const NotFound = NOT_FOUND_COMPONENT;
 // ⚡ Bolt: Extracted static routes configuration outside the component to prevent O(N) object
 // reallocation and nested JSX re-instantiation on every render of AppRoutes.
 const STATIC_ROUTES: RouteObject[] = [
+  // 🔗 Standalone routes — sem Navbar/Footer para máxima conversão em link-in-bio
+  ...generateStandaloneRoutes(),
+
   // 🇧🇷 Rotas em Português (Raiz /pt)
   // Movido para cima para garantir prioridade na detecção
   {
@@ -89,16 +107,6 @@ const STATIC_ROUTES: RouteObject[] = [
       </ErrorBoundary>
     ),
     children: generateRoutes('en'),
-  },
-
-  // 🔗 ZenLink — página independente (sem Navbar/Footer)
-  {
-    path: '/zenlink',
-    element: (
-      <ErrorBoundary>
-        <ZenLinkPage />
-      </ErrorBoundary>
-    ),
   },
 
   // 🚫 404 Catch-all

--- a/src/components/AppRoutes.tsx
+++ b/src/components/AppRoutes.tsx
@@ -10,6 +10,8 @@ import {
   getLocalizedPaths,
 } from '../config/routes';
 
+const STANDALONE_ROUTE_KEYS = new Set(['zenlink']);
+
 const wrapRouteElement = (Component: ComponentType) => (
   <ErrorBoundary>
     <Component />
@@ -19,7 +21,7 @@ const wrapRouteElement = (Component: ComponentType) => (
 // Função auxiliar robusta para gerar rotas do React Router v6
 const generateRoutes = (lang: Language): RouteObject[] => {
   return ROUTES_CONFIG.flatMap((route) => {
-    if (route.standalone) return [];
+    if (STANDALONE_ROUTE_KEYS.has(route.key)) return [];
 
     // 1. Acessa diretamente a propriedade do idioma (en ou pt)
     const rawPath = route.paths[lang];
@@ -59,7 +61,7 @@ const generateStandaloneRoutes = (): RouteObject[] => {
   const seen = new Set<string>();
 
   return ROUTES_CONFIG.flatMap((route) => {
-    if (!route.standalone) return [];
+    if (!STANDALONE_ROUTE_KEYS.has(route.key)) return [];
 
     const Component = route.component;
 

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -104,7 +104,7 @@ const HomePage: React.FC = () => {
   const { artist } = useBranding();
 
   const currentLang = normalizeLanguage(i18n.language);
-  const currentPath = i18n.language === 'pt' ? '/pt' : '/';
+  const currentPath = currentLang === 'pt' ? '/pt' : '/';
   const baseUrl = artist?.site?.baseUrl || ARTIST.site.baseUrl;
   const currentUrl = `${baseUrl}${currentPath}`;
   const festivalsHighlight = useMemo(() => (artist?.festivals || ARTIST.festivals).slice(0, 6), [artist?.festivals]);
@@ -184,7 +184,8 @@ const HomePage: React.FC = () => {
         keywords={t('home.seo.keywords')}
         leadAnswer={t('home.seo.lead_answer')}
         preload={[
-          { href: '/images/hero-background.webp', as: 'image' }
+          { href: '/images/hero-background-mobile.webp', as: 'image', media: '(max-width: 768px)' },
+          { href: '/images/hero-background.webp', as: 'image', media: '(min-width: 769px)' }
         ]}
       />
 


### PR DESCRIPTION
## Summary

Implements the high-impact fixes identified for the site:

- Keeps ZenLink routes standalone, without `MainLayout`, including localized/alias paths from the route config.
- Fixes the Portuguese homepage canonical/schema URL by using `normalizeLanguage()` instead of strict `i18n.language === 'pt'`.
- Adds responsive hero preloads so mobile gets the mobile hero image and desktop gets the desktop image.
- Adds `sitemap-posts.xml` generation for WordPress releases/posts and includes it in the sitemap index.

## Notes

- I kept the ZenLink fix centralized in `AppRoutes.tsx` instead of changing the route config type, to reduce risk.
- I could not run the local build in this environment because the GitHub repo could not be cloned from the container, so CI/build should be checked on the PR.