### PR TITLE
fix(events): use canonical event URLs in calendar links

### DIFF
--- a/src/components/Events/AddCalendarMenu.tsx
+++ b/src/components/Events/AddCalendarMenu.tsx
@@ -8,9 +8,10 @@ interface AddCalendarMenuProps {
     event: ZenBitEventListItem;
     variant?: 'primary' | 'ghost';
     className?: string;
+    eventUrl?: string;
 }
 
-const AddCalendarMenu = ({ event, variant = 'primary', className = '' }: AddCalendarMenuProps) => {
+const AddCalendarMenu = ({ event, variant = 'primary', className = '', eventUrl }: AddCalendarMenuProps) => {
     const { t } = useTranslation();
 
     const getDetails = () => {
@@ -41,8 +42,11 @@ const AddCalendarMenu = ({ event, variant = 'primary', className = '' }: AddCale
             const loc = event.location;
             const location = loc.venue ? `${loc.venue}, ${loc.city}` : (loc.city || "TBA");
 
-            const eventUrl = `${window.location.origin}${window.location.pathname}`;
-            const details = `${t('events_view_details')}: ${eventUrl}`;
+            const fallbackUrl = typeof window !== 'undefined'
+                ? `${window.location.origin}${window.location.pathname}`
+                : '';
+            const canonicalEventUrl = eventUrl || event.canonical_url || fallbackUrl;
+            const details = `${t('events_view_details')}: ${canonicalEventUrl}`;
 
             return { title, start, end, location, details };
         } catch (error) {

--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -73,6 +73,7 @@ const EventDetailContent = ({ id, lang }: { id: string; lang: string }) => {
   const isValidDate = !isNaN(eventDate.getTime());
   const loc = event.location;
   const cleanDescription = stripHtml(event.description || '');
+  const eventDetailUrl = event.canonical_url || `${origin}${getLocalizedRoute('events', lang as Language)}/${id}`;
 
   const share = () => {
     const canonical = event.canonical_url || `${ARTIST.site.baseUrl}${getLocalizedRoute('events', lang as Language)}/${event.event_id}`;
@@ -159,7 +160,7 @@ const EventDetailContent = ({ id, lang }: { id: string; lang: string }) => {
             <div className="prose prose-invert mt-10 mb-10 text-white/60 leading-relaxed text-lg" dangerouslySetInnerHTML={{ __html: sanitizeHtml(event.description || '') }} />
 
             <div className="space-y-4">
-              <AddCalendarMenu event={event} variant="primary" />
+              <AddCalendarMenu event={event} variant="primary" eventUrl={eventDetailUrl} />
 
               <button onClick={share} className="btn btn-outline border-white/10 w-full py-4 rounded-2xl flex items-center justify-center gap-2 hover:bg-white/5 transition-all text-white/50 hover:text-white font-bold uppercase tracking-widest text-xs">
                 <Share2 size={18} /> {t('share')}
@@ -287,6 +288,7 @@ const EventListContent = ({ lang }: { lang: string }) => {
                     : e.event_id;
 
                   const detailHref = e._processed?.detailHref || generatePath(eventsDetailRoute, { id: identifier });
+                  const detailUrl = e.canonical_url || `${ARTIST.site.baseUrl}${detailHref}`;
                   const loc = e.location;
 
                   return (
@@ -299,7 +301,7 @@ const EventListContent = ({ lang }: { lang: string }) => {
                         </Link>
                       </div>
                       <div className="flex gap-2">
-                        <AddCalendarMenu event={e as unknown as ZenBitEventDetail} variant="ghost" />
+                        <AddCalendarMenu event={e as unknown as ZenBitEventDetail} variant="ghost" eventUrl={detailUrl} />
                         <button onClick={() => share(e)} className="w-11 h-11 rounded-xl bg-white/5 flex items-center justify-center hover:bg-primary/20 transition-all">
                           <Share2 size={16} />
                         </button>


### PR DESCRIPTION
## Summary

Fixes Add to Calendar links so event details point to the event's canonical URL instead of blindly using the current browser path.

## Why

`AddCalendarMenu` is used both on event detail pages and inside the event list. When clicked from the list, `window.location.pathname` can point to `/zouk-events/` instead of the specific event detail route. Calendar entries should preserve the event-specific canonical URL.

## Changes

- Adds optional `eventUrl` prop to `AddCalendarMenu`.
- Prefers `eventUrl`, then `event.canonical_url`, then the current browser path as fallback.
- Passes the event detail URL from both:
  - event detail page
  - event list card button

## Suggested validation

```bash
npm run type-check
npm run lint
```

Manual smoke test:

1. Open `/zouk-events`.
2. Click the calendar icon on an event card.
3. Confirm the Google Calendar details link points to the specific event, not only the event list.
