### PR TITLE
fix: make husky prepare script non-fatal for WebContainers

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "dns-aid:publish": "node scripts/publish-dns-aid-cloudflare.mjs --skip-doh",
     "dns-aid:dry": "node scripts/publish-dns-aid-cloudflare.mjs --dry-run --skip-doh",
     "dns-aid:verify": "node scripts/check-dns-aid.mjs",
-    "prepare": "husky"
+    "prepare": "husky || true"
   },
   "dependencies": {
     "@marsidev/react-turnstile": "^1.5.2",


### PR DESCRIPTION
Closing — workaround específico para Bolt.new/WebContainers. O projeto não será mais desenvolvido nesse ambiente. Não há benefício para o fluxo normal de desenvolvimento.