### PR TITLE
fix(security): add fallback to safeUrl() calls in image src attributes

### DIFF
--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -104,7 +104,7 @@ const HexBadge = ({ earned, title, image, size = '14' }: { earned: boolean; titl
     <div className={`clip-hex flex items-center justify-center p-[2px] ${earned ? 'bg-gradient-to-br from-primary to-secondary' : 'bg-white/10'}`} style={{ width: `${size}rem`, height: `${size}rem` }}>
       <div className="clip-hex h-full w-full bg-surface-dark flex items-center justify-center overflow-hidden bg-black/40">
         {image ? (
-          <img src={safeUrl(image)} alt={title} className="h-2/3 w-2/3 object-contain" loading="lazy" width="64" height="64" />
+          <img src={safeUrl(image, '')} alt={title} className="h-2/3 w-2/3 object-contain" loading="lazy" width="64" height="64" />
         ) : (
           <Award className={`h-1/2 w-1/2 ${earned ? 'text-primary' : 'text-white/20'}`} />
         )}

--- a/src/pages/MyAccountPage.tsx
+++ b/src/pages/MyAccountPage.tsx
@@ -306,7 +306,7 @@ const MyAccountContent: React.FC = () => {
                 >
                   <div className="relative z-10 flex flex-col items-center text-center">
                     <div className={`w-20 h-20 rounded-2xl mb-6 flex items-center justify-center ${ach?.earned ? 'bg-primary/10' : 'bg-white/5'}`}>
-                      {ach?.image ? <img src={safeUrl(ach.image)} className="w-12 h-12 object-contain" alt={ach?.title || t('gamification.achievement')} loading="lazy" width="48" height="48" /> : <Award size={32} />}
+                      {ach?.image ? <img src={safeUrl(ach.image, '')} className="w-12 h-12 object-contain" alt={ach?.title || t('gamification.achievement')} loading="lazy" width="48" height="48" /> : <Award size={32} />}
                     </div>
                     <h4 className="font-black font-display text-xl mb-3 tracking-tight">{ach?.title || t('account.achievement_unknown')}</h4>
                     <p className="text-sm text-white/40 mb-6 leading-relaxed">

--- a/src/pages/NewsPage.tsx
+++ b/src/pages/NewsPage.tsx
@@ -404,7 +404,7 @@ const NewsPage: React.FC = () => {
                         height="675"
                         srcSet={
                           featuredPost.featured_image_src && featuredPost.featured_image_src !== featuredPost.featured_image_src_full
-                            ? `${safeUrl(featuredPost.featured_image_src)} 800w, ${safeUrl(featuredPost.featured_image_src_full || featuredPost.featured_image_src)} 1200w`
+                            ? `${safeUrl(featuredPost.featured_image_src, '')} 800w, ${safeUrl(featuredPost.featured_image_src_full || featuredPost.featured_image_src, '')} 1200w`
                             : undefined
                         }
                         sizes="100vw"

--- a/src/pages/ProductPage.tsx
+++ b/src/pages/ProductPage.tsx
@@ -35,7 +35,7 @@ const ProductGallery = React.memo(({ product, placeholderImage }: ProductGallery
     <div>
       <div className="rounded-xl overflow-hidden border border-white/10 bg-surface">
         <img
-          src={safeUrl(mainImage)}
+          src={safeUrl(mainImage, placeholderImage)}
           alt={product.name || ''}
           className="w-full h-full object-cover"
           loading="eager"
@@ -55,7 +55,7 @@ const ProductGallery = React.memo(({ product, placeholderImage }: ProductGallery
                 activeImage === img.src ? 'border-primary ring-2 ring-primary/40' : 'border-white/10 hover:border-white/30'
               }`}
             >
-              <img src={safeUrl(img.sizes?.thumbnail || img.src)} alt={img.alt || product.name} className="w-full h-full object-cover" loading="lazy" width="150" height="150" />
+              <img src={safeUrl(img.sizes?.thumbnail || img.src, '')} alt={img.alt || product.name} className="w-full h-full object-cover" loading="lazy" width="150" height="150" />
             </button>
           ))}
         </div>

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -105,6 +105,7 @@ const TRUSTED_DOMAINS = [
     'google.com',
     'googleusercontent.com',  // Google OAuth profile photos (lh3.googleusercontent.com)
     'gravatar.com',            // WordPress/Gravatar avatars
+    'placehold.co',            // Placeholder images used in dev/fallbacks
 ];
 
 /**


### PR DESCRIPTION
## Summary

- Adiciona segundo argumento (fallback) em todas as chamadas de `safeUrl()` em atributos `src` de imagens
- Adiciona `placehold.co` à `TRUSTED_DOMAINS` em `sanitize.ts`

## Problema

`safeUrl()` retorna `'#'` por padrão quando a URL é inválida ou de domínio não confiável. Usar `'#'` como `src` de `<img>` faz o browser disparar uma requisição carregando a própria URL da página como imagem — requisição inútil que aparece nos logs de rede.

Adicionalmente, as imagens placeholder de desenvolvimento (`https://placehold.co/...`) usadas em `ProductPage` e `ShopPage` eram bloqueadas por `safeUrl` pois `placehold.co` não estava na allowlist, fazendo o fallback ser `'#'` em vez da imagem de placeholder.

## Arquivos modificados

| Arquivo | Correção |
|---|---|
| `src/utils/sanitize.ts` | Adiciona `placehold.co` a `TRUSTED_DOMAINS` |
| `src/pages/MyAccountPage.tsx` | `safeUrl(ach.image)` → `safeUrl(ach.image, '')` |
| `src/pages/DashboardPage.tsx` | `safeUrl(image)` → `safeUrl(image, '')` |
| `src/pages/ProductPage.tsx` | Fallbacks em imagem principal e thumbnails da galeria |
| `src/pages/NewsPage.tsx` | Fallback vazio nas URLs do `srcSet` |

## Test plan

- [ ] Imagens de conquistas/achievements carregam (ou degradam para o ícone de fallback)
- [ ] Galeria de produtos exibe imagens corretamente
- [ ] Nenhuma requisição `src="#"` aparece no network tab do DevTools

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6aF2qt8Fu2Uf6Qebpsmy1)_