### PR TITLE
fix(ci): correct Lighthouse trigger to match frontend deploy workflow name

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -2,7 +2,7 @@ name: Lighthouse Audit
 
 on:
   workflow_run:
-    workflows: ["🚀 Deploy Frontend"]
+    workflows: ["🖥️ Deploy · Frontend"]
     types: [completed]
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
## Problema

O Lighthouse parou de rodar automaticamente após deploys.

**Causa raiz:** o workflow `lighthouse.yml` escuta o evento `workflow_run` com o nome `"🚀 Deploy Frontend"`, mas o workflow de deploy do frontend foi renomeado para `"🖥️ Deploy · Frontend"`. O GitHub faz match exato de nome — qualquer diferença (incluindo emoji) faz o trigger nunca disparar.

## Fix

```diff
- workflows: ["🚀 Deploy Frontend"]
+ workflows: ["🖥️ Deploy · Frontend"]
```

## Verificação

Após merge, o próximo deploy do frontend vai disparar o Lighthouse automaticamente.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JfvKC7WsKbv6dFfjmEH51S)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Atualização na configuração de processos automatizados internos para melhor identificação de fluxos de trabalho.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->