### PR TITLE
fix: restore shell-level Cloudflare secret checks (deploy was broken)

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -166,11 +166,15 @@ jobs:
 
       - name: 🌐 Purge Cloudflare CDN cache
         continue-on-error: true
-        if: ${{ secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_ZONE_ID != '' }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
         run: |
+          if [ -z "$CLOUDFLARE_API_TOKEN" ] || [ -z "$CLOUDFLARE_ZONE_ID" ]; then
+            echo "Cloudflare secrets not set; skipping CDN cache purge."
+            exit 0
+          fi
+
           RESPONSE=$(curl -s -X POST \
             "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache" \
             -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
@@ -196,8 +200,13 @@ jobs:
 
       - name: 🔖 Publish DNS-AID records
         continue-on-error: true
-        if: ${{ secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_ZONE_ID != '' }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
-        run: node scripts/publish-dns-aid-cloudflare.mjs --skip-doh
+        run: |
+          if [ -z "$CLOUDFLARE_API_TOKEN" ] || [ -z "$CLOUDFLARE_ZONE_ID" ]; then
+            echo "Cloudflare secrets not set; skipping DNS-AID publish."
+            exit 0
+          fi
+
+          node scripts/publish-dns-aid-cloudflare.mjs --skip-doh


### PR DESCRIPTION
## Problema

O deploy frontend estava falhando silenciosamente com **0 jobs** desde o PR #701.

**Causa raiz**: durante a resolução de merge conflicts no #701, mantive a versão do branch que tinha `if: ${{ secrets.CLOUDFLARE_API_TOKEN != '' }}` nos steps do Cloudflare. O GitHub Actions **não permite acesso ao contexto `secrets` em condições `if:` de step** — isso faz o workflow inteiro falhar antes de criar qualquer job.

O commit original `b32a1ae` ("fix: avoid secrets context in workflow conditions") já tinha corrigido isso usando guards no shell. Esse PR restaura esse fix.

## Mudança

Remove `if: ${{ secrets.X != '' }}` dos dois steps Cloudflare e usa checks no shell:

```bash
if [ -z "$CLOUDFLARE_API_TOKEN" ] || [ -z "$CLOUDFLARE_ZONE_ID" ]; then
  echo "Cloudflare secrets not set; skipping."
  exit 0
fi
```

## Por que não `continue-on-error: true` resolve?

`continue-on-error` lida com falhas de runtime, mas o erro de expressão `secrets` acontece na **avaliação do workflow** — antes de qualquer job rodar.

https://claude.ai/code/session_017MN1Cq8fmAi9Sxqdqw2A23

---
_Generated by [Claude Code](https://claude.ai/code/session_017MN1Cq8fmAi9Sxqdqw2A23)_