### PR TITLE
fix(ci): restore frontend deploy workflow name to 🚀 Deploy Frontend (#715)

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,4 +1,4 @@
-name: 🖥️ Deploy · Frontend
+name: 🚀 Deploy Frontend
 
 on:
   push:


### PR DESCRIPTION
Reverte o rename do PR #702 que mudou `🚀 Deploy Frontend` para `🖥️ Deploy · Frontend`.

O nome original é mais fácil de encontrar na lista do Actions e é o nome que o Lighthouse workflow usa no trigger `workflow_run`. Com esse PR, os dois voltam a estar em sincronia: o deploy tem o nome que você reconhece e o Lighthouse dispara automaticamente após cada deploy.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JfvKC7WsKbv6dFfjmEH51S)_