### PR TITLE
ci: Hardcode SSH known hosts para deployment

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -56,7 +56,10 @@ jobs:
         uses: shimataro/ssh-key-action@v2
         with:
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
+          known_hosts: |
+            |1|TNUVcyD1aWr2wGYOmlQPeemFgTE=|5B1Q6wvwM69bU8G3GUrrKiRut0o= ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDShI+yYwF5uYrL7PTxqcZtl3B7EouJcdgS233vGtyRePOflah2WGeZZIT5DFHKxwlMfhSC0wKjLJa4wwTKZpIT4j7bH07h5iHm8XFmeOdU6kv0pu4W+7nLmVDZzh82/0iodYw1XgRfunt1K+JhCmHIOnWDaf6C80DtOZR4YcpeJAbyKSWhQTNhUm5oN3u1b703M1iomP6KCs8Jf7hiR0FOWFCsJ4qE1AR80I0RIigpdAJPieEHjyglsxRXvR90oCYNyNbAuOMF6H7gMKY5FsQyoe3DiOJWKbyad20CqheFB0hBkqaxwTtil2xW6xG6ZT8ELTuZp5QEzp3lJUrtC/YiKyfNLoJq7tFEyTGjVzkA1FJdxE7q7CZlc4WgmGmWbPZWF/cMSIKt4VAZeizZayrFOtPZmicdCAqwZXEerTONhtLs+IEF+/mGcadNZlyqop5mgegNoM1Cs21zRqQIn06WOZEX7nr/zra/snQiODJ2d+afOED1o+NSIHHApFZNWSU=
+            |1|/fdbloAM89tpWbUllaYu487m+XE=|6vm64/rMpLGUlMAoh8eC3hF7HAY= ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFxQCICOTF37QQ0qOp8sP5FxG9Na/euvpJY66hO14H6atxwu3wCoNXHhiY8nRUxmq4yzhDsEuklJuVWM+4vSDPY=
+            |1|j3r8EBK800IPfRXohTW0XOek1Ks=|Vp6bWwZs1aymxjlr/UZPDreSUs8= ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ3BBPDXxVSsh7zTZu2jBnm08DuW6HYGb6V4fKXFCSyD
           name: id_rsa
 
       - name: 🔌 Deploy plugins/

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -95,7 +95,10 @@ jobs:
         uses: shimataro/ssh-key-action@v2
         with:
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
+          known_hosts: |
+            |1|TNUVcyD1aWr2wGYOmlQPeemFgTE=|5B1Q6wvwM69bU8G3GUrrKiRut0o= ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDShI+yYwF5uYrL7PTxqcZtl3B7EouJcdgS233vGtyRePOflah2WGeZZIT5DFHKxwlMfhSC0wKjLJa4wwTKZpIT4j7bH07h5iHm8XFmeOdU6kv0pu4W+7nLmVDZzh82/0iodYw1XgRfunt1K+JhCmHIOnWDaf6C80DtOZR4YcpeJAbyKSWhQTNhUm5oN3u1b703M1iomP6KCs8Jf7hiR0FOWFCsJ4qE1AR80I0RIigpdAJPieEHjyglsxRXvR90oCYNyNbAuOMF6H7gMKY5FsQyoe3DiOJWKbyad20CqheFB0hBkqaxwTtil2xW6xG6ZT8ELTuZp5QEzp3lJUrtC/YiKyfNLoJq7tFEyTGjVzkA1FJdxE7q7CZlc4WgmGmWbPZWF/cMSIKt4VAZeizZayrFOtPZmicdCAqwZXEerTONhtLs+IEF+/mGcadNZlyqop5mgegNoM1Cs21zRqQIn06WOZEX7nr/zra/snQiODJ2d+afOED1o+NSIHHApFZNWSU=
+            |1|/fdbloAM89tpWbUllaYu487m+XE=|6vm64/rMpLGUlMAoh8eC3hF7HAY= ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFxQCICOTF37QQ0qOp8sP5FxG9Na/euvpJY66hO14H6atxwu3wCoNXHhiY8nRUxmq4yzhDsEuklJuVWM+4vSDPY=
+            |1|j3r8EBK800IPfRXohTW0XOek1Ks=|Vp6bWwZs1aymxjlr/UZPDreSUs8= ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ3BBPDXxVSsh7zTZu2jBnm08DuW6HYGb6V4fKXFCSyD
           name: id_rsa
 
       - name: 📦 Prepare and Backup Remote


### PR DESCRIPTION
## Descrição

Este PR substitui o placeholder `unnecessary` no campo `known_hosts` pela saída real do comando `ssh-keyscan -H -p 65002 147.79.84.222`.

### O que foi feito?
- Rodamos localmente o keyscan para o servidor de produção.
- Inserimos as chaves públicas (RSA, ECDSA e ED25519) diretamente nos arquivos YAML (deploy-backend.yml e deploy-frontend.yml).
- Com isso, eliminamos a necessidade de criar um secret no GitHub para uma chave que já é pública.

### Por que isso foi feito?
Anteriormente, os workflows usavam `unnecessary`, o que seria substituído por um secret. Como a chave é pública, a abordagem mais direta e simples foi hardcodar o valor no próprio repositório, garantindo uma verificação de host segura via SSH sem envolver criptografia de secrets desnecessária.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Diretório de Festivais de Zouk agora indexável e otimizado para mecanismos de busca e IA
  * Validação automática de invariantes SEO integrada ao pipeline de CI/CD

* **Bug Fixes**
  * Corrigido tratamento de URLs canônicas durante pré-renderização do site
  * Melhorada acessibilidade com rótulos ARIA em elementos interativos

* **Style**
  * Ajustado destaque visual de rodapé com melhor contraste de identificadores

* **Chores**
  * Atualizado nomenclatura de campeonatos para consistência global
  * Otimizações nas configurações de deploy e cache

<!-- end of auto-generated comment: release notes by coderabbit.ai -->