### PR TITLE
ci: retrigger deploy after SSH timeout (#707)

### DIFF
--- a/public/.well-known/.htaccess
+++ b/public/.well-known/.htaccess
@@ -17,18 +17,18 @@
     Header set Access-Control-Allow-Origin "*"
   </Files>
 
-  # OAuth 2.0 metadata (RFC 8414)
+  # OAuth 2.0 metadata (RFC 8414) — served via PHP handlers; short TTL
   <Files "oauth-authorization-server">
     ForceType "application/json"
     Header set Content-Type "application/json; charset=UTF-8"
-    Header set Cache-Control "public, max-age=3600"
+    Header set Cache-Control "public, max-age=300, stale-while-revalidate=60"
     Header set Access-Control-Allow-Origin "*"
   </Files>
 
   <Files "oauth-protected-resource">
     ForceType "application/json"
     Header set Content-Type "application/json; charset=UTF-8"
-    Header set Cache-Control "public, max-age=3600"
+    Header set Cache-Control "public, max-age=300, stale-while-revalidate=60"
     Header set Access-Control-Allow-Origin "*"
   </Files>
 


### PR DESCRIPTION
Retrigger deploy after the PR #707 run failed with `dial tcp: i/o timeout` on the Hostinger SSH connection (transient network error, not a code issue).

Also aligns the `.htaccess` fallback Cache-Control TTL (300s) with the PHP handler headers added in #707.

---
_Generated by [Claude Code](https://claude.ai/code/session_017MN1Cq8fmAi9Sxqdqw2A23)_