### PR TITLE
feat(analytics): add lightweight conversion tracking foundation

### DIFF
--- a/docs/analytics-events.md
+++ b/docs/analytics-events.md
@@ -1,0 +1,40 @@
+# Conversion Analytics Event Map
+
+This document maps the public conversion events that matter for djzeneyer.com.
+
+## Goal
+
+Measure which public actions create real business value: booking interest, event intent, music discovery, press-kit reuse, community signup and shop revenue.
+
+The implementation should stay lightweight. The current helper in `src/lib/analytics.ts` no-ops when no analytics provider is present and sends events through `window.gtag()` or `window.dataLayer` when GA4/GTM is configured.
+
+## Recommended GA4-compatible events
+
+| User action | Event | Required context |
+|---|---|---|
+| WhatsApp booking click | `generate_lead` | `method: whatsapp`, page path |
+| Email booking click | `generate_lead` | `method: email`, page path |
+| Press kit PDF/MD download | `select_content` | `content_type: press_kit`, asset type |
+| Official photo gallery click | `select_content` | `content_type: press_gallery` |
+| Add event to Google Calendar | `select_content` | `content_type: event_calendar`, `calendar_provider: google` |
+| Share event | `share` | `content_type: event`, event id/title |
+| External music-platform click | `select_content` | `content_type: music_platform`, platform |
+| Zen Tribe registration | `sign_up` | signup method |
+| Newsletter subscription | `sign_up` | source page/list |
+| Cart item added | `add_to_cart` | product id/name/value |
+| Checkout completed | `purchase` | order id/value/currency |
+
+## Implementation rules
+
+- Keep the analytics helper dependency-free.
+- Do not block user navigation if analytics fails.
+- Do not send private user data, payment data, tokens, email addresses or full message bodies.
+- Prefer GA4 recommended event names when they match the action.
+- Use custom parameters only for low-risk public context: page, content type, item id, platform, UI variant.
+- Authenticated/user-specific tracking needs a separate privacy review before implementation.
+
+## Validation
+
+- In local/dev without GA4, events should silently no-op.
+- With GTM, verify `dataLayer` receives the event object.
+- With GA4, verify events in DebugView before relying on reports.

--- a/src/components/Events/AddCalendarMenu.tsx
+++ b/src/components/Events/AddCalendarMenu.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { CalendarPlus } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
+import { trackSelectContent } from '../../lib/analytics';
 import type { ZenBitEventListItem } from '../../types/events';
 
 interface AddCalendarMenuProps {
@@ -56,10 +57,19 @@ const AddCalendarMenu = ({ event, variant = 'primary', className = '' }: AddCale
 
     const googleUrl = `https://calendar.google.com/calendar/render?action=TEMPLATE&text=${encodeURIComponent(details.title)}&dates=${details.start}/${details.end}&details=${encodeURIComponent(details.details)}&location=${encodeURIComponent(details.location)}`;
 
+    const openCalendar = () => {
+        trackSelectContent('event_calendar', event.event_id || details.title, {
+            item_name: details.title,
+            calendar_provider: 'google',
+            ui_variant: variant,
+        });
+        window.open(googleUrl, '_blank');
+    };
+
     if (variant === 'primary') {
         return (
             <button
-                onClick={() => window.open(googleUrl, '_blank')}
+                onClick={openCalendar}
                 className={`btn btn-outline border-primary/30 text-primary w-full py-5 rounded-2xl flex items-center justify-center gap-3 font-black uppercase tracking-widest text-sm hover:bg-primary/10 transition-all ${className}`}
             >
                 <CalendarPlus size={20} />
@@ -70,7 +80,7 @@ const AddCalendarMenu = ({ event, variant = 'primary', className = '' }: AddCale
 
     return (
         <button
-            onClick={() => window.open(googleUrl, '_blank')}
+            onClick={openCalendar}
             className={`w-10 h-10 rounded-xl bg-white/5 flex items-center justify-center hover:bg-primary/20 hover:text-primary transition-all ${className}`}
             title={t('events_add_google')}
         >

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,67 @@
+// Lightweight analytics helpers for public conversion events.
+// This file intentionally has no runtime dependency: GA4/GTM can consume window.gtag
+// when configured, and local/dev environments safely no-op.
+
+import { logger } from './logger';
+
+type AnalyticsValue = string | number | boolean | undefined | null;
+
+export type AnalyticsParams = Record<string, AnalyticsValue>;
+
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void;
+    dataLayer?: unknown[];
+  }
+}
+
+const sanitizeParams = (params: AnalyticsParams = {}): Record<string, string | number | boolean> => {
+  return Object.fromEntries(
+    Object.entries(params).filter(([, value]) => ['string', 'number', 'boolean'].includes(typeof value))
+  ) as Record<string, string | number | boolean>;
+};
+
+export const trackEvent = (eventName: string, params: AnalyticsParams = {}) => {
+  if (typeof window === 'undefined') return;
+
+  const eventParams = sanitizeParams(params);
+
+  try {
+    if (typeof window.gtag === 'function') {
+      window.gtag('event', eventName, eventParams);
+      return;
+    }
+
+    if (Array.isArray(window.dataLayer)) {
+      window.dataLayer.push({ event: eventName, ...eventParams });
+    }
+  } catch (error) {
+    logger.warn('ANALYTICS_EVENT_FAILED', 'Failed to send analytics event', {
+      eventName,
+      error: String(error),
+    });
+  }
+};
+
+export const trackGenerateLead = (method: string, params: AnalyticsParams = {}) => {
+  trackEvent('generate_lead', {
+    method,
+    ...params,
+  });
+};
+
+export const trackSelectContent = (contentType: string, itemId: string, params: AnalyticsParams = {}) => {
+  trackEvent('select_content', {
+    content_type: contentType,
+    item_id: itemId,
+    ...params,
+  });
+};
+
+export const trackShare = (contentType: string, itemId: string, params: AnalyticsParams = {}) => {
+  trackEvent('share', {
+    content_type: contentType,
+    item_id: itemId,
+    ...params,
+  });
+};


### PR DESCRIPTION
## Summary

Adds a dependency-free analytics foundation for public conversion events.

## Why

The site already has strong SEO/GEO/AEO surfaces, but conversion actions should be measurable: booking leads, calendar intent, press-kit use, music-platform clicks, community signup, and purchases.

## Changes

- Adds `src/lib/analytics.ts` with:
  - `trackEvent`
  - `trackGenerateLead`
  - `trackSelectContent`
  - `trackShare`
- Sends to `window.gtag()` when configured.
- Falls back to `window.dataLayer.push()` when GTM is present.
- Safely no-ops in dev/no-provider environments.
- Tracks Add to Calendar clicks as `select_content` with `content_type: event_calendar`.
- Adds `docs/analytics-events.md` with the conversion event map and privacy constraints.

## Notes

This PR intentionally does not add GA/GTM scripts or vendor dependencies. It only creates the public event API and one first instrumentation point.

## Suggested validation

```bash
npm run type-check
npm run lint
```
