### PR TITLE
feat: DNS-AID verification script and npm shortcuts

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "perf:budget": "node scripts/check-performance-budget.mjs",
     "rollback": "node scripts/rollback.js",
     "indexnow": "node scripts/submit-indexnow.mjs",
-    "dns-aid:publish": "node scripts/publish-dns-aid-cloudflare.mjs",
+    "dns-aid:publish": "node scripts/publish-dns-aid-cloudflare.mjs --skip-doh",
     "dns-aid:dry": "node scripts/publish-dns-aid-cloudflare.mjs --dry-run --skip-doh",
     "dns-aid:verify": "node scripts/check-dns-aid.mjs",
     "prepare": "husky"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "perf:budget": "node scripts/check-performance-budget.mjs",
     "rollback": "node scripts/rollback.js",
     "indexnow": "node scripts/submit-indexnow.mjs",
+    "dns-aid:publish": "node scripts/publish-dns-aid-cloudflare.mjs",
+    "dns-aid:dry": "node scripts/publish-dns-aid-cloudflare.mjs --dry-run --skip-doh",
+    "dns-aid:verify": "node scripts/check-dns-aid.mjs",
     "prepare": "husky"
   },
   "dependencies": {

--- a/scripts/check-dns-aid.mjs
+++ b/scripts/check-dns-aid.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/**
+ * DNS-AID record verification via DNS-over-HTTPS.
+ * No credentials required — queries public resolvers only.
+ *
+ * Usage:
+ *   node scripts/check-dns-aid.mjs
+ *   node scripts/check-dns-aid.mjs --verbose
+ *
+ * Exit codes:
+ *   0 — all records found and DNSSEC-validated
+ *   1 — one or more records missing or DNSSEC not validated
+ */
+
+const DOMAIN = 'djzeneyer.com';
+const DOH_RESOLVER = 'https://cloudflare-dns.com/dns-query';
+const VERBOSE = process.argv.includes('--verbose');
+
+const DNS_AID_NAMES = [
+  `_index._agents.${DOMAIN}`,
+];
+
+async function checkRecord(name) {
+  const params = new URLSearchParams({ name, type: '64', do: '1' });
+  const response = await fetch(`${DOH_RESOLVER}?${params}`, {
+    headers: { accept: 'application/dns-json' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`DoH HTTP ${response.status} for ${name}`);
+  }
+
+  const json = await response.json();
+
+  if (VERBOSE) {
+    console.log(`[${name}] raw:`, JSON.stringify(json, null, 2));
+  }
+
+  const answer = json.Answer?.find((entry) => entry.type === 64);
+
+  return {
+    name,
+    found: Boolean(answer),
+    dnssec: json.AD === true,
+    rdata: answer?.data ?? null,
+    rcode: json.Status,
+  };
+}
+
+async function main() {
+  let allOk = true;
+
+  for (const name of DNS_AID_NAMES) {
+    let result;
+    try {
+      result = await checkRecord(name);
+    } catch (err) {
+      console.error(`❌ ${name}: fetch failed — ${err.message}`);
+      allOk = false;
+      continue;
+    }
+
+    if (!result.found) {
+      console.error(`❌ ${name}: SVCB record not found (RCODE=${result.rcode})`);
+      console.error(`   → Run: CLOUDFLARE_API_TOKEN=... CLOUDFLARE_ZONE_ID=... node scripts/publish-dns-aid-cloudflare.mjs`);
+      allOk = false;
+      continue;
+    }
+
+    if (!result.dnssec) {
+      console.warn(`⚠️  ${name}: record found but AD=false (DNSSEC not validated)`);
+      console.warn(`   → Ensure the DS record is published at your domain registrar.`);
+      console.warn(`   → Data: ${result.rdata}`);
+      allOk = false;
+      continue;
+    }
+
+    console.log(`✅ ${name}`);
+    if (VERBOSE) console.log(`   Data: ${result.rdata}`);
+  }
+
+  if (!allOk) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((err) => {
+  console.error(err.message);
+  process.exitCode = 1;
+});

--- a/scripts/check-dns-aid.mjs
+++ b/scripts/check-dns-aid.mjs
@@ -20,6 +20,12 @@ const DNS_AID_NAMES = [
   `_index._agents.${DOMAIN}`,
 ];
 
+/**
+ * Query a DNS-AID SVCB record through public DNS-over-HTTPS.
+ *
+ * @param {string} name Fully-qualified DNS name to verify.
+ * @returns {Promise<{name: string, found: boolean, dnssec: boolean, rdata: string | null, rcode: number}>}
+ */
 async function checkRecord(name) {
   const params = new URLSearchParams({ name, type: '64', do: '1' });
   const response = await fetch(`${DOH_RESOLVER}?${params}`, {
@@ -47,6 +53,11 @@ async function checkRecord(name) {
   };
 }
 
+/**
+ * Verify every DNS-AID entrypoint and report missing records or DNSSEC gaps.
+ *
+ * @returns {Promise<void>}
+ */
 async function main() {
   let allOk = true;
 
@@ -62,7 +73,7 @@ async function main() {
 
     if (!result.found) {
       console.error(`❌ ${name}: SVCB record not found (RCODE=${result.rcode})`);
-      console.error(`   → Run: CLOUDFLARE_API_TOKEN=... CLOUDFLARE_ZONE_ID=... node scripts/publish-dns-aid-cloudflare.mjs`);
+      console.error('   → Export CLOUDFLARE_API_TOKEN and CLOUDFLARE_ZONE_ID first, then run: npm run dns-aid:publish');
       allOk = false;
       continue;
     }

--- a/scripts/publish-dns-aid-cloudflare.mjs
+++ b/scripts/publish-dns-aid-cloudflare.mjs
@@ -75,11 +75,16 @@ function recordNeedsUpdate(existing, desired) {
   );
 }
 
-async function ensureDnssec({ zoneId, token }) {
+async function ensureDnssec({ zoneId, token, dryRun }) {
   const dnssec = await cloudflareRequest(`/zones/${zoneId}/dnssec`, { token });
 
   if (dnssec.status === 'active') {
     console.log('DNSSEC is active for the zone.');
+    return;
+  }
+
+  if (dryRun) {
+    console.log(`DNSSEC status is "${dnssec.status || 'unknown'}"; dry-run will not request activation.`);
     return;
   }
 
@@ -173,7 +178,7 @@ async function main() {
     );
   }
 
-  await ensureDnssec({ zoneId, token });
+  await ensureDnssec({ zoneId, token, dryRun });
 
   for (const desired of DNS_AID_RECORDS) {
     await upsertRecord({ zoneId, token, desired, dryRun });

--- a/scripts/publish-dns-aid-cloudflare.mjs
+++ b/scripts/publish-dns-aid-cloudflare.mjs
@@ -92,7 +92,11 @@ async function ensureDnssec({ zoneId, token }) {
 
   console.log(`DNSSEC status after update: ${updated.status || 'unknown'}.`);
   if (updated.status !== 'active') {
-    console.log('Registrar DS publication may still be required before validators return AD=true.');
+    console.log(
+      'Registrar DS publication required: go to Cloudflare Dashboard → djzeneyer.com → DNS → DNSSEC ' +
+        '→ copy the DS record → paste it at your domain registrar. ' +
+        'Validators return AD=true only after the DS record propagates (up to 48h).',
+    );
   }
 }
 


### PR DESCRIPTION
## Contexto

O audit `isitagentready.com` reporta "DNS for AI Discovery (DNS-AID) well-known entrypoint records not found". O registro SVCB `_index._agents.djzeneyer.com` precisa existir no DNS com DNSSEC validado (AD=true).

O script `scripts/publish-dns-aid-cloudflare.mjs` já existia e está correto — **o problema é que nunca foi executado com credenciais válidas**. Os secrets `CLOUDFLARE_API_TOKEN` e `CLOUDFLARE_ZONE_ID` precisam ser adicionados ao GitHub (PR #688 já automatiza isso no CI).

Este PR adiciona o tooling para verificar e publicar os registros de forma explícita.

## O que foi adicionado

### `scripts/check-dns-aid.mjs` — verificação sem credenciais
Script DoH-only (DNS-over-HTTPS) que verifica se os registros existem e se DNSSEC está validado. Não precisa de credenciais — consulta o resolver público do Cloudflare:

```bash
npm run dns-aid:verify
# ✅ _index._agents.djzeneyer.com
# ou
# ❌ _index._agents.djzeneyer.com: SVCB record not found (RCODE=3)
#    → Run: CLOUDFLARE_API_TOKEN=... CLOUDFLARE_ZONE_ID=... node scripts/publish-dns-aid-cloudflare.mjs
```

Flag `--verbose` exibe a resposta DoH completa para debug.

### npm scripts adicionados

| Script | Comando |
|--------|---------|
| `dns-aid:publish` | Publica os registros no Cloudflare (requer secrets) |
| `dns-aid:dry` | Dry-run: mostra o que seria publicado sem alterar DNS |
| `dns-aid:verify` | Verifica via DoH se os registros existem e têm DNSSEC |

### Guidance de DNSSEC melhorada
O `publish-dns-aid-cloudflare.mjs` agora inclui instruções claras sobre publicação do DS record no registrador de domínio (necessário para AD=true).

## O registro DNS em questão

```
_index._agents.djzeneyer.com. 3600 IN SVCB 1 djzeneyer.com. (
  mandatory=alpn,port
  alpn="h2"
  port=443
  key65280="/.well-known/ai-plugin.json"
  key65281="/llms.txt"
  key65282="/wp-json/djzeneyer/v1/ai-context"
)
```

## O que você precisa fazer (fora do código)

1. Adicionar secrets em **Settings → Secrets → Actions**:
   - `CLOUDFLARE_API_TOKEN` (Zone.DNS Edit)
   - `CLOUDFLARE_ZONE_ID` (ID da zona djzeneyer.com)

2. Depois do merge do PR #688 e do próximo deploy: o step "Publish DNS-AID records" roda automaticamente.

3. Após publicação, verificar: `npm run dns-aid:verify`

4. Se AD=false: ir ao Cloudflare Dashboard → djzeneyer.com → DNS → DNSSEC → copiar o DS record → colar no painel do registrador de domínio. Propagação pode levar até 48h.

## Test plan

- [ ] `npm run dns-aid:dry` mostra os registros que seriam criados sem alterar DNS
- [ ] Com secrets configurados: `npm run dns-aid:publish` cria `_index._agents.djzeneyer.com`
- [ ] `npm run dns-aid:verify` retorna ✅ com AD=true
- [ ] Re-rodar auditoria `isitagentready.com` — item DNS-AID deve sumir

## Referências

- https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/
- https://www.rfc-editor.org/rfc/rfc9460 (SVCB/HTTPS records)

https://claude.ai/code/session_017MN1Cq8fmAi9Sxqdqw2A23

---
_Generated by [Claude Code](https://claude.ai/code/session_017MN1Cq8fmAi9Sxqdqw2A23)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Adicionados novos comandos para gerenciar registros DNS: publicação, modo dry-run e verificação de validação DNSSEC.

* **Documentation**
  * Instruções aprimoradas no processo de publicação, detalhando onde localizar registros DS e tempos esperados de validação.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->