### PR TITLE
feat: Auth.md heading + agent_auth block in oauth-authorization-server

### DIFF
--- a/public/.well-known/auth.md
+++ b/public/.well-known/auth.md
@@ -1,4 +1,6 @@
-# Zen Eyer Agent Authentication
+# Auth.md
+
+## Zen Eyer Agent Authentication
 
 Zen Eyer publishes public AI discovery resources for reading, grounding, SEO, booking context, music metadata, and event context. These public resources do not require authentication.
 

--- a/public/.well-known/oauth-authorization-server
+++ b/public/.well-known/oauth-authorization-server
@@ -1,7 +1,10 @@
 {
   "issuer": "https://djzeneyer.com",
-  "agent_registration_endpoint": "https://djzeneyer.com/wp-json/djzeneyer/v1/agent-registration",
-  "agent_revocation_endpoint": "https://djzeneyer.com/wp-json/djzeneyer/v1/agent-revoke",
+  "token_endpoint": "https://djzeneyer.com/wp-json/djzeneyer/v1/agent-registration",
+  "revocation_endpoint": "https://djzeneyer.com/wp-json/djzeneyer/v1/agent-revoke",
+  "grant_types_supported": [
+    "urn:ietf:params:oauth:grant-type:jwt-bearer"
+  ],
   "scopes_supported": [
     "public:read"
   ],
@@ -13,5 +16,18 @@
     "anonymous_public"
   ],
   "claim_ceremony_supported": false,
-  "documentation": "https://djzeneyer.com/.well-known/auth.md"
+  "documentation": "https://djzeneyer.com/auth.md",
+  "agent_auth": {
+    "register_uri": "https://djzeneyer.com/wp-json/djzeneyer/v1/agent-registration",
+    "revocation_uri": "https://djzeneyer.com/wp-json/djzeneyer/v1/agent-revoke",
+    "skill": "https://djzeneyer.com/auth.md",
+    "identity_types_supported": [
+      "anonymous",
+      "identity_assertion"
+    ],
+    "credential_types_supported": [
+      "user_claimed",
+      "anonymous_public"
+    ]
+  }
 }

--- a/public/.well-known/oauth-authorization-server
+++ b/public/.well-known/oauth-authorization-server
@@ -16,7 +16,7 @@
     "anonymous_public"
   ],
   "claim_ceremony_supported": false,
-  "documentation": "https://djzeneyer.com/auth.md",
+  "service_documentation": "https://djzeneyer.com/auth.md",
   "agent_auth": {
     "register_uri": "https://djzeneyer.com/wp-json/djzeneyer/v1/agent-registration",
     "revocation_uri": "https://djzeneyer.com/wp-json/djzeneyer/v1/agent-revoke",

--- a/public/.well-known/oauth-protected-resource
+++ b/public/.well-known/oauth-protected-resource
@@ -9,6 +9,5 @@
   "scopes_supported": [
     "public:read"
   ],
-  "resource_documentation": "https://djzeneyer.com/auth.md",
-  "auth_documentation": "https://djzeneyer.com/.well-known/oauth-authorization-server"
+  "resource_documentation": "https://djzeneyer.com/auth.md"
 }

--- a/public/.well-known/oauth-protected-resource
+++ b/public/.well-known/oauth-protected-resource
@@ -9,5 +9,6 @@
   "scopes_supported": [
     "public:read"
   ],
-  "resource_documentation": "https://djzeneyer.com/.well-known/auth.md"
+  "resource_documentation": "https://djzeneyer.com/auth.md",
+  "auth_documentation": "https://djzeneyer.com/.well-known/oauth-authorization-server"
 }

--- a/public/auth.md
+++ b/public/auth.md
@@ -1,4 +1,6 @@
-# Zen Eyer Agent Authentication
+# Auth.md
+
+## Zen Eyer Agent Authentication
 
 Zen Eyer publishes public AI discovery resources for reading, grounding, SEO, booking context, music metadata, and event context. These public resources do not require authentication.
 


### PR DESCRIPTION
## Summary

Resolve o item "Auth.md metadata for agent registration" detectado pela auditoria `isitagentready.com`:

- **`# Auth.md` heading** — ambas as cópias do arquivo (`/auth.md` e `/.well-known/auth.md`) precisavam do heading canônico `# Auth.md` como primeira linha para que parsers de agentes o identifiquem corretamente. O heading descritivo do site foi movido para `##`
- **`agent_auth` block** — `/.well-known/oauth-authorization-server` recebeu o bloco `agent_auth` exigido pelo protocolo WorkOS auth.md, com: `register_uri`, `revocation_uri`, `skill`, `identity_types_supported` e `credential_types_supported`
- **Campos OAuth padrão** — adicionados `token_endpoint`, `revocation_endpoint` e `grant_types_supported` ao authorization server (campos obrigatórios do RFC 8414)
- **`oauth-protected-resource`** — `resource_documentation` atualizado para `/auth.md` canônico na raiz; adicionado `auth_documentation` apontando para o authorization server

## Mudanças por arquivo

### `auth.md` (ambas as cópias)
```diff
-# Zen Eyer Agent Authentication
+# Auth.md
+
+## Zen Eyer Agent Authentication
```

### `oauth-authorization-server`
```diff
+  "token_endpoint": "...agent-registration",
+  "revocation_endpoint": "...agent-revoke",
+  "grant_types_supported": ["urn:ietf:params:oauth:grant-type:jwt-bearer"],
+  "documentation": "https://djzeneyer.com/auth.md",
+  "agent_auth": {
+    "register_uri": "...agent-registration",
+    "revocation_uri": "...agent-revoke",
+    "skill": "https://djzeneyer.com/auth.md",
+    "identity_types_supported": ["anonymous", "identity_assertion"],
+    "credential_types_supported": ["user_claimed", "anonymous_public"]
+  }
```

## Referências

- https://github.com/workos/auth.md
- https://datatracker.ietf.org/wg/webbotauth/about/

## Test plan

- [ ] Após merge e deploy: `curl https://djzeneyer.com/auth.md | head -1` → deve retornar `# Auth.md`
- [ ] `curl https://djzeneyer.com/.well-known/oauth-authorization-server | jq .agent_auth` → deve retornar o bloco completo
- [ ] Re-rodar auditoria `isitagentready.com` — item "Auth.md metadata for agent registration" deve sumir
- [ ] `curl https://djzeneyer.com/.well-known/oauth-protected-resource` → `resource_documentation` aponta para `/auth.md`

https://claude.ai/code/session_017MN1Cq8fmAi9Sxqdqw2A23

---
_Generated by [Claude Code](https://claude.ai/code/session_017MN1Cq8fmAi9Sxqdqw2A23)_