### PR TITLE
Update support page: novo texto de pitch para doação

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1051,7 +1051,9 @@
     },
     "header": {
       "title": "Support DJ <1>Zen Eyer</1>",
-      "description": "If you enjoy my work and want to help keep the cremosidade alive on the dance floor, here are a few simple ways to support it."
+      "description_p1": "If you're the kind of person who believes dancing can be more than steps — if you want more connection, human music, and real presence — supporting my work costs less than a water bottle at a zouk party.",
+      "description_p2": "For you, it's almost nothing. For me, it makes a big difference at the end of the month.",
+      "description_p3": "Consider contributing and helping this project keep existing, with new music, sets, and experiences made for those who don't want to stay on the surface."
     },
     "payment": {
       "title": "Payment Methods",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -1047,7 +1047,9 @@
     },
     "header": {
       "title": "Apoie o DJ <1>Zen Eyer</1>",
-      "description": "Se você gosta do meu trabalho e quer ajudar a manter a cremosidade nas pistas, aqui estão algumas formas simples de apoiar:"
+      "description_p1": "Se você é do tipo de pessoa que acredita que dançar pode ser mais do que passos, se você quer mais conexão, música humana e presença de verdade, apoiar o meu trabalho custa menos que uma garrafinha de água em uma festa de zouk.",
+      "description_p2": "Para você é quase nada. Para mim, faz uma grande diferença no fim do mês.",
+      "description_p3": "Considere colaborar e ajudar esse projeto a continuar existindo, com novas músicas, sets e experiências feitas para quem não quer ficar só na superfície."
     },
     "payment": {
       "title": "Métodos de Pagamento",

--- a/src/pages/SupportArtistPage.tsx
+++ b/src/pages/SupportArtistPage.tsx
@@ -150,9 +150,11 @@ const SupportArtistPage: React.FC = () => {
               Support DJ <span className="text-primary">Zen Eyer</span>
             </Trans>
           </h1>
-          <p className="text-base sm:text-xl text-white/70 max-w-2xl mx-auto leading-relaxed">
-            {t('support.header.description')}
-          </p>
+          <div className="text-base sm:text-xl text-white/70 max-w-2xl mx-auto leading-relaxed space-y-4">
+            <p>{t('support.header.description_p1')}</p>
+            <p>{t('support.header.description_p2')}</p>
+            <p>{t('support.header.description_p3')}</p>
+          </div>
         </motion.div>
 
         <section className="mx-auto mb-16 max-w-4xl rounded-2xl border border-white/10 bg-surface/40 p-5 sm:p-8">


### PR DESCRIPTION
## O que mudou

Substitui o texto genérico do cabeçalho da página de apoio por um pitch mais autêntico, direcionado à comunidade de zouk.

**Antes:**
> "Se você gosta do meu trabalho e quer ajudar a manter a cremosidade nas pistas, aqui estão algumas formas simples de apoiar:"

**Depois (3 parágrafos):**
> "Se você é do tipo de pessoa que acredita que dançar pode ser mais do que passos, se você quer mais conexão, música humana e presença de verdade, apoiar o meu trabalho custa menos que uma garrafinha de água em uma festa de zouk."
>
> "Para você é quase nada. Para mim, faz uma grande diferença no fim do mês."
>
> "Considere colaborar e ajudar esse projeto a continuar existindo, com novas músicas, sets e experiências feitas para quem não quer ficar só na superfície."

## Arquivos alterados

- `src/locales/pt/translation.json` — texto em português (3 campos `description_p1/p2/p3`)
- `src/locales/en/translation.json` — tradução equivalente em inglês
- `src/pages/SupportArtistPage.tsx` — componente atualizado para renderizar os 3 parágrafos separados

---
_Generated by [Claude Code](https://claude.ai/code/session_01NkaxwKML39MMkbyjgHthpn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Melhorias**
  * Reorganização da página de suporte ao artista: descrição agora apresentada em múltiplos parágrafos com espaçamento vertical aprimorado, facilitando a leitura e melhor compreensão das diferentes formas de apoiar e contribuir com o trabalho criativo do artista.
  * Atualização das traduções em português e inglês para refletir adequadamente a nova estrutura segmentada de apresentação do conteúdo de suporte.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->