### PR TITLE
fix + refactor + data: CSP, sameAs SSOT e plataformas ausentes

### DIFF
--- a/inc/csp.php
+++ b/inc/csp.php
@@ -49,7 +49,7 @@ add_action('send_headers', function() {
     $policy = implode('; ', [
         "default-src 'self' https: data:",
         
-        "script-src 'self' 'nonce-{$nonce}' 'strict-dynamic' 'unsafe-inline' https: http: blob: https://accounts.google.com https://apis.google.com https://gsi.gstatic.com https://gsi.client-url.com https://www.googletagmanager.com https://widget.bandsintown.com https://cdn.bandsintown.com https://rest.bandsintown.com https://static.cloudflareinsights.com https://fonts.googleapis.com https://challenges.cloudflare.com",
+        "script-src 'self' 'nonce-{$nonce}' 'strict-dynamic' https: http: blob: https://accounts.google.com https://apis.google.com https://gsi.gstatic.com https://gsi.client-url.com https://www.googletagmanager.com https://widget.bandsintown.com https://cdn.bandsintown.com https://rest.bandsintown.com https://static.cloudflareinsights.com https://fonts.googleapis.com https://challenges.cloudflare.com",
         
         "style-src 'self' 'nonce-{$nonce}' https://fonts.googleapis.com https://accounts.google.com https://widget.bandsintown.com https://cdn.bandsintown.com",
         

--- a/src/data/artist.schema.ts
+++ b/src/data/artist.schema.ts
@@ -35,6 +35,13 @@ export const ARTIST_SCHEMA_SAME_AS = [
   'https://www.shazam.com/artist/1439280950',
   'https://www.patreon.com/djzeneyer',
   'https://medium.com/@djzeneyer',
+  'https://www.tiktok.com/@djzeneyer',
+  'https://x.com/djzeneyer',
+  'https://genius.com/artists/Zen-eyer',
+  'https://audiomack.com/djzeneyer',
+  'https://www.boomplay.com/artists/35157982',
+  'https://us.napster.com/artist/art.626690096',
+  'https://play.qobuz.com/artist/4083033',
 ] as const;
 
 export const ARTIST_SCHEMA_BASE = {

--- a/src/data/artist.schema.ts
+++ b/src/data/artist.schema.ts
@@ -8,41 +8,34 @@ import { ARTIST } from './artistData';
 export const DISAMBIGUATING_DESCRIPTION =
   'Zen Eyer is pronounced /zɛn ˈaɪər/. DJ Zen Eyer is a commonly used stage-name variant; Zen Ayer is a common misspelling, not an official artist name.';
 
-// Schema.org sameAs list (consolidated for Knowledge Graph)
-export const ARTIST_SCHEMA_SAME_AS = [
-  'https://www.wikidata.org/wiki/Q136551855',
-  'https://musicbrainz.org/artist/13afa63c-8164-4697-9cad-c5100062a154',
-  'https://www.discogs.com/artist/16872046',
-  'https://isni.org/isni/0000000528931015',
-  'https://open.spotify.com/artist/68SHKGndTlq3USQ2LZmyLw',
-  'https://music.apple.com/us/artist/1439280950',
-  'https://www.youtube.com/@djzeneyer',
-  'https://www.instagram.com/djzeneyer/',
-  'https://www.facebook.com/djzeneyer/',
-  'https://www.linkedin.com/in/eyermarcelo',
-  'https://soundcloud.com/djzeneyer',
-  'https://www.deezer.com/artist/52900762',
-  'https://tidal.com/artist/10492592',
-  'https://djzeneyer.bandcamp.com',
-  'https://music.amazon.com/artists/B07JKCDCG8',
-  'https://www.mixcloud.com/djzeneyer',
-  'https://www.last.fm/music/Zen+Eyer',
-  'https://www.songkick.com/artists/8815204-zen-eyer',
-  'https://www.bandsintown.com/a/15619775-zen-eyer',
-  'https://ra.co/dj/djzeneyer',
-  'https://bsky.app/profile/djzeneyer.bsky.social',
-  'https://www.threads.net/@djzeneyer',
-  'https://www.shazam.com/artist/1439280950',
-  'https://www.patreon.com/djzeneyer',
-  'https://medium.com/@djzeneyer',
-  'https://www.tiktok.com/@djzeneyer',
-  'https://x.com/djzeneyer',
-  'https://genius.com/artists/Zen-eyer',
-  'https://audiomack.com/djzeneyer',
-  'https://www.boomplay.com/artists/35157982',
-  'https://us.napster.com/artist/art.626690096',
-  'https://play.qobuz.com/artist/4083033',
+// Schema.org sameAs — derived from ARTIST (single source of truth).
+// To add/change a platform URL, edit artistData.ts only.
+const { identifiers, social } = ARTIST;
+
+const SAME_AS_AUTHORITY = [
+  identifiers.wikidataUrl,
+  identifiers.musicbrainzUrl,
+  identifiers.discogsUrl,
+  `https://isni.org/isni/${identifiers.isni}`,
+  identifiers.residentAdvisorUrl,
 ] as const;
+
+// Platforms in ARTIST.social whose URLs belong in sameAs
+const SAME_AS_SOCIAL_KEYS = [
+  'spotify', 'appleMusic', 'youtube', 'YouTubeMusic',
+  'instagram', 'facebook', 'linkedin', 'tiktok', 'twitter',
+  'bluesky', 'threads', 'soundcloud', 'deezer', 'tidal',
+  'bandcamp', 'amazonMusic', 'mixcloud', 'lastfm', 'songkick',
+  'bandsintown', 'shazam', 'patreon', 'medium', 'genius',
+  'audiomack', 'boomplay', 'napster', 'qobuz',
+] as const;
+
+export const ARTIST_SCHEMA_SAME_AS: string[] = [
+  ...SAME_AS_AUTHORITY,
+  ...SAME_AS_SOCIAL_KEYS
+    .map((key) => (social as Record<string, { url?: string }>)[key]?.url)
+    .filter((url): url is string => Boolean(url)),
+];
 
 export const ARTIST_SCHEMA_BASE = {
   '@type': 'Person',

--- a/src/data/artistData.ts
+++ b/src/data/artistData.ts
@@ -191,7 +191,7 @@ export const ARTIST = {
     audiomack: { url: 'https://audiomack.com/djzeneyer' },
     boomplay: { url: 'https://www.boomplay.com/artists/35157982' },
     napster: { url: 'https://us.napster.com/artist/art.626690096' },
-    qobuz: { url: 'https://www.qobuz.com/artist/7501129' },
+    qobuz: { url: 'https://play.qobuz.com/artist/4083033' },
     patreon: { url: 'https://www.patreon.com/djzeneyer' },
     medium: { url: 'https://medium.com/@djzeneyer' },
     reddit: { url: 'https://www.reddit.com/user/djzeneyer' },


### PR DESCRIPTION
## Resumo

Três correções feitas na sessão de 2026-06-02.

### 1. `security: remove unsafe-inline from CSP script-src`
O `'unsafe-inline'` estava presente no `inc/csp.php` junto com `'nonce-{$nonce}'` e `'strict-dynamic'`, o que anulava a proteção XSS do CSP. O nonce já cobre scripts inline legítimos — `unsafe-inline` era redundante e inseguro.

### 2. `data: add missing sameAs platforms and fix Qobuz ID`
Adicionadas 7 plataformas ausentes ao `ARTIST_SCHEMA_SAME_AS`: TikTok, X, Genius, Audiomack, Boomplay, Napster, Qobuz. Corrigido o ID do Qobuz de `7501129` (errado) para `4083033` (confirmado) em `artistData.ts`.

### 3. `refactor(schema): derive ARTIST_SCHEMA_SAME_AS from artistData (SSOT)`
A lista `ARTIST_SCHEMA_SAME_AS` em `artist.schema.ts` era hardcoded e duplicava URLs já definidas em `artistData.ts`. Agora é derivada automaticamente de `ARTIST.identifiers` e `ARTIST.social` — adicionar ou alterar uma plataforma requer editar apenas `artistData.ts`.

## Validação

```bash
npm run type-check
```

https://claude.ai/code/session_01QjoirBGW63iSwsYwEdnZUr

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjoirBGW63iSwsYwEdnZUr)_