### PR TITLE
fix(ci): correct workflow name in Lighthouse trigger

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -2,7 +2,7 @@ name: Lighthouse Audit
 
 on:
   workflow_run:
-    workflows: ["🖥️ Deploy · Frontend"]
+    workflows: ["🚀 Deploy Frontend"]
     types: [completed]
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
O `lighthouse.yml` estava escutando por `"🖥️ Deploy · Frontend"` mas o workflow de deploy chama-se `"🚀 Deploy Frontend"` — por isso o Lighthouse nunca disparava automaticamente após os deploys.

**Fix:** corrige o nome do workflow no trigger `workflow_run`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6aF2qt8Fu2Uf6Qebpsmy1)_