### PR TITLE
ci(lighthouse): run audit only after deploy completes

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,7 +1,9 @@
 name: Lighthouse Audit
 
 on:
-  push:
+  workflow_run:
+    workflows: ["🚀 Deploy Frontend"]
+    types: [completed]
     branches: [main]
   workflow_dispatch:
 
@@ -17,6 +19,7 @@ jobs:
     name: Audit djzeneyer.com
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Problema

O Lighthouse rodava em paralelo com o deploy (`on: push: branches: [main]`), o que significa que podia terminar antes do site novo estar no ar e auditar a versão anterior — resultados sempre defasados.

## Solução

Substituído o trigger `push` por `workflow_run` apontando para o workflow "🚀 Deploy Frontend". O Lighthouse agora só roda depois que o deploy conclui com sucesso.

A condição `if` garante que:
- Se o deploy falhou → Lighthouse **não roda** (não faz sentido auditar site quebrado)
- Se disparado manualmente (`workflow_dispatch`) → roda normalmente

## Mudança

```yaml
# Antes
on:
  push:
    branches: [main]

# Depois
on:
  workflow_run:
    workflows: ["🚀 Deploy Frontend"]
    types: [completed]
    branches: [main]
```

https://claude.ai/code/session_015q8aQY4GRAWugYxZ65ubyY

---
_Generated by [Claude Code](https://claude.ai/code/session_015q8aQY4GRAWugYxZ65ubyY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Aprimoramento da automação do fluxo de auditoria de desempenho. A auditoria agora executa automaticamente após implantações bem-sucedidas ou pode ser acionada manualmente conforme necessário, proporcionando maior flexibilidade operacional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->