### PR TITLE
fix: post-#653 CodeRabbit items — JSON-LD slug, catalog SEO/i18n, workflow hardening

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -31,6 +31,9 @@ jobs:
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+          persist-credentials: false
 
       - name: 🔧 Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -20,6 +20,9 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
+      with:
+        fetch-depth: 2
+        persist-credentials: false
 
     - name: Setup Node.js
       uses: actions/setup-node@v6

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -36,6 +36,9 @@ jobs:
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+          persist-credentials: false
 
       - name: 🔨 Build plugin dependencies (Composer)
         run: |

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -42,6 +42,9 @@ jobs:
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+          persist-credentials: false
 
       - name: 🔧 Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -21,6 +21,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+          persist-credentials: false
 
       - name: Run Lighthouse CI
         uses: treosh/lighthouse-ci-action@v12

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -29,6 +29,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -458,6 +458,10 @@
   },
   "music_catalog_title": "Music Catalog",
   "music_catalog_description": "Tracks, edits and releases by DJ Zen Eyer with DJ-friendly metadata.",
+  "track": {
+    "bpm": "BPM",
+    "energy": "energy"
+  },
   "music_page_title": "Music Hub",
   "music_page_meta_desc": "Listen to the latest mixes and productions by DJ Zen Eyer",
   "music": {

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -457,6 +457,10 @@
   },
   "music_catalog_title": "Catálogo Musical",
   "music_catalog_description": "Faixas, edits e lançamentos do Zen Eyer com metadados para DJs.",
+  "track": {
+    "bpm": "BPM",
+    "energy": "energia"
+  },
   "music_page_title": "Hub de Música",
   "music_page_meta_desc": "Ouça as últimas mixagens e produções do Zen Eyer",
   "music": {

--- a/src/pages/music/catalog.tsx
+++ b/src/pages/music/catalog.tsx
@@ -1,6 +1,8 @@
 import { useTranslation } from 'react-i18next';
 import type { Track } from '../../types/music';
 import { tracks } from '../../data/tracks';
+import { HeadlessSEO } from '../../components/HeadlessSEO';
+import { safeUrl } from '../../utils/sanitize';
 
 export function MusicCatalogPage() {
   const { t } = useTranslation();
@@ -8,6 +10,8 @@ export function MusicCatalogPage() {
 
   return (
     <main className="mx-auto max-w-5xl px-4 py-12">
+      <HeadlessSEO title={t('music_catalog_title')} description={t('music_catalog_description')} />
+
       <header className="mb-8">
         <h1 className="text-3xl font-semibold tracking-tight">{t('music_catalog_title')}</h1>
         <p className="mt-2 text-sm text-zinc-300">
@@ -26,8 +30,8 @@ export function MusicCatalogPage() {
                 <h2 className="text-lg font-medium">{track.title}</h2>
                 <p className="text-xs text-zinc-400">
                   {track.primaryArtist}
-                  {track.bpm != null ? ` • ${track.bpm} BPM` : ''}
-                  {track.energy != null ? ` • ${track.energy} energy` : ''}
+                  {track.bpm != null ? ` • ${track.bpm} ${t('track.bpm')}` : ''}
+                  {track.energy != null ? ` • ${track.energy} ${t('track.energy')}` : ''}
                   {track.key != null ? ` • ${track.key}` : ''}
                 </p>
                 {track.moodTags.length > 0 && (
@@ -41,7 +45,7 @@ export function MusicCatalogPage() {
                 {track.links.map((link) => (
                   <a
                     key={`${track.id}-${link.platform}`}
-                    href={link.url}
+                    href={safeUrl(link.url, '#')}
                     target="_blank"
                     rel="noreferrer"
                     className="rounded-full bg-emerald-500/10 px-3 py-1 text-xs text-emerald-300 hover:bg-emerald-500/20 transition-colors"

--- a/src/utils/music.ts
+++ b/src/utils/music.ts
@@ -36,7 +36,8 @@ export function buildDiscographyListItems(
     !!url && !artistSocialUrls.has(url);
 
   return discography.map((release, index) => {
-    const releasePath = getNewsDetailPath(release.id);
+    const localizedSlug = release.newsSlugs?.[lang.slice(0, 2) as 'en' | 'pt'] || release.id;
+    const releasePath = getNewsDetailPath(localizedSlug);
     const releaseUrl = `${baseUrl}${releasePath}`;
 
     const schemaType =


### PR DESCRIPTION
Endereça todos os comentários válidos do CodeRabbit no PR #653.

## Changes

**`src/utils/music.ts`**
- `buildDiscographyListItems`: usava `release.id` para montar `releaseUrl` no JSON-LD, mas `buildReleaseCards` já resolve `newsSlugs[lang]`. URLs do schema agora batem com as rotas reais.

**`src/pages/music/catalog.tsx`**
- Adicionado `<HeadlessSEO>` (obrigatório para páginas públicas)
- Links passados por `safeUrl(url, '#')` conforme regra do projeto
- `'BPM'` e `'energy'` hardcoded substituídos por `t('track.bpm')` / `t('track.energy')`

**`src/locales/{en,pt}/translation.json`**
- Chaves `track.bpm` e `track.energy` adicionadas em paridade (EN: BPM/energy, PT: BPM/energia)

**`.github/workflows/*`**
- `fetch-depth: 2` e `persist-credentials: false` adicionados em todos os steps de checkout (ci-tests, quality-gate, contract-tests, deploy-backend, deploy-frontend, lighthouse)

https://claude.ai/code/session_01QjoirBGW63iSwsYwEdnZUr

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjoirBGW63iSwsYwEdnZUr)_