### PR TITLE
revert(robots.txt): restore Content-Signal directive

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -2,7 +2,7 @@ name: Lighthouse Audit
 
 on:
   workflow_run:
-    workflows: ["🖥️ Deploy · Frontend"]
+    workflows: ["🚀 Deploy Frontend"]
     types: [completed]
     branches: [main]
   workflow_dispatch:

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,7 +4,6 @@
 
 User-agent: *
 Allow: /
-Content-Signal: ai-train=yes, search=yes, ai-input=yes
 Allow: /wp-json/djzeneyer/v1/ai-context
 Disallow: /wp-admin/
 Disallow: /wp-login.php
@@ -165,7 +164,6 @@ User-agent: BraveBot
 User-agent: Qwenbot
 User-agent: MistralBot
 Allow: /
-Content-Signal: ai-train=yes, search=yes, ai-input=yes
 Allow: /wp-json/djzeneyer/v1/ai-context
 Disallow: /wp-admin/
 Disallow: /wp-login.php

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,6 +4,7 @@
 
 User-agent: *
 Allow: /
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
 Allow: /wp-json/djzeneyer/v1/ai-context
 Disallow: /wp-admin/
 Disallow: /wp-login.php
@@ -164,6 +165,7 @@ User-agent: BraveBot
 User-agent: Qwenbot
 User-agent: MistralBot
 Allow: /
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
 Allow: /wp-json/djzeneyer/v1/ai-context
 Disallow: /wp-admin/
 Disallow: /wp-login.php

--- a/src/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb.tsx
@@ -31,7 +31,7 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({ items, className = '' })
       animate={BREADCRUMB_ANIMATE}
       transition={BREADCRUMB_TRANSITION}
     >
-      <ol className="flex flex-wrap items-center justify-start gap-2 text-xs sm:text-sm text-white/50">
+      <ol className="flex flex-wrap items-center justify-start gap-2 text-xs sm:text-sm text-white/70">
         <li>
           <Link
             to={getLocalizedRoute('home', currentLang)}


### PR DESCRIPTION
Restaura `Content-Signal` que foi removido incorretamente no PR #728.

`Content-Signal` é uma iniciativa da Cloudflare já presente em 3,8M de sites. O erro "Unknown directive" no Lighthouse era lag de versão — o [PR #16767](https://github.com/GoogleChrome/lighthouse/pull/16767) adicionou suporte oficial no Lighthouse 13.0.2 / Chrome 146 (março 2026).

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6aF2qt8Fu2Uf6Qebpsmy1)_