### PR TITLE
fix(hooks): correct useMemo dependencies in ZoukFestivalsPage

### DIFF
--- a/src/pages/ZoukFestivalsPage.tsx
+++ b/src/pages/ZoukFestivalsPage.tsx
@@ -57,7 +57,7 @@ const ZoukFestivalsPage: React.FC = () => {
     const today = new Date();
     today.setHours(0, 0, 0, 0);
     return categorizeFestivals(ARTIST.festivals, today);
-  }, []);
+  }, [ARTIST.festivals]);
 
   const formatYear = useCallback((date: string | undefined): string => {
     if (!date) return '';


### PR DESCRIPTION
## Summary

- Corrige o array de dependências do `useMemo` em `ZoukFestivalsPage.tsx` que estava vazio (`[]`)
- Adiciona `ARTIST.festivals` como dependência, satisfazendo a regra `exhaustive-deps`

## Problema

O `useMemo` que categoriza festivais em "próximos/passados" capturava `today` e `ARTIST.festivals` apenas no primeiro render. Embora `ARTIST.festivals` seja uma constante de módulo (sem impacto runtime real), o array vazio violava a regra `exhaustive-deps` e escondia a intenção do código.

## Test plan

- [ ] Página de festivais renderiza corretamente
- [ ] Festivais futuros aparecem na seção "Próximos"
- [ ] Festivais passados aparecem na seção "Edições Anteriores"

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6aF2qt8Fu2Uf6Qebpsmy1)_