### PR TITLE
fix(seo+a11y): remove Content-Signal from robots.txt, fix breadcrumb contrast

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -2,7 +2,7 @@ name: Lighthouse Audit
 
 on:
   workflow_run:
-    workflows: ["🖥️ Deploy · Frontend"]
+    workflows: ["🚀 Deploy Frontend"]
     types: [completed]
     branches: [main]
   workflow_dispatch:

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,7 +4,6 @@
 
 User-agent: *
 Allow: /
-Content-Signal: ai-train=yes, search=yes, ai-input=yes
 Allow: /wp-json/djzeneyer/v1/ai-context
 Disallow: /wp-admin/
 Disallow: /wp-login.php
@@ -165,7 +164,6 @@ User-agent: BraveBot
 User-agent: Qwenbot
 User-agent: MistralBot
 Allow: /
-Content-Signal: ai-train=yes, search=yes, ai-input=yes
 Allow: /wp-json/djzeneyer/v1/ai-context
 Disallow: /wp-admin/
 Disallow: /wp-login.php

--- a/src/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb.tsx
@@ -31,7 +31,7 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({ items, className = '' })
       animate={BREADCRUMB_ANIMATE}
       transition={BREADCRUMB_TRANSITION}
     >
-      <ol className="flex flex-wrap items-center justify-start gap-2 text-xs sm:text-sm text-white/50">
+      <ol className="flex flex-wrap items-center justify-start gap-2 text-xs sm:text-sm text-white/70">
         <li>
           <Link
             to={getLocalizedRoute('home', currentLang)}


### PR DESCRIPTION
Corrige os 2 problemas identificados no Lighthouse:

**SEO 92 → 100**
- Remove `Content-Signal: ai-train=yes, search=yes, ai-input=yes` do `robots.txt` — diretiva não reconhecida pelo RFC 9309, causava 2 erros no validator do Google. Os AI bots continuam com `Allow: /` explícito, que é o suficiente.

**Acessibilidade — contraste insuficiente**
- `Breadcrumb.tsx`: `text-white/50` → `text-white/70` no `<ol>` base, corrigindo o contraste WCAG AA do item "Home".

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6aF2qt8Fu2Uf6Qebpsmy1)_