### PR TITLE
fix: deploy auth.md WorkOS spec fixes to server (PRs #699-703 never deployed)

### DIFF
--- a/public/.well-known/oauth-protected-resource
+++ b/public/.well-known/oauth-protected-resource
@@ -1,5 +1,6 @@
 {
   "resource": "https://djzeneyer.com",
+  "resource_name": "DJ Zen Eyer",
   "authorization_servers": [
     "https://djzeneyer.com"
   ],


### PR DESCRIPTION
## O que e por quê

Os deploys pós-PR #700 falharam silenciosamente com 0 jobs (bug do workflow com `if: secrets.X`), então o servidor Hostinger ainda tem o conteúdo antigo — sem os campos corretos do WorkOS spec (`identity_endpoint`, `events_endpoint`) e com YAML frontmatter indevido no `auth.md`.

Este PR toca um arquivo em `public/` para acionar o deploy e finalmente entregar ao servidor as correções dos PRs #699–703.

**Mudança real:** adiciona `resource_name: "DJ Zen Eyer"` ao `oauth-protected-resource` conforme RFC 9728.

## O que vai ser deployado

- `public/auth.md` — `# Auth.md` como primeira linha (sem YAML frontmatter)
- `public/.well-known/auth.md` — idem
- `public/.well-known/oauth-authorization-server` — campos corretos: `identity_endpoint`, `claim_endpoint`, `events_endpoint`, `identity_assertion.assertion_types_supported`
- `public/.htaccess` — Link headers no auth.md apontando para os endpoints OAuth
- `public/.well-known/oauth-protected-resource` — + `resource_name`

https://claude.ai/code/session_017MN1Cq8fmAi9Sxqdqw2A23

---
_Generated by [Claude Code](https://claude.ai/code/session_017MN1Cq8fmAi9Sxqdqw2A23)_