### PR TITLE
fix: auth.md agent_auth — flatten credential_types + YAML frontmatter

### DIFF
--- a/public/.well-known/auth.md
+++ b/public/.well-known/auth.md
@@ -1,3 +1,16 @@
+---
+agent_auth:
+  register_uri: https://djzeneyer.com/wp-json/djzeneyer/v1/agent-registration
+  claim_endpoint: https://djzeneyer.com/wp-json/djzeneyer/v1/agent-claim
+  revocation_uri: https://djzeneyer.com/wp-json/djzeneyer/v1/agent-revoke
+  identity_types_supported:
+    - anonymous
+    - identity_assertion
+  credential_types_supported:
+    - user_claimed
+    - anonymous_public
+---
+
 # Auth.md
 
 ## Zen Eyer Agent Authentication

--- a/public/.well-known/oauth-authorization-server
+++ b/public/.well-known/oauth-authorization-server
@@ -15,15 +15,16 @@
   "agent_auth": {
     "skill": "https://djzeneyer.com/auth.md",
     "register_uri": "https://djzeneyer.com/wp-json/djzeneyer/v1/agent-registration",
+    "claim_endpoint": "https://djzeneyer.com/wp-json/djzeneyer/v1/agent-claim",
     "revocation_uri": "https://djzeneyer.com/wp-json/djzeneyer/v1/agent-revoke",
     "identity_types_supported": [
-      "anonymous"
+      "anonymous",
+      "identity_assertion"
     ],
-    "anonymous": {
-      "credential_types_supported": [
-        "access_token"
-      ]
-    },
+    "credential_types_supported": [
+      "user_claimed",
+      "anonymous_public"
+    ],
     "events_supported": [
       "https://schemas.workos.com/events/agent/auth/identity/assertion/revoked"
     ]

--- a/public/auth.md
+++ b/public/auth.md
@@ -1,3 +1,16 @@
+---
+agent_auth:
+  register_uri: https://djzeneyer.com/wp-json/djzeneyer/v1/agent-registration
+  claim_endpoint: https://djzeneyer.com/wp-json/djzeneyer/v1/agent-claim
+  revocation_uri: https://djzeneyer.com/wp-json/djzeneyer/v1/agent-revoke
+  identity_types_supported:
+    - anonymous
+    - identity_assertion
+  credential_types_supported:
+    - user_claimed
+    - anonymous_public
+---
+
 # Auth.md
 
 ## Zen Eyer Agent Authentication


### PR DESCRIPTION
## Problema persistente

Após múltiplas tentativas, o checker `isitagentready.com` ainda reporta "agent_auth metadata was not found". Investigação identificou dois problemas distintos:

## Causa 1 — `credential_types_supported` aninhado incorretamente

O `agent_auth` block tinha `credential_types_supported` dentro de um objeto `anonymous` em vez de no topo do bloco:

```json
// ❌ Errado (gerado por outra sessão)
"agent_auth": {
  "anonymous": {
    "credential_types_supported": ["access_token"]
  }
}

// ✅ Correto (o checker espera no topo)
"agent_auth": {
  "credential_types_supported": ["user_claimed", "anonymous_public"]
}
```

## Causa 2 — Checker pode parsear auth.md diretamente

O erro diz "auth.md exists **but** agent_auth metadata was not found" — o checker encontra o arquivo mas não o metadata. Isso indica que ele parseia o próprio arquivo `auth.md` em busca de dados estruturados, não apenas o `oauth-authorization-server`.

**Fix**: adicionado YAML frontmatter em `/auth.md` e `/.well-known/auth.md`:

```yaml
---
agent_auth:
  register_uri: https://djzeneyer.com/wp-json/djzeneyer/v1/agent-registration
  claim_endpoint: https://djzeneyer.com/wp-json/djzeneyer/v1/agent-claim
  revocation_uri: https://djzeneyer.com/wp-json/djzeneyer/v1/agent-revoke
  identity_types_supported:
    - anonymous
    - identity_assertion
  credential_types_supported:
    - user_claimed
    - anonymous_public
---
```

## Resultado esperado

O checker encontra `agent_auth` de dois lugares:
1. Diretamente no frontmatter de `auth.md`
2. No `/.well-known/oauth-authorization-server` com estrutura correta

---
_Generated by [Claude Code](https://claude.ai/code/session_017MN1Cq8fmAi9Sxqdqw2A23)_