### PR TITLE
chore(dx): add husky pre-commit hook + .editorconfig to prevent mojibake

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.php]
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+# Bloqueia commits com mojibake (UTF-8 corrompido) em PHP e JS/TS
+npm run utf8:check

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "eslint-plugin-react": "^7.34.3",
         "eslint-plugin-react-hooks": "^7.1.1",
         "globals": "^17.6.0",
+        "husky": "^9.1.7",
         "jsdom": "^29.1.1",
         "msw": "^2.10.2",
         "postcss": "^8.5.8",
@@ -4124,6 +4125,22 @@
       "license": "MIT",
       "dependencies": {
         "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/i18next": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "perf:baseline": "node scripts/perf-baseline.mjs",
     "perf:budget": "node scripts/check-performance-budget.mjs",
     "rollback": "node scripts/rollback.js",
-    "indexnow": "node scripts/submit-indexnow.mjs"
+    "indexnow": "node scripts/submit-indexnow.mjs",
+    "prepare": "husky"
   },
   "dependencies": {
     "@marsidev/react-turnstile": "^1.5.2",
@@ -60,6 +61,7 @@
     "eslint-plugin-react": "^7.34.3",
     "eslint-plugin-react-hooks": "^7.1.1",
     "globals": "^17.6.0",
+    "husky": "^9.1.7",
     "jsdom": "^29.1.1",
     "msw": "^2.10.2",
     "postcss": "^8.5.8",


### PR DESCRIPTION
## Problema

Mojibake (UTF-8 corrompido como Windows-1252) reaparece toda hora. Até agora dependíamos do `npm run utf8:check` no CI para detectar — mas o CI só roda depois do push, e o dano já foi propagado em commits anteriores.

## Solução em 2 camadas

### Camada 1 — `.husky/pre-commit`
Bloqueia o commit antes que o código corrompido chegue ao repositório:
```sh
npm run utf8:check  # já cobre 76 arquivos PHP em inc/ e plugins/
```
Qualquer caractere IPA ou acento corrompido → commit rejeitado na hora, com mensagem clara.

### Camada 2 — `.editorconfig`
Configura o editor para salvar como UTF-8 desde o início:
- `charset = utf-8` para todos os arquivos
- LF line endings
- `indent_size = 4` para PHP, `2` para JS/TS
- Suportado por VS Code, JetBrains, Vim, Emacs, etc.

## Root cause

Arquivos PHP abertos em editores sem charset explícito eram salvos como Windows-1252. EditorConfig previne o mis-save; husky previne o mis-commit.

## Impacto

Nenhuma mudança de lógica. Zero risco de regressão. Só DX.

https://claude.ai/code/session_015q8aQY4GRAWugYxZ65ubyY

---
_Generated by [Claude Code](https://claude.ai/code/session_015q8aQY4GRAWugYxZ65ubyY)_