### PR TITLE
fix(i18n): translate EnergyLevel values in music catalog

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -460,7 +460,12 @@
   "music_catalog_description": "Tracks, edits and releases by DJ Zen Eyer with DJ-friendly metadata.",
   "track": {
     "bpm": "BPM",
-    "energy": "energy"
+    "energy": "energy",
+    "energy_level": {
+      "chill": "chill",
+      "medium": "medium",
+      "high": "high"
+    }
   },
   "music_page_title": "Music Hub",
   "music_page_meta_desc": "Listen to the latest mixes and productions by DJ Zen Eyer",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -459,7 +459,12 @@
   "music_catalog_description": "Faixas, edits e lançamentos do Zen Eyer com metadados para DJs.",
   "track": {
     "bpm": "BPM",
-    "energy": "energia"
+    "energy": "energia",
+    "energy_level": {
+      "chill": "relaxante",
+      "medium": "média",
+      "high": "alta"
+    }
   },
   "music_page_title": "Hub de Música",
   "music_page_meta_desc": "Ouça as últimas mixagens e produções do Zen Eyer",

--- a/src/pages/music/catalog.tsx
+++ b/src/pages/music/catalog.tsx
@@ -31,7 +31,7 @@ export function MusicCatalogPage() {
                 <p className="text-xs text-zinc-400">
                   {track.primaryArtist}
                   {track.bpm != null ? ` • ${track.bpm} ${t('track.bpm')}` : ''}
-                  {track.energy != null ? ` • ${track.energy} ${t('track.energy')}` : ''}
+                  {track.energy != null ? ` • ${t(`track.energy_level.${track.energy}`)} ${t('track.energy')}` : ''}
                   {track.key != null ? ` • ${track.key}` : ''}
                 </p>
                 {track.moodTags.length > 0 && (


### PR DESCRIPTION
Follow-up do PR #654 — corrige violação de i18n HIGH identificada pelo Gemini.

`track.energy` é um union tipado (`'chill' | 'medium' | 'high'`) que estava sendo renderizado diretamente na tela. Usuários em PT veriam "chill energia" / "high energia" (inglês misturado).

## Changes

- `t('track.energy_level.X')` para traduzir o nível antes de exibir
- EN: chill / medium / high
- PT: relaxante / média / alta

https://claude.ai/code/session_01QjoirBGW63iSwsYwEdnZUr

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjoirBGW63iSwsYwEdnZUr)_