### PR TITLE
fix: truncate DNS-AID record comment to Cloudflare 100-char limit

### DIFF
--- a/scripts/publish-dns-aid-cloudflare.mjs
+++ b/scripts/publish-dns-aid-cloudflare.mjs
@@ -16,8 +16,7 @@ const DNS_AID_RECORDS = [
       value:
         'mandatory=alpn,port alpn="h2" port=443 key65280="/.well-known/ai-plugin.json" key65281="/llms.txt" key65282="/wp-json/djzeneyer/v1/ai-context"',
     },
-    comment:
-      'DNS-AID organization index for Zen Eyer AI discovery. key65280-65282 are experimental private-use descriptor locators.',
+    comment: 'DNS-AID index for djzeneyer.com. key65280-65282: experimental private-use descriptor locators.',
   },
 ];
 

--- a/scripts/publish-dns-aid-cloudflare.mjs
+++ b/scripts/publish-dns-aid-cloudflare.mjs
@@ -16,7 +16,7 @@ const DNS_AID_RECORDS = [
       value:
         'mandatory=alpn,port alpn="h2" port=443 key65280="/.well-known/ai-plugin.json" key65281="/llms.txt" key65282="/wp-json/djzeneyer/v1/ai-context"',
     },
-    comment: 'DNS-AID index for djzeneyer.com. key65280-65282: experimental private-use descriptor locators.',
+    comment: `DNS-AID index for ${DOMAIN}. key65280-65282: experimental private-use descriptor locators.`,
   },
 ];
 


### PR DESCRIPTION
## Problema

O step `Publish DNS-AID records` falhava silenciosamente no CI com:

```
Cloudflare API POST /zones/***/dns_records failed: DNS record comment exceeds the maximum length of 100 characters.
```

O comment tinha 118 caracteres — acima do limite da API do Cloudflare.

## Fix

Encurtado de 118 para 94 caracteres:

```diff
- comment: 'DNS-AID organization index for Zen Eyer AI discovery. key65280-65282 are experimental private-use descriptor locators.',
+ comment: 'DNS-AID index for djzeneyer.com. key65280-65282: experimental private-use descriptor locators.',
```

## Resultado esperado

Após merge e deploy, o step `Publish DNS-AID records` vai criar o registro `_index._agents.djzeneyer.com` SVCB no Cloudflare com sucesso, resolvendo o item "DNS-AID well-known entrypoint records not found" da auditoria `isitagentready.com`.

---
_Generated by [Claude Code](https://claude.ai/code/session_017MN1Cq8fmAi9Sxqdqw2A23)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Atualização de comentários em configurações DNS para melhor clareza e documentação dos registros.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->