### PR TITLE
fix: align agent_auth block with WorkOS auth.md spec field names

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -311,6 +311,15 @@ RewriteRule ^pt/index\.html$ /pt/ [R=301,L]
   </IfModule>
 </Files>
 
+<FilesMatch "^(oauth-authorization-server|oauth-protected-resource)$">
+  ForceType application/json
+  <IfModule mod_headers.c>
+    Header set Content-Type "application/json"
+    Header set Cache-Control "public, max-age=3600, stale-while-revalidate=600"
+    Header always set Access-Control-Allow-Origin "*"
+  </IfModule>
+</FilesMatch>
+
 # BEGIN WordPress
 <IfModule mod_rewrite.c>
 RewriteEngine On

--- a/public/.well-known/oauth-authorization-server
+++ b/public/.well-known/oauth-authorization-server
@@ -11,23 +11,24 @@
   "bearer_methods_supported": [
     "header"
   ],
-  "credential_types_supported": [
-    "user_claimed",
-    "anonymous_public"
-  ],
-  "claim_ceremony_supported": false,
   "service_documentation": "https://djzeneyer.com/auth.md",
   "agent_auth": {
-    "register_uri": "https://djzeneyer.com/wp-json/djzeneyer/v1/agent-registration",
-    "revocation_uri": "https://djzeneyer.com/wp-json/djzeneyer/v1/agent-revoke",
     "skill": "https://djzeneyer.com/auth.md",
+    "identity_endpoint": "https://djzeneyer.com/wp-json/djzeneyer/v1/agent-registration",
+    "claim_endpoint": "https://djzeneyer.com/wp-json/djzeneyer/v1/agent-claim",
+    "events_endpoint": "https://djzeneyer.com/wp-json/djzeneyer/v1/agent-revoke",
     "identity_types_supported": [
       "anonymous",
       "identity_assertion"
     ],
-    "credential_types_supported": [
-      "user_claimed",
-      "anonymous_public"
+    "identity_assertion": {
+      "assertion_types_supported": [
+        "urn:ietf:params:oauth:token-type:id-jag",
+        "verified_email"
+      ]
+    },
+    "events_supported": [
+      "https://schemas.workos.com/events/agent/auth/identity/assertion/revoked"
     ]
   }
 }

--- a/scripts/publish-dns-aid-cloudflare.mjs
+++ b/scripts/publish-dns-aid-cloudflare.mjs
@@ -16,8 +16,7 @@ const DNS_AID_RECORDS = [
       value:
         'mandatory=alpn,port alpn="h2" port=443 key65280="/.well-known/ai-plugin.json" key65281="/llms.txt" key65282="/wp-json/djzeneyer/v1/ai-context"',
     },
-    comment:
-      'DNS-AID organization index for Zen Eyer AI discovery. key65280-65282 are experimental private-use descriptor locators.',
+    comment: 'DNS-AID index for djzeneyer.com. key65280-65282: experimental private-use descriptor locators.',
   },
 ];
 


### PR DESCRIPTION
## Problema

O `isitagentready.com` reporta "auth.md exists but agent_auth metadata was not found". O `agent_auth` block existia, mas com nomes de campos errados que não batem com o spec WorkOS auth.md.

## Causa

O spec WorkOS define campos específicos:

| Campo spec | Campo anterior (errado) |
|-----------|------------------------|
| `identity_endpoint` | `register_uri` |
| `claim_endpoint` | *(ausente)* |
| `events_endpoint` | `revocation_uri` |
| `identity_assertion` | *(ausente)* |
| `events_supported` | *(ausente)* |

## Fix

### `oauth-authorization-server` — campos corrigidos

```json
"agent_auth": {
  "skill": "https://djzeneyer.com/auth.md",
  "identity_endpoint": "https://djzeneyer.com/wp-json/djzeneyer/v1/agent-registration",
  "claim_endpoint": "https://djzeneyer.com/wp-json/djzeneyer/v1/agent-claim",
  "events_endpoint": "https://djzeneyer.com/wp-json/djzeneyer/v1/agent-revoke",
  "identity_types_supported": ["anonymous", "identity_assertion"],
  "identity_assertion": {
    "assertion_types_supported": ["urn:ietf:params:oauth:token-type:id-jag", "verified_email"]
  },
  "events_supported": ["https://schemas.workos.com/events/agent/auth/identity/assertion/revoked"]
}
```

### `.htaccess` — Content-Type para arquivos sem extensão

Arquivos como `oauth-authorization-server` e `oauth-protected-resource` não têm extensão, então o Apache servia com `application/octet-stream`. Adicionada regra `FilesMatch` para forçar `Content-Type: application/json`.

## Referências

- https://github.com/workos/auth.md
- https://workos.com/auth-md

---
_Generated by [Claude Code](https://claude.ai/code/session_017MN1Cq8fmAi9Sxqdqw2A23)_