### PR TITLE
fix: prevent Vite optimizer hang in WebContainers

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -46,6 +46,15 @@ export default defineConfig(({ command, mode }) => {
       },
     },
 
+    // Fix for WebContainers hanging on 'bundling dependencies'
+    server: {
+      host: '0.0.0.0',
+      strictPort: true,
+    },
+    optimizeDeps: {
+      exclude: ['@tailwindcss/vite', 'framer-motion', 'lucide-react']
+    },
+
     build: {
       manifest: true,
       outDir: 'dist',


### PR DESCRIPTION
Closing — workaround específico para Bolt.new/WebContainers. O projeto não será mais desenvolvido nesse ambiente. Não há benefício para o fluxo normal de desenvolvimento.