### PR TITLE
Polish route fallback and IndexNow deploy handling

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -165,6 +165,7 @@ jobs:
             php -r "opcache_reset();" 2>/dev/null || true
 
       - name: 📡 Submit URLs to IndexNow
+        continue-on-error: true
         env:
           INDEXNOW_STRICT: 'true'
         run: |

--- a/src/components/AppRoutes.tsx
+++ b/src/components/AppRoutes.tsx
@@ -12,9 +12,15 @@ import {
 
 const STANDALONE_ROUTE_KEYS = new Set(['zenlink']);
 
+const RouteFallback = () => (
+  <div className="min-h-[60vh] flex items-center justify-center bg-background" role="status" aria-label="Loading page">
+    <div className="h-12 w-12 animate-spin rounded-full border-2 border-primary/30 border-t-primary" />
+  </div>
+);
+
 const wrapRouteElement = (Component: ComponentType) => (
   <ErrorBoundary>
-    <Suspense fallback={null}>
+    <Suspense fallback={<RouteFallback />}>
       <Component />
     </Suspense>
   </ErrorBoundary>


### PR DESCRIPTION
## Summary
- show a real route-level loading spinner instead of rendering nothing while lazy route chunks load
- keep IndexNow strict diagnostics visible without marking an already-published frontend deploy as failed

## Context
PR #684 is merged and deployed. The rerun deployed successfully through dist activation, public assets, and cache purge, but IndexNow still returns provider-side 403 authorization even though the key file is publicly verifiable. This follow-up keeps deployment status aligned with publication while preserving the IndexNow failure in logs.

## Validation
- npm run type-check
- npm run lint
- npm test
- npm run build
- npm run seo:check
- npm run utf8:check
- npm run perf:budget

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Melhorias de UX**
  * Adicionado indicador visual de carregamento (spinner) ao navegar entre páginas, proporcionando feedback melhor durante o carregamento de componentes.

* **Infraestrutura**
  * Melhorada a robustez do processo de deploy para evitar interrupções no workflow de publicação em caso de falhas na submissão de URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->