### PR TITLE
feat(auth): lazy /settings fetch — Option D implementation

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,7 +1,9 @@
 name: Lighthouse Audit
 
 on:
-  push:
+  workflow_run:
+    workflows: ["🚀 Deploy Frontend"]
+    types: [completed]
     branches: [main]
   workflow_dispatch:
 
@@ -17,6 +19,7 @@ jobs:
     name: Audit djzeneyer.com
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Checkout

--- a/src/components/auth/AuthModal.tsx
+++ b/src/components/auth/AuthModal.tsx
@@ -1,7 +1,7 @@
 // src/components/auth/AuthModal.tsx
 // VERSÃO DEFINITIVA: SEGURANÇA MÁXIMA (Turnstile + Honeypot) + UX PREMIUM
 
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
 import { X, Mail, Lock, User, Loader2, AlertCircle, Eye, EyeOff } from 'lucide-react';
@@ -47,7 +47,14 @@ const AuthModal: React.FC<AuthModalProps> = ({ isOpen, onClose, onSuccess }) => 
 
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
-  const { login, register, googleLogin, googleClientId } = useUser();
+  const { login, register, googleLogin, googleClientId, loadGoogleClientId } = useUser();
+
+  // Opção D: busca o Google Client ID apenas quando o modal abre
+  useEffect(() => {
+    if (isOpen) {
+      loadGoogleClientId();
+    }
+  }, [isOpen, loadGoogleClientId]);
   const currentLang = useMemo(() => normalizeLanguage(i18n.language), [i18n.language]);
 
   // Estados do Formulário

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -32,6 +32,8 @@ interface UserContextType {
   requestPasswordReset: (email: string) => Promise<void>;
   resetPassword: (key: string, login: string, password: string) => Promise<void>;
   clearError: () => void;
+  // Opção D: busca o Google Client ID sob demanda (chamado pelo AuthModal ao abrir)
+  loadGoogleClientId: () => Promise<void>;
 }
 
 const UserContext = createContext<UserContextType | undefined>(undefined);
@@ -63,74 +65,70 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
   }, []);
 
   // ========================================================================
-  // INICIALIZAÇÃO
+  // INICIALIZAÇÃO — Opção D: sem fetch de /settings no mount
+  // Sessão restaurada imediatamente do localStorage; /settings só é buscado
+  // quando AuthModal abre (via loadGoogleClientId).
   // ========================================================================
   useEffect(() => {
-    const init = async () => {
+    const token = localStorage.getItem('zen_jwt');
+    const savedUser = localStorage.getItem('zen_user');
+
+    if (token && savedUser) {
       try {
-        // 1. Busca Google Client ID
-        const settingsRes = await fetch(`${API_URL}/settings`);
-        const settingsText = await settingsRes.text();
+        const parsedUser = JSON.parse(savedUser);
+        setUser({ ...parsedUser, token, isLoggedIn: true });
 
-        if (settingsText.trim().startsWith('<!DOCTYPE') || settingsText.trim().startsWith('<html')) {
-          console.error('[UserContext] ❌ ERRO: Backend retornou HTML ao invés de JSON!');
-          console.error('[UserContext] 💡 Possíveis causas:');
-          console.error('  1. Plugin ZenEyer Auth não está ativo');
-          console.error('  2. Rewrite rules não foram flushed (wp rewrite flush)');
-          console.error('  3. .htaccess bloqueando o endpoint');
-          setError('Plugin de autenticação não está configurado. Contate o administrador.');
-          setLoadingInitial(false);
-          return;
-        }
-
-        const settingsData = JSON.parse(settingsText);
-
-        if (settingsData.success && settingsData.data.google_client_id) {
-          setGoogleClientId(settingsData.data.google_client_id);
-        } else {
-          console.warn('[UserContext] ⚠️ Google Client ID não configurado');
-        }
-
-        // 2. Restaura Sessão
-        const token = localStorage.getItem('zen_jwt');
-        const savedUser = localStorage.getItem('zen_user');
-
-        if (token && savedUser) {
-          const parsedUser = JSON.parse(savedUser);
-          // Garante que o token de zen_jwt esteja sempre presente no user,
-          // mesmo se zen_user foi salvo por versão anterior sem o campo token.
-          setUser({ ...parsedUser, token, isLoggedIn: true });
-
-          // Validação silenciosa
-          queryClient.fetchQuery({
-            queryKey: QUERY_KEYS.user.session(Boolean(token)),
-            queryFn: () => fetchAuthSessionFn(token),
-            staleTime: 0,
+        // Valida token em background sem bloquear a UI
+        queryClient.fetchQuery({
+          queryKey: QUERY_KEYS.user.session(Boolean(token)),
+          queryFn: () => fetchAuthSessionFn(token),
+          staleTime: 0,
+        })
+          .then(data => {
+            if (!data.authenticated) {
+              logout();
+              return;
+            }
+            if (data.user) {
+              saveSession(data.user, token);
+            }
           })
-            .then(data => {
-              if (!data.authenticated) {
-                logout();
-                return;
-              }
-
-              if (data.user) {
-                saveSession(data.user, token);
-              }
-            })
-            .catch(err => {
-              console.error('[UserContext] ❌ Erro na validação:', err);
-            });
-        }
+          .catch(err => {
+            console.error('[UserContext] ❌ Erro na validação:', err);
+          });
       } catch (err) {
-        console.error('[UserContext] ❌ Falha na inicialização:', err);
-        setError('Erro ao conectar com o servidor de autenticação');
-      } finally {
-        setLoadingInitial(false);
+        console.error('[UserContext] ❌ Erro ao restaurar sessão:', err);
+        logout();
       }
-    };
+    }
 
-    init();
-  }, [API_URL, logout, saveSession]);
+    setLoadingInitial(false);
+  }, [logout, saveSession]);
+
+  // ========================================================================
+  // LOAD GOOGLE CLIENT ID — chamado pelo AuthModal ao abrir
+  // Falha isolada: apenas oculta botão Google, email login continua
+  // ========================================================================
+  const loadGoogleClientId = useCallback(async () => {
+    if (googleClientId !== null) return;
+    try {
+      const res = await fetch(`${API_URL}/settings`);
+      const text = await res.text();
+      if (text.trim().startsWith('<!DOCTYPE') || text.trim().startsWith('<html')) {
+        console.warn('[UserContext] ⚠️ /settings retornou HTML — Google OAuth indisponível');
+        return;
+      }
+      const data = JSON.parse(text);
+      if (data.success && data.data?.google_client_id) {
+        setGoogleClientId(data.data.google_client_id);
+      } else {
+        console.warn('[UserContext] ⚠️ Google Client ID não configurado no backend');
+      }
+    } catch (err) {
+      console.warn('[UserContext] ⚠️ Falha ao carregar /settings — Google OAuth indisponível:', err);
+      // Não propaga: email login continua funcionando normalmente
+    }
+  }, [API_URL, googleClientId]);
 
 
 
@@ -316,7 +314,6 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
 
   const clearError = useCallback(() => setError(null), []);
 
-  // ⚡ Bolt: Wrapped context value with useMemo to prevent unnecessary re-renders of all consumer components when Provider re-renders.
   const value = useMemo(() => ({
     user,
     googleClientId,
@@ -330,7 +327,8 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     logout,
     requestPasswordReset,
     resetPassword,
-    clearError
+    clearError,
+    loadGoogleClientId,
   }), [
     user,
     googleClientId,
@@ -343,7 +341,8 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     logout,
     requestPasswordReset,
     resetPassword,
-    clearError
+    clearError,
+    loadGoogleClientId,
   ]);
 
   // ========================================================================


### PR DESCRIPTION
Fechando esta PR pois a implementação foi superada pela #676, que usa o padrão correto do TanStack Query v5 com `enabled: boolean` para lazy loading. A abordagem da #676 é mais idiomática e não duplica estado no Context.