### PR TITLE
Audit canonical releases URL

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -4,7 +4,7 @@
       "url": [
         "https://djzeneyer.com",
         "https://djzeneyer.com/pt/eventos-zouk/",
-        "https://djzeneyer.com/releases"
+        "https://djzeneyer.com/releases/"
       ],
       "numberOfRuns": 3,
       "settings": {


### PR DESCRIPTION
## Summary
- update Lighthouse CI to audit the canonical /releases/ URL
- avoid artificial redirect/document-latency warnings caused by auditing the pre-canonical path

## Validation
- JSON parse check for lighthouserc.json
- git diff --check