### PR TITLE
Improve agent discovery metadata

### DIFF
--- a/inc/agent-discovery.php
+++ b/inc/agent-discovery.php
@@ -24,6 +24,7 @@ function djz_agent_discovery_link_header_value(): string
         '</.well-known/mcp/server-card.json>; rel="service-desc"; type="application/json", ' .
         '</.well-known/agent-skills/index.json>; rel="service-desc"; type="application/json", ' .
         '</.well-known/oauth-protected-resource>; rel="oauth-protected-resource"; type="application/json", ' .
+        '</auth.md>; rel="service-doc"; type="text/markdown", ' .
         '</.well-known/auth.md>; rel="service-doc"; type="text/markdown", ' .
         '</llms.txt>; rel="service-doc"; type="text/plain", ' .
         '</llms-full.txt>; rel="describedby"; type="text/plain"';

--- a/public/auth.md
+++ b/public/auth.md
@@ -1,0 +1,45 @@
+# Zen Eyer Agent Authentication
+
+Zen Eyer publishes public AI discovery resources for reading, grounding, SEO, booking context, music metadata, and event context. These public resources do not require authentication.
+
+## Public Access
+
+The following resources are available without credentials:
+
+- `https://djzeneyer.com/llms.txt`
+- `https://djzeneyer.com/llms-full.txt`
+- `https://djzeneyer.com/.well-known/api-catalog`
+- `https://djzeneyer.com/.well-known/ai-plugin.json`
+- `https://djzeneyer.com/.well-known/agent-skills/index.json`
+- `https://djzeneyer.com/.well-known/mcp/server-card.json`
+- `https://djzeneyer.com/wp-json/djzeneyer/v1/ai-context`
+
+## Agent Registration
+
+Agents that prefer an explicit registration flow can request an informational public-read token:
+
+```http
+POST https://djzeneyer.com/wp-json/djzeneyer/v1/agent-registration
+Content-Type: application/json
+
+{
+  "type": "user_claimed",
+  "audience": "https://djzeneyer.com",
+  "scope": ["public:read"]
+}
+```
+
+The returned token grants no private access. It only confirms that the agent discovered the public-read registration flow. Public endpoints remain readable without a token.
+
+## Protected User APIs
+
+Authenticated user-account APIs, orders, profile data, and newsletter preferences use the site's existing WordPress/JWT authentication. Autonomous agent registration is not allowed to create or access private user accounts.
+
+## Discovery
+
+OAuth-style discovery documents:
+
+- Protected resource metadata: `https://djzeneyer.com/.well-known/oauth-protected-resource`
+- Authorization server metadata: `https://djzeneyer.com/.well-known/oauth-authorization-server`
+
+Contact: `booking@djzeneyer.com`

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,7 +4,7 @@
 
 User-agent: *
 Allow: /
-# Content-Signal: ai-train=yes, search=yes, ai-input=yes
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
 Allow: /wp-json/djzeneyer/v1/ai-context
 Disallow: /wp-admin/
 Disallow: /wp-login.php
@@ -165,7 +165,7 @@ User-agent: BraveBot
 User-agent: Qwenbot
 User-agent: MistralBot
 Allow: /
-# Content-Signal: ai-train=yes, search=yes, ai-input=yes
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
 Allow: /wp-json/djzeneyer/v1/ai-context
 Disallow: /wp-admin/
 Disallow: /wp-login.php


### PR DESCRIPTION
## Summary
- Enable Content-Signal directives in both robots.txt wildcard and AI crawler groups
- Add root /auth.md with the same public agent authentication guidance as /.well-known/auth.md

## Validation
- npm run seo:check
- npm run utf8:check
- git diff --check
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Adicionada documentação abrangente sobre fluxo de autenticação e autorização, detalhando recursos públicos, processo de registro para agentes, endpoints protegidos e recursos de descoberta.

* **Chores**
  * Ativadas diretivas de controle de acesso para bots de busca e sistemas de IA.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->