### PR TITLE
fix(security): incomplete URL substring sanitization in test helpers

### DIFF
--- a/src/__tests__/pages/HomePage.test.tsx
+++ b/src/__tests__/pages/HomePage.test.tsx
@@ -123,18 +123,22 @@ describe('HomePage — render', () => {
     renderPage();
     const links = screen.getAllByRole('link');
     const hrefs = links.map((l) => l.getAttribute('href') ?? '');
-    const hostname = (href: string) => { try { return new URL(href).hostname; } catch { return ''; } };
-    expect(hrefs.some((h) => hostname(h).endsWith('wikidata.org'))).toBe(true);
-    expect(hrefs.some((h) => hostname(h).endsWith('musicbrainz.org'))).toBe(true);
-    expect(hrefs.some((h) => hostname(h).endsWith('spotify.com'))).toBe(true);
+    const matchesDomain = (href: string, domain: string) => {
+      try { const h = new URL(href).hostname; return h === domain || h.endsWith(`.${domain}`); } catch { return false; }
+    };
+    expect(hrefs.some((h) => matchesDomain(h, 'wikidata.org'))).toBe(true);
+    expect(hrefs.some((h) => matchesDomain(h, 'musicbrainz.org'))).toBe(true);
+    expect(hrefs.some((h) => matchesDomain(h, 'spotify.com'))).toBe(true);
   });
 
   it('renders SoundCloud listen link', () => {
     renderPage();
     const links = screen.getAllByRole('link');
     const hrefs = links.map((l) => l.getAttribute('href') ?? '');
-    const hostname = (href: string) => { try { return new URL(href).hostname; } catch { return ''; } };
-    expect(hrefs.some((h) => hostname(h).endsWith('soundcloud.com'))).toBe(true);
+    const matchesDomain = (href: string, domain: string) => {
+      try { const h = new URL(href).hostname; return h === domain || h.endsWith(`.${domain}`); } catch { return false; }
+    };
+    expect(hrefs.some((h) => matchesDomain(h, 'soundcloud.com'))).toBe(true);
   });
 
   it('renders stats section with champion value', () => {

--- a/src/__tests__/pages/HomePage.test.tsx
+++ b/src/__tests__/pages/HomePage.test.tsx
@@ -124,7 +124,7 @@ describe('HomePage — render', () => {
     const links = screen.getAllByRole('link');
     const hrefs = links.map((l) => l.getAttribute('href') ?? '');
     const matchesDomain = (href: string, domain: string) => {
-      try { const h = new URL(href).hostname; return h === domain || h.endsWith(`.${domain}`); } catch { return false; }
+      try { const h = new URL(href, 'http://localhost').hostname; return h === domain || h.endsWith(`.${domain}`); } catch { return false; }
     };
     expect(hrefs.some((h) => matchesDomain(h, 'wikidata.org'))).toBe(true);
     expect(hrefs.some((h) => matchesDomain(h, 'musicbrainz.org'))).toBe(true);
@@ -136,7 +136,7 @@ describe('HomePage — render', () => {
     const links = screen.getAllByRole('link');
     const hrefs = links.map((l) => l.getAttribute('href') ?? '');
     const matchesDomain = (href: string, domain: string) => {
-      try { const h = new URL(href).hostname; return h === domain || h.endsWith(`.${domain}`); } catch { return false; }
+      try { const h = new URL(href, 'http://localhost').hostname; return h === domain || h.endsWith(`.${domain}`); } catch { return false; }
     };
     expect(hrefs.some((h) => matchesDomain(h, 'soundcloud.com'))).toBe(true);
   });

--- a/src/__tests__/pages/MediaPage.test.tsx
+++ b/src/__tests__/pages/MediaPage.test.tsx
@@ -96,10 +96,12 @@ describe('MediaPage — render', () => {
     renderPage();
     const links = screen.getAllByRole('link');
     const hrefs = links.map((l) => l.getAttribute('href') ?? '');
-    const hostname = (href: string) => { try { return new URL(href).hostname; } catch { return ''; } };
-    expect(hrefs.some((h) => hostname(h).endsWith('wikidata.org'))).toBe(true);
-    expect(hrefs.some((h) => hostname(h).endsWith('musicbrainz.org'))).toBe(true);
-    expect(hrefs.some((h) => hostname(h).endsWith('discogs.com'))).toBe(true);
+    const matchesDomain = (href: string, domain: string) => {
+      try { const h = new URL(href).hostname; return h === domain || h.endsWith(`.${domain}`); } catch { return false; }
+    };
+    expect(hrefs.some((h) => matchesDomain(h, 'wikidata.org'))).toBe(true);
+    expect(hrefs.some((h) => matchesDomain(h, 'musicbrainz.org'))).toBe(true);
+    expect(hrefs.some((h) => matchesDomain(h, 'discogs.com'))).toBe(true);
   });
 
   it('renders published works in the clipping list', () => {

--- a/src/__tests__/pages/MediaPage.test.tsx
+++ b/src/__tests__/pages/MediaPage.test.tsx
@@ -97,7 +97,7 @@ describe('MediaPage — render', () => {
     const links = screen.getAllByRole('link');
     const hrefs = links.map((l) => l.getAttribute('href') ?? '');
     const matchesDomain = (href: string, domain: string) => {
-      try { const h = new URL(href).hostname; return h === domain || h.endsWith(`.${domain}`); } catch { return false; }
+      try { const h = new URL(href, 'http://localhost').hostname; return h === domain || h.endsWith(`.${domain}`); } catch { return false; }
     };
     expect(hrefs.some((h) => matchesDomain(h, 'wikidata.org'))).toBe(true);
     expect(hrefs.some((h) => matchesDomain(h, 'musicbrainz.org'))).toBe(true);


### PR DESCRIPTION
## Problem

CodeQL flagged 7 high-severity alerts in test files (`HomePage.test.tsx` lines 127-129/137, `MediaPage.test.tsx` lines 100-102) for **"Incomplete URL substring sanitization"**.

The pattern `hostname(h).endsWith('wikidata.org')` is insecure because `"fakewikidata.org".endsWith("wikidata.org")` is `true` — an attacker-controlled URL with a domain that merely ends with the target domain passes the check.

## Fix

Replace the `endsWith` hostname helper with a `matchesDomain` helper that requires either exact equality or a leading dot:

```ts
const matchesDomain = (href: string, domain: string) => {
  try { const h = new URL(href).hostname; return h === domain || h.endsWith(`.${domain}`); }
  catch { return false; }
};
```

This ensures `fakewikidata.org` ≠ `wikidata.org` and `something.wikidata.org` ✓ still passes.

## Test plan

- [ ] All 285 unit tests pass (`npm test`)
- [ ] CodeQL alerts #83–#89 resolved after merge

https://claude.ai/code/session_015q8aQY4GRAWugYxZ65ubyY

---
_Generated by [Claude Code](https://claude.ai/code/session_015q8aQY4GRAWugYxZ65ubyY)_