### PR TITLE
perf(vite): exclude framer-motion and lucide-react from pre-bundler

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -46,6 +46,14 @@ export default defineConfig(({ command, mode }) => {
       },
     },
 
+    // framer-motion and lucide-react have many sub-modules that can stall the
+    // Vite pre-bundler in memory-constrained environments (containers, CI).
+    // They are already split into their own vendor chunks at build time so
+    // excluding them from optimizeDeps is safe and consistent.
+    optimizeDeps: {
+      exclude: ['framer-motion', 'lucide-react'],
+    },
+
     build: {
       manifest: true,
       outDir: 'dist',


### PR DESCRIPTION
## Summary

- Adiciona `framer-motion` e `lucide-react` ao `optimizeDeps.exclude` no `vite.config.ts`
- Ambas as libs têm centenas de sub-módulos que podem travar o pré-bundler do Vite em ambientes com memória limitada (containers, CI, cloud IDEs)
- As libs já são separadas em chunks próprios via `manualChunks`, então excluí-las do `optimizeDeps` é consistente e não afeta o build de produção

## Motivação

O `npm run dev` travava na etapa `[optimizer] bundling dependencies...` em ambientes container (incluindo o ambiente remoto do Claude Code). Esse fix resolve o hang sem afetar o fluxo normal de desenvolvimento local.

## Impacto

| Contexto | Impacto |
|---|---|
| `npm run dev` local | Nenhum — ou dev server inicia ligeiramente mais rápido |
| `npm run build` produção | Zero — `optimizeDeps` só afeta o dev server |
| Container/CI | Dev server não trava mais na etapa de bundling |

## Test plan

- [ ] `npm run dev` inicia sem travar
- [ ] `npm run build` conclui com sucesso
- [ ] Nenhuma regressão visual nas páginas com animações (framer-motion) e ícones (lucide-react)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6aF2qt8Fu2Uf6Qebpsmy1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Versão

* **Chores**
  * Otimizada a configuração de compilação para melhorar o desempenho em ambientes com memória limitada.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->