### PR TITLE
Stabilize listing page layout height

### DIFF
--- a/src/components/AppRoutes.tsx
+++ b/src/components/AppRoutes.tsx
@@ -1,5 +1,6 @@
 import { ComponentType, Suspense } from 'react';
-import { useRoutes, RouteObject } from 'react-router-dom';
+import { useRoutes, RouteObject, useLocation } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import MainLayout from '../layouts/MainLayout';
 import ErrorBoundary from './common/ErrorBoundary';
 import {
@@ -12,11 +13,28 @@ import {
 
 const STANDALONE_ROUTE_KEYS = new Set(['zenlink']);
 
-const RouteFallback = () => (
-  <div className="min-h-[60vh] flex items-center justify-center bg-background" role="status" aria-label="Loading page">
-    <div className="h-12 w-12 animate-spin rounded-full border-2 border-primary/30 border-t-primary" />
-  </div>
-);
+const LISTING_FALLBACK_PATHS = [
+  '/zouk-events',
+  '/pt/eventos-zouk',
+  '/releases',
+  '/pt/lancamentos',
+];
+
+const RouteFallback = () => {
+  const { t } = useTranslation();
+  const { pathname } = useLocation();
+  const reservesListingHeight = LISTING_FALLBACK_PATHS.some((path) => pathname.startsWith(path));
+
+  return (
+    <div
+      className={`${reservesListingHeight ? 'min-h-[1600px]' : 'min-h-[60vh]'} flex items-start justify-center bg-background pt-32`}
+      role="status"
+      aria-label={t('common.loading_page', { defaultValue: 'Loading page' })}
+    >
+      <div className="h-12 w-12 animate-spin rounded-full border-2 border-primary/30 border-t-primary" />
+    </div>
+  );
+};
 
 const wrapRouteElement = (Component: ComponentType) => (
   <ErrorBoundary>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -88,6 +88,7 @@
     "cnpj": "44.063.765/0001-46",
     "isni": "0000 0005 2893 1015",
     "loading": "Loading…",
+    "loading_page": "Loading page",
     "copy": "Copy",
     "retry": "Try again",
     "close": "Close",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -119,6 +119,7 @@
     "cnpj": "44.063.765/0001-46",
     "isni": "0000 0005 2893 1015",
     "loading": "Carregando…",
+    "loading_page": "Carregando página",
     "copy": "Copiar",
     "retry": "Tentar novamente",
     "close": "Fechar",

--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -352,7 +352,7 @@ const EventsPage: React.FC = () => {
           </h1>
         </header>
 
-        <React.Suspense fallback={<EventSkeleton />}>
+        <React.Suspense fallback={<div className="min-h-[1600px]"><EventSkeleton /></div>}>
           <EventListContent lang={lang} />
         </React.Suspense>
 

--- a/src/pages/NewsPage.tsx
+++ b/src/pages/NewsPage.tsx
@@ -372,7 +372,7 @@ const NewsPage: React.FC = () => {
             </section>
           )}
 
-          <div className="min-h-[1200px]">
+          <div className={loading ? 'min-h-[1600px]' : ''}>
           {loading ? (
             <div className="animate-pulse space-y-8" aria-busy="true" aria-label={t('common.loading')}>
               <div className="aspect-[16/9] bg-white/5 rounded-2xl w-full" />


### PR DESCRIPTION
## Summary
- reserve stable vertical space for lazy route fallback while chunks hydrate
- reserve stable vertical space for the events listing content and fallback
- increase the releases/news listing reserve from 1200px to 1600px

## Lighthouse evidence
From the provided lighthouse-results.zip:
- /pt/eventos-zouk/: CLS 0.315, main culprit footer shift
- /releases: CLS 0.376-0.417, main culprit footer shift
- Home already has CLS 0 and performance 92-100

The goal is to prevent the footer from moving while async/lazy listing content replaces the initial fallback/prerender state.

## Validation
- npm run type-check
- npm run lint
- npm test
- npm run build
- npm run seo:check
- npm run utf8:check
- npm run perf:budget

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Style**
  * Realinhados componentes de carregamento com ajustes de espaçamento para melhor aproveitamento de espaço vertical na tela, oferecendo experiência visual mais aprimorada durante estados de carregamento de conteúdo
  * Padronizados valores de altura mínima em páginas de eventos, notícias e componentes de rota para uma apresentação visual mais consistente e profissional

<!-- end of auto-generated comment: release notes by coderabbit.ai -->