### PR TITLE
fix(webmcp): separate genre (Brazilian Zouk) from philosophy (Cremosidade)

### DIFF
--- a/src/hooks/useWebMCP.ts
+++ b/src/hooks/useWebMCP.ts
@@ -39,7 +39,8 @@ export function useWebMCP() {
               execute: () => {
                 return {
                   name: ARTIST.identity.stageName,
-                  style: ARTIST.philosophy.style,
+                  genre: 'Brazilian Zouk',
+                  philosophy: ARTIST.philosophy.style,
                   mission: ARTIST.philosophy.mission,
                   bio: ARTIST.site.defaultDescription,
                 };


### PR DESCRIPTION
Cremosidade é a filosofia do Zen Eyer, não o gênero musical. Corrige o `get_bio` do WebMCP para expor os dois campos separadamente:\n\n- `genre`: Brazilian Zouk\n- `philosophy`: Cremosidade

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDRvziFeECHGwVAQ8vVWYq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added genre field to artist information with Brazilian Zouk classification.

* **Improvements**
  * Reorganized artist profile structure with updated philosophy field mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->