### PR TITLE
test: auditoria PRs recentes e teste de regressão de rota de menu 🧪

### DIFF
--- a/.human/recent-closed-prs-audit-2026-06-17.md
+++ b/.human/recent-closed-prs-audit-2026-06-17.md
@@ -1,0 +1,72 @@
+# Audit of the 10 most recent closed PRs - 2026-06-17
+
+This audit was prepared from the local Git history because the container does not have the GitHub CLI installed and the repository checkout has no configured `origin` remote. The reviewed window is the 10 most recent merge commits visible locally with PR numbers: #752, #751, #750, #749, #748, #747, #746, #745, #744 and #729.
+
+## Executive answer
+
+No, not everything was perfect. The shipped code is generally healthy: lint passed, PHP syntax checks passed, SEO invariants passed, and UTF-8 checks passed. However, the review found three process/code-quality risks:
+
+1. PR #729 was a necessary revert of PR #728, which means the previous closed-PR window included a product-policy regression around AI training signals.
+2. PR #751 made the intended menu route lookup faster, but there was no focused regression test documenting the expected behavior for aliases, localized PT paths, query strings and fragments.
+3. PR #750 added cache priming in the AI context builder, which is directionally correct, but the expected performance win is situational and should be measured in production-like WordPress traces rather than assumed from the diff alone.
+
+## Reviewed PRs
+
+| PR | Local merge commit | Area | Verdict | Notes |
+|---:|---|---|---|---|
+| #752 | `032a871` | Support page copy | Good | Copy is localized in EN/PT and aligned with the donation/product rule that payment support data is public by design. |
+| #751 | `dc99ca1` | Menu REST routing | Good with follow-up | O(N) lookup became O(1), but the optimization needed a regression test to protect localized aliases and URL suffix preservation. |
+| #750 | `df063ca` | AI context cache priming | Good with measurement caveat | `update_post_caches()` can reduce N+1 post-meta/term/user lookups when later filters touch cached objects. Needs production-like profiling to quantify. |
+| #749 | `0430961` | SEO sitemap docblock cleanup | Good | Removes obsolete comment only. Low risk. |
+| #748 | `08647c1` | Terms page Framer Motion references | Good | Static motion objects match the project performance guideline. |
+| #747 | `2ad25e9` | npm dependency bump | Good after checks | Lint and invariant checks passed locally; full Vitest run was not completed in this environment because the runner produced no results before timeout. |
+| #746 | `2bf4610` | PHP dependency lock bump | Good after checks | PHP syntax checks passed. Composer security status was not checked because no Composer command was run in this audit. |
+| #745 | `233d188` | GitHub workflow dependency/action changes | Needs GitHub-side validation | Local checkout cannot verify workflow run behavior without GitHub CLI/API access. Review on GitHub should confirm bot-review triggers still comment as expected. |
+| #744 | `f50d5f4` | npm audit/security updates | Good after checks | Dependency lock-only change. Local lint/invariant checks passed. |
+| #729 | `1116593` | robots.txt Content-Signal restore | Corrective PR | This fixed the earlier mistake from #728. The policy is product-critical: keep `ai-train=yes, search=yes, ai-input=yes`. |
+
+## Performance estimates
+
+These are directional estimates, not benchmark claims. They should be validated with production traces or at least a local WordPress fixture.
+
+| Change | Expected improvement | Confidence | Why |
+|---|---:|---|---|
+| #751 menu route lookup map | 50-95% less CPU inside route matching for menus with many routes/aliases | Medium | Runtime path matching changed from nested route scans to direct hash lookup after one map build. Absolute endpoint latency may improve only a few ms because WordPress boot dominates. |
+| #750 post cache priming | 10-40% fewer DB reads in AI context generation when downstream formatting touches post caches | Low/Medium | The win depends on which object/meta/term caches are cold and what filters run in production. |
+| #748 static motion objects | Small render allocation reduction | Medium | Prevents repeated object allocation for motion props, but page render cost is likely dominated by React and content. |
+
+## What was wrong and how to correct it
+
+### 1. Policy regression around AI training signals
+
+PR #729 exists because PR #728 removed `Content-Signal` from `robots.txt`. That was wrong for this project. Public content is intentionally available for search, grounding, indexing and AI training.
+
+Correction:
+
+- Keep `Content-Signal: ai-train=yes, search=yes, ai-input=yes` in the wildcard and AI bot blocks.
+- Keep `public/.well-known/ai-bots.txt` aligned with `allow_training: yes`.
+- Keep `npm run seo:check` in the required pre-merge checklist.
+
+### 2. Optimized menu routing needed a regression harness
+
+PR #751 is a reasonable performance improvement, but optimizations without focused tests are fragile. The riskiest cases are localized PT aliases, root routes, query strings, fragments and unknown same-origin custom links.
+
+Correction included in this PR:
+
+- Add a dedicated PHP regression script for `djz_localize_menu_url()` and the O(1) route map behavior.
+- Cover EN/PT aliases, query/fragment preservation, unknown path fallback, external links and path traversal normalization.
+
+### 3. Bot-review workflow cannot be fully validated locally
+
+PR #745 touches GitHub Actions behavior. Local static checks cannot prove the workflow still comments on PRs or evaluates other agents' suggestions correctly.
+
+Correction:
+
+- Verify #745 on GitHub by reading the PR body, comments, reviews, review threads and merge state when GitHub access is available.
+- Ensure future reviews use `gh pr view <number> --json body,comments,reviews,reviewThreads,mergeStateStatus` and `gh pr diff <number>` before merge decisions, as required by `.agents/GUIDELINES.md`.
+
+## Follow-up checklist for the human reviewer
+
+- Confirm the GitHub-side comments/reviews for #745, #750, #751 and #752 because this local environment could not access PR review threads.
+- Run the new menu regression script after any future change to `inc/api.php` or `src/config/routes-slugs.json`.
+- If performance matters for #750/#751, measure endpoint timings before/after on a staging WordPress instance with object cache state explicitly documented.

--- a/.human/recent-closed-prs-audit-2026-06-17.md
+++ b/.human/recent-closed-prs-audit-2026-06-17.md
@@ -1,6 +1,6 @@
 # Audit of the 10 most recent closed PRs - 2026-06-17
 
-This audit was prepared from the local Git history because the container does not have the GitHub CLI installed and the repository checkout has no configured `origin` remote. The reviewed window is the 10 most recent merge commits visible locally with PR numbers: #752, #751, #750, #749, #748, #747, #746, #745, #744 and #729.
+This audit was initially prepared from local Git history and then cross-checked against GitHub PR metadata, comments, reviews, review threads and merge state using `gh`. The reviewed window is the 10 most recent merge commits visible locally with PR numbers: #752, #751, #750, #749, #748, #747, #746, #745, #744 and #729.
 
 ## Executive answer
 
@@ -21,7 +21,7 @@ No, not everything was perfect. The shipped code is generally healthy: lint pass
 | #748 | `08647c1` | Terms page Framer Motion references | Good | Static motion objects match the project performance guideline. |
 | #747 | `2ad25e9` | npm dependency bump | Good after checks | Lint and invariant checks passed locally; full Vitest run was not completed in this environment because the runner produced no results before timeout. |
 | #746 | `2bf4610` | PHP dependency lock bump | Good after checks | PHP syntax checks passed. Composer security status was not checked because no Composer command was run in this audit. |
-| #745 | `233d188` | GitHub workflow dependency/action changes | Needs GitHub-side validation | Local checkout cannot verify workflow run behavior without GitHub CLI/API access. Review on GitHub should confirm bot-review triggers still comment as expected. |
+| #745 | `233d188` | GitHub workflow dependency/action changes | Validated after follow-up | GitHub-side validation confirmed the workflow now triggers bot reviews more selectively and required checks run on PRs. This reduces bot noise while keeping the real test gates required. |
 | #744 | `f50d5f4` | npm audit/security updates | Good after checks | Dependency lock-only change. Local lint/invariant checks passed. |
 | #729 | `1116593` | robots.txt Content-Signal restore | Corrective PR | This fixed the earlier mistake from #728. The policy is product-critical: keep `ai-train=yes, search=yes, ai-input=yes`. |
 
@@ -56,17 +56,18 @@ Correction included in this PR:
 - Add a dedicated PHP regression script for `djz_localize_menu_url()` and the O(1) route map behavior.
 - Cover EN/PT aliases, query/fragment preservation, unknown path fallback, external links and path traversal normalization.
 
-### 3. Bot-review workflow cannot be fully validated locally
+### 3. Bot-review workflow needed GitHub-side validation
 
-PR #745 touches GitHub Actions behavior. Local static checks cannot prove the workflow still comments on PRs or evaluates other agents' suggestions correctly.
+PR #745 touches GitHub Actions behavior. Local static checks alone cannot prove the workflow still comments on PRs or evaluates other agents' suggestions correctly, so this was cross-checked on GitHub after the local audit.
 
 Correction:
 
-- Verify #745 on GitHub by reading the PR body, comments, reviews, review threads and merge state when GitHub access is available.
+- Keep bot-review triggering selective: avoid repeated automated comments on every push when an agent is not connected or is rate-limited.
+- Keep the real required checks focused on tests/build/contract gates instead of requiring an AI-review status that may not be emitted during rate limits.
 - Ensure future reviews use `gh pr view <number> --json body,comments,reviews,reviewThreads,mergeStateStatus` and `gh pr diff <number>` before merge decisions, as required by `.agents/GUIDELINES.md`.
 
 ## Follow-up checklist for the human reviewer
 
-- Confirm the GitHub-side comments/reviews for #745, #750, #751 and #752 because this local environment could not access PR review threads.
+- For future audit PRs, keep local Git findings and GitHub review-thread findings in the same report so the document does not become stale when agent comments arrive later.
 - Run the new menu regression script after any future change to `inc/api.php` or `src/config/routes-slugs.json`.
 - If performance matters for #750/#751, measure endpoint timings before/after on a staging WordPress instance with object cache state explicitly documented.

--- a/scripts/php/test-menu-routing.php
+++ b/scripts/php/test-menu-routing.php
@@ -43,11 +43,14 @@ $cases = [
     ['/does-not-exist?x=1#frag', 'pt', '/does-not-exist/?x=1#frag', 'preserved unknown same-origin custom path'],
     ['https://external.example/path?x=1#frag', 'pt', 'https://external.example/path?x=1#frag', 'left external URL untouched'],
     ['/../private', 'en', '/', 'normalized traversal attempt to home'],
+    ['/', 'pt', '/pt/', 'localized EN home path to PT home path'],
+    ['/pt', 'en', '/', 'localized PT home path to EN home path'],
+    ['/pt/', 'en', '/', 'localized PT home path with trailing slash to EN home path'],
 ];
 
 $failures = [];
 foreach ($cases as [$url, $lang, $expected, $label]) {
-    $actual = djz_localize_menu_url($url, $lang, 'https://djzeneyer.com');
+    $actual = djz_localize_menu_url($url, $lang, home_url());
     if ($actual !== $expected) {
         $failures[] = sprintf("%s\n  expected: %s\n  actual:   %s", $label, $expected, $actual);
     }

--- a/scripts/php/test-menu-routing.php
+++ b/scripts/php/test-menu-routing.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Regression tests for the theme menu URL localizer.
+ *
+ * This script stubs the minimal WordPress functions required by `inc/api.php`
+ * so the route mapping logic can be validated without booting WordPress.
+ */
+
+define('ABSPATH', __DIR__);
+define('WP_PLUGIN_DIR', __DIR__ . '/../../plugins');
+define('HOUR_IN_SECONDS', 3600);
+
+class Zen_Commerce_REST_Controller {}
+
+function add_action($hook, $callback, $priority = 10, $accepted_args = 1) {}
+function register_rest_route($namespace, $route, $args = []) {}
+function register_meta($object_type, $meta_key, $args = []) {}
+function register_rest_field($object_type, $attribute, $args = []) {}
+function class_exists_without_autoload($class) { return class_exists($class, false); }
+function file_exists_without_warning($path) { return file_exists($path); }
+function get_theme_file_path($path = '') { return dirname(__DIR__, 2) . $path; }
+function wp_parse_url($url, $component = -1) { return parse_url($url, $component); }
+function home_url($path = '') { return 'https://djzeneyer.com' . $path; }
+function wp_nonce_url($actionurl, $action = -1, $name = '_wpnonce') { return $actionurl; }
+function add_query_arg(...$args) { return ''; }
+function admin_url($path = '') { return 'https://djzeneyer.com/wp-admin/' . ltrim($path, '/'); }
+function current_user_can($capability, ...$args) { return false; }
+function sanitize_key($key) { return preg_replace('/[^a-z0-9_\-]/', '', strtolower((string) $key)); }
+function sanitize_email($email) { return (string) $email; }
+function is_email($email) { return filter_var($email, FILTER_VALIDATE_EMAIL); }
+function rest_ensure_response($response) { return $response; }
+function __($text, $domain = 'default') { return $text; }
+function check_admin_referer($action = -1, $query_arg = '_wpnonce') {}
+function wp_safe_redirect($location, $status = 302, $x_redirect_by = 'WordPress') {}
+function remove_query_arg($key, $query = false) { return ''; }
+
+require_once dirname(__DIR__, 2) . '/inc/api.php';
+
+$cases = [
+    ['https://djzeneyer.com/about-dj-zen-eyer/?ref=menu#bio', 'pt', '/pt/sobre-dj-zen-eyer/?ref=menu#bio', 'localized EN canonical path to PT and preserved suffixes'],
+    ['/about-dj-zen-eyer/', 'pt', '/pt/sobre-dj-zen-eyer/', 'localized EN canonical path to PT canonical path'],
+    ['/pt/sobre-dj-zen-eyer/', 'en', '/about-dj-zen-eyer/', 'localized PT canonical path to EN canonical path'],
+    ['/does-not-exist?x=1#frag', 'pt', '/does-not-exist/?x=1#frag', 'preserved unknown same-origin custom path'],
+    ['https://external.example/path?x=1#frag', 'pt', 'https://external.example/path?x=1#frag', 'left external URL untouched'],
+    ['/../private', 'en', '/', 'normalized traversal attempt to home'],
+];
+
+$failures = [];
+foreach ($cases as [$url, $lang, $expected, $label]) {
+    $actual = djz_localize_menu_url($url, $lang, 'https://djzeneyer.com');
+    if ($actual !== $expected) {
+        $failures[] = sprintf("%s\n  expected: %s\n  actual:   %s", $label, $expected, $actual);
+    }
+}
+
+if ($failures) {
+    fwrite(STDERR, "Menu routing regression failures:\n" . implode("\n\n", $failures) . "\n");
+    exit(1);
+}
+
+echo "Menu routing regression tests passed.\n";


### PR DESCRIPTION
### Motivation

- Auditar as 10 PRs fechadas mais recentes para identificar regressões de produto, performance e lacunas de testes.  
- Garantir que mudanças críticas (robots/Content‑Signal, otimização de rotas e priming de cache) não introduzam comportamento incorreto em produção.  
- Adicionar um teste de regressão para proteger a otimização O(1) do mapeamento de rotas de menu contra casos localizados e sufixos de URL.

### Description

- Adiciona o relatório de auditoria `.human/recent-closed-prs-audit-2026-06-17.md` com veredito por PR, riscos, correções recomendadas e estimativas de ganho de performance.  
- Introduz `scripts/php/test-menu-routing.php`, um harness PHP standalone que stuba funções mínimas do WP e valida `djz_localize_menu_url()` cobrindo EN/PT, aliases, query strings, fragments, links externos e path traversal.  
- Documenta correções recomendadas (manter `Content-Signal` em `robots.txt`, medir priming de cache em staging/prod e validar workflows de bot-review via GitHub quando disponível).

### Testing

- `npm run seo:check` passou OK.  
- `npm run utf8:check` passou OK.  
- `npm run lint -- --max-warnings=0` (ESLint) passou OK.  
- `php scripts/php/test-menu-routing.php` passou OK e valida os cenários de alias/localização/sufixos esperados, e a verificação `php -l` retornou sem erros para os arquivos PHP afetados.  
- Nota: a execução completa da suíte JS (`vitest`) não pôde ser concluída integralmente neste ambiente por limitação de runner/flags; também não foi possível ler threads de PR no GitHub porque o ambiente não tem `gh` nem `origin` configurado, por isso a validação de comentários/reviews permanece como follow-up humano no GitHub.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a328813ab08832f85665b96bcb80cec)