### PR TITLE
feat: Web Bot Auth — publish Ed25519 JWKS for signed outbound agent requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,11 @@ THEME_NAME=djzeneyer
 # ============================================================================
 CLOUDFLARE_API_TOKEN=
 CLOUDFLARE_ZONE_ID=
+
+# ============================================================================
+# WEB BOT AUTH — RFC 9421 HTTP Message Signatures
+# Public key published at /.well-known/http-message-signatures-directory (JWKS)
+# Private key must NEVER be committed — store as GitHub Secret: WEB_BOT_AUTH_PRIVATE_KEY_D
+# kid: djzeneyer-bot-v2 (Ed25519)
+# ============================================================================
+WEB_BOT_AUTH_PRIVATE_KEY_D=

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -302,6 +302,15 @@ RewriteRule ^pt/index\.html$ /pt/ [R=301,L]
   </IfModule>
 </Files>
 
+<Files "http-message-signatures-directory">
+  ForceType application/jwk-set+json
+  <IfModule mod_headers.c>
+    Header set Content-Type "application/jwk-set+json"
+    Header set Cache-Control "public, max-age=86400, stale-while-revalidate=3600"
+    Header always set Access-Control-Allow-Origin "*"
+  </IfModule>
+</Files>
+
 # BEGIN WordPress
 <IfModule mod_rewrite.c>
 RewriteEngine On

--- a/public/.well-known/http-message-signatures-directory
+++ b/public/.well-known/http-message-signatures-directory
@@ -1,0 +1,12 @@
+{
+  "keys": [
+    {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "kid": "djzeneyer-bot-v2",
+      "x": "RFWhUsFXiJjLrLl4qldfaBQzxt683oPg-oO6VLoPMDo",
+      "use": "sig",
+      "alg": "EdDSA"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Implementa Web Bot Auth (IETF Web Bot Auth / RFC 9421 HTTP Message Signatures) para que `djzeneyer.com` possa publicar uma chave p?blica verific?vel para requisi??es assinadas de agente/bot.

- Publica JWKS em `/.well-known/http-message-signatures-directory` com chave p?blica Ed25519
- Adiciona regra `.htaccess`: `ForceType application/jwk-set+json`, cache p?blico e CORS `Access-Control-Allow-Origin: *`
- Documenta `WEB_BOT_AUTH_PRIVATE_KEY_D` no `.env.example` sem expor material secreto

## Seguran?a

A chave privada nunca deve ser commitada ou publicada em descri??o de PR. O par inicial foi rotacionado e a branch foi reescrita; o JWKS agora usa `kid: djzeneyer-bot-v2`.

O GitHub Actions Secret `WEB_BOT_AUTH_PRIVATE_KEY_D` j? foi atualizado com a chave privada correspondente ao JWKS p?blico deste PR.

## Test plan

- [ ] Ap?s merge e deploy, verificar: `curl -I https://djzeneyer.com/.well-known/http-message-signatures-directory` retorna `Content-Type: application/jwk-set+json`
- [ ] Verificar que o JSON retornado ? v?lido JWKS com `kty: OKP`, `crv: Ed25519`, `kid: djzeneyer-bot-v2`
- [ ] Re-rodar auditoria no `isitagentready.com` ? item "Web Bot Auth directory not found" deve sumir

https://datatracker.ietf.org/wg/webbotauth/about/
https://developers.cloudflare.com/bots/reference/bot-verification/web-bot-auth/
