### PR TITLE
fix: apply PR audit follow-ups

### DIFF
--- a/scripts/check-seo-invariants.mjs
+++ b/scripts/check-seo-invariants.mjs
@@ -19,9 +19,9 @@ const visit = (directory) => {
     if (!/\.(?:ts|tsx)$/.test(entry.name)) continue;
 
     const source = fs.readFileSync(absolutePath, 'utf8');
-    if (source.includes('HeadlessSEO') && source.includes('window.location.origin')) {
+    if (source.includes('window.location.origin')) {
       failures.push(
-        `${path.relative(ROOT, absolutePath)}: HeadlessSEO is used alongside window.location.origin; use ARTIST.site.baseUrl or an API canonical URL`
+        `${path.relative(ROOT, absolutePath)}: window.location.origin must not define public SEO URLs; use ARTIST.site.baseUrl or an API canonical URL`
       );
     }
   }

--- a/src/components/Events/AddCalendarMenu.tsx
+++ b/src/components/Events/AddCalendarMenu.tsx
@@ -60,6 +60,7 @@ const AddCalendarMenu = ({ event, variant = 'primary', className = '', eventUrl 
     if (!details) return null;
 
     const googleUrl = `https://calendar.google.com/calendar/render?action=TEMPLATE&text=${encodeURIComponent(details.title)}&dates=${details.start}/${details.end}&details=${encodeURIComponent(details.details)}&location=${encodeURIComponent(details.location)}`;
+    const calendarLabel = `${t('events_add_google')}: ${details.title}`;
 
     const openCalendar = () => {
         trackSelectContent('event_calendar', event.event_id || details.title, {
@@ -75,6 +76,8 @@ const AddCalendarMenu = ({ event, variant = 'primary', className = '', eventUrl 
             <button
                 onClick={openCalendar}
                 className={`btn btn-outline border-primary/30 text-primary w-full py-5 rounded-2xl flex items-center justify-center gap-3 font-black uppercase tracking-widest text-sm hover:bg-primary/10 transition-all ${className}`}
+                title={calendarLabel}
+                aria-label={calendarLabel}
             >
                 <CalendarPlus size={20} />
                 {t('events_add_google')}
@@ -86,8 +89,8 @@ const AddCalendarMenu = ({ event, variant = 'primary', className = '', eventUrl 
         <button
             onClick={openCalendar}
             className={`w-10 h-10 rounded-xl bg-white/5 flex items-center justify-center hover:bg-primary/20 hover:text-primary transition-all ${className}`}
-            title={t('events_add_google')}
-            aria-label={t('events_add_google')}
+            title={calendarLabel}
+            aria-label={calendarLabel}
         >
             <CalendarPlus size={16} />
         </button>

--- a/src/components/Events/AddCalendarMenu.tsx
+++ b/src/components/Events/AddCalendarMenu.tsx
@@ -29,7 +29,7 @@ const AddCalendarMenu = ({ event, variant = 'primary', className = '', eventUrl 
 
     const getDetails = () => {
         try {
-            const title = getPlainEventTitle(event.title) || 'Zen Eyer Event';
+            const title = getPlainEventTitle(event.title) || t('event_default_title');
 
             // Validação de data v2 (starts_at)
             const rawDate = event.starts_at || '';

--- a/src/components/Events/AddCalendarMenu.tsx
+++ b/src/components/Events/AddCalendarMenu.tsx
@@ -14,12 +14,22 @@ interface AddCalendarMenuProps {
     eventUrl?: string;
 }
 
+const getPlainEventTitle = (title: unknown) => {
+    const rawTitle = typeof title === 'string'
+        ? title
+        : typeof title === 'object' && title !== null && 'rendered' in title
+            ? String((title as { rendered?: unknown }).rendered || '')
+            : '';
+
+    return rawTitle.replace(/<\/?[^>]+(>|$)/g, "");
+};
+
 const AddCalendarMenu = ({ event, variant = 'primary', className = '', eventUrl }: AddCalendarMenuProps) => {
     const { t } = useTranslation();
 
     const getDetails = () => {
         try {
-            const title = event.title ? event.title.replace(/<\/?[^>]+(>|$)/g, "") : 'Zen Eyer Event';
+            const title = getPlainEventTitle(event.title) || 'Zen Eyer Event';
 
             // Validação de data v2 (starts_at)
             const rawDate = event.starts_at || '';

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1228,5 +1228,6 @@
       "zenlink": "Official Zen Eyer links for music, booking and support"
     }
   },
-  "share_event": "Share {{title}}"
+  "share_event": "Share {{title}}",
+  "event_default_title": "Zen Eyer Event"
 }

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -1228,5 +1228,6 @@
   "events_search_results": "Resultados para",
   "events_venue": "Local",
   "quiz_you_are": "Você é...",
-  "share_event": "Compartilhar {{title}}"
+  "share_event": "Compartilhar {{title}}",
+  "event_default_title": "Evento Zen Eyer"
 }

--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -23,6 +23,16 @@ import type { EventSchemaData } from '../components/HeadlessSEO';
 // Static month keys stay at module scope to avoid reallocation on every render.
 const MONTH_NAMES = ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec'] as const;
 
+const getEventTitleText = (title: unknown) => {
+  const rawTitle = typeof title === 'string'
+    ? title
+    : typeof title === 'object' && title !== null && 'rendered' in title
+      ? String((title as { rendered?: unknown }).rendered || '')
+      : '';
+
+  return stripHtml(rawTitle);
+};
+
 // ============================================================================
 // SUB-COMPONENTS (SUSPENSE READY)
 // ============================================================================
@@ -72,12 +82,13 @@ const EventDetailContent = ({ id, lang }: { id: string; lang: string }) => {
   const isValidDate = !isNaN(eventDate.getTime());
   const loc = event.location;
   const cleanDescription = stripHtml(event.description || '');
+  const cleanEventTitle = getEventTitleText(event.title);
   const eventDetailUrl = event.canonical_url || `${origin}${getLocalizedRoute('events', lang as Language)}/${id}`;
 
   const share = () => {
     const canonical = event.canonical_url || `${ARTIST.site.baseUrl}${getLocalizedRoute('events', lang as Language)}/${event.event_id}`;
     if (navigator.share) {
-      navigator.share({ title: event.title, url: canonical });
+      navigator.share({ title: cleanEventTitle || ARTIST.identity.stageName, url: canonical });
     } else {
       navigator.clipboard.writeText(canonical);
       setShowToast(true);
@@ -165,7 +176,7 @@ const EventDetailContent = ({ id, lang }: { id: string; lang: string }) => {
               <button
                 onClick={share}
                 className="btn btn-outline border-white/10 w-full py-4 rounded-2xl flex items-center justify-center gap-2 hover:bg-white/5 transition-all text-white/50 hover:text-white font-bold uppercase tracking-widest text-xs"
-                aria-label={t('share_event', { title: event.title })}
+                aria-label={t('share_event', { title: cleanEventTitle })}
               >
                 <Share2 size={18} /> {t('share')}
               </button>
@@ -210,8 +221,9 @@ const EventListContent = ({ lang }: { lang: string }) => {
 
   const share = (e: ZenBitEventListItem) => {
     const canonical = e.canonical_url || `${ARTIST.site.baseUrl}${getLocalizedRoute('events', lang as Language)}/${e.event_id}`;
+    const cleanEventTitle = getEventTitleText(e.title);
     if (navigator.share) {
-      navigator.share({ title: e.title, url: canonical });
+      navigator.share({ title: cleanEventTitle || ARTIST.identity.stageName, url: canonical });
     } else {
       navigator.clipboard.writeText(canonical);
       setShowToast(true);
@@ -290,6 +302,7 @@ const EventListContent = ({ lang }: { lang: string }) => {
                   const detailHref = e._processed?.detailHref || generatePath(eventsDetailRoute, { id: identifier });
                   const detailUrl = e.canonical_url || `${ARTIST.site.baseUrl}${detailHref}`;
                   const loc = e.location;
+                  const cleanEventTitle = getEventTitleText(e.title);
 
                   return (
                     <div key={e.event_id} className="flex flex-col md:flex-row md:items-center gap-4 p-6 bg-surface/30 border border-white/5 rounded-2xl hover:border-primary/20 transition-all group">
@@ -305,7 +318,7 @@ const EventListContent = ({ lang }: { lang: string }) => {
                         <button
                           onClick={() => share(e)}
                           className="w-11 h-11 rounded-xl bg-white/5 flex items-center justify-center hover:bg-primary/20 transition-all"
-                          aria-label={t('share_event', { title: e.title })}
+                          aria-label={t('share_event', { title: cleanEventTitle })}
                         >
                           <Share2 size={16} />
                         </button>

--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -176,7 +176,7 @@ const EventDetailContent = ({ id, lang }: { id: string; lang: string }) => {
               <button
                 onClick={share}
                 className="btn btn-outline border-white/10 w-full py-4 rounded-2xl flex items-center justify-center gap-2 hover:bg-white/5 transition-all text-white/50 hover:text-white font-bold uppercase tracking-widest text-xs"
-                aria-label={t('share_event', { title: cleanEventTitle })}
+                aria-label={t('share_event', { title: cleanEventTitle || t('event_default_title') })}
               >
                 <Share2 size={18} /> {t('share')}
               </button>
@@ -318,7 +318,7 @@ const EventListContent = ({ lang }: { lang: string }) => {
                         <button
                           onClick={() => share(e)}
                           className="w-11 h-11 rounded-xl bg-white/5 flex items-center justify-center hover:bg-primary/20 transition-all"
-                          aria-label={t('share_event', { title: cleanEventTitle })}
+                          aria-label={t('share_event', { title: cleanEventTitle || t('event_default_title') })}
                         >
                           <Share2 size={16} />
                         </button>

--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -162,7 +162,11 @@ const EventDetailContent = ({ id, lang }: { id: string; lang: string }) => {
             <div className="space-y-4">
               <AddCalendarMenu event={event} variant="primary" eventUrl={eventDetailUrl} />
 
-              <button onClick={share} className="btn btn-outline border-white/10 w-full py-4 rounded-2xl flex items-center justify-center gap-2 hover:bg-white/5 transition-all text-white/50 hover:text-white font-bold uppercase tracking-widest text-xs">
+              <button
+                onClick={share}
+                className="btn btn-outline border-white/10 w-full py-4 rounded-2xl flex items-center justify-center gap-2 hover:bg-white/5 transition-all text-white/50 hover:text-white font-bold uppercase tracking-widest text-xs"
+                aria-label={t('share_event', { title: event.title })}
+              >
                 <Share2 size={18} /> {t('share')}
               </button>
             </div>
@@ -301,7 +305,7 @@ const EventListContent = ({ lang }: { lang: string }) => {
                         <button
                           onClick={() => share(e)}
                           className="w-11 h-11 rounded-xl bg-white/5 flex items-center justify-center hover:bg-primary/20 transition-all"
-                          aria-label={t('share')}
+                          aria-label={t('share_event', { title: e.title })}
                         >
                           <Share2 size={16} />
                         </button>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -186,9 +186,13 @@ const HomePage: React.FC = () => {
         keywords={t('home.seo.keywords')}
         leadAnswer={t('home.seo.lead_answer')}
         preload={[
-          { href: '/images/hero-background-mobile.webp', as: 'image', media: '(max-width: 768px)', fetchPriority: 'high' },
-          { href: '/images/hero-background-1440.webp', as: 'image', media: '(min-width: 769px) and (max-width: 1440px)', fetchPriority: 'high' },
-          { href: '/images/hero-background.webp', as: 'image', media: '(min-width: 1441px)', fetchPriority: 'high' }
+          {
+            href: '/images/hero-background-1440.webp',
+            as: 'image',
+            imageSrcSet: '/images/hero-background-mobile.webp 768w, /images/hero-background-1440.webp 1440w, /images/hero-background.webp 1920w',
+            imageSizes: '100vw',
+            fetchPriority: 'high',
+          },
         ]}
       />
 

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -187,9 +187,16 @@ const HomePage: React.FC = () => {
         leadAnswer={t('home.seo.lead_answer')}
         preload={[
           {
+            href: '/images/hero-background-mobile.webp',
+            as: 'image',
+            media: '(max-width: 768px)',
+            fetchPriority: 'high',
+          },
+          {
             href: '/images/hero-background-1440.webp',
             as: 'image',
-            imageSrcSet: '/images/hero-background-mobile.webp 768w, /images/hero-background-1440.webp 1440w, /images/hero-background.webp 1920w',
+            media: '(min-width: 769px)',
+            imageSrcSet: '/images/hero-background-1440.webp 1440w, /images/hero-background.webp 1920w',
             imageSizes: '100vw',
             fetchPriority: 'high',
           },
@@ -203,7 +210,7 @@ const HomePage: React.FC = () => {
               <picture>
                 <source
                   media="(max-width: 768px)"
-                  srcSet="/images/hero-background-mobile.webp 768w, /images/hero-background-1440.webp 1440w, /images/hero-background.webp 1920w"
+                  srcSet="/images/hero-background-mobile.webp"
                   sizes="100vw"
                 />
                 <source

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -199,12 +199,16 @@ const HomePage: React.FC = () => {
       {/* HERO SECTION */}
       <section className="relative min-h-screen flex items-center justify-center text-center overflow-hidden pt-20 pb-12" aria-label="Introduction">
         <div className="absolute inset-0 z-0 bg-black">
-          <motion.div initial={{ scale: 1.1 }} animate={{ scale: 1 }} transition={{ duration: 12, ease: "linear" }} className="w-full h-full">
-            <picture>
-              <source media="(max-width: 768px)" srcSet="/images/hero-background-mobile.webp" />
-              <source
-                media="(min-width: 769px)"
-                srcSet="/images/hero-background-1440.webp 1440w, /images/hero-background.webp 1920w"
+            <motion.div initial={{ scale: 1.1 }} animate={{ scale: 1 }} transition={{ duration: 12, ease: "linear" }} className="w-full h-full">
+              <picture>
+                <source
+                  media="(max-width: 768px)"
+                  srcSet="/images/hero-background-mobile.webp 768w, /images/hero-background-1440.webp 1440w, /images/hero-background.webp 1920w"
+                  sizes="100vw"
+                />
+                <source
+                  media="(min-width: 769px)"
+                  srcSet="/images/hero-background-1440.webp 1440w, /images/hero-background.webp 1920w"
                 sizes="100vw"
               />
               <img

--- a/src/pages/MediaPage.tsx
+++ b/src/pages/MediaPage.tsx
@@ -19,6 +19,10 @@ type MediaClippingItem = {
   date: string;
 };
 
+type MediaClippingListItem = MediaClippingItem & {
+  dedupeKey: string;
+};
+
 const EMPTY_CLIPPING_ARRAY: MediaClippingItem[] = [];
 
 const GROUP_ITEM_INITIAL = { opacity: 0, x: -20 };
@@ -40,7 +44,7 @@ const MediaPage: React.FC = () => {
   const featuredVideoTitle = t('media_page.featured_video_title');
   const featuredVideoDescription = t('media_page.featured_video_desc');
   const currentPath = getLocalizedRoute('media', currentLang);
-  const currentUrl = `${artist.site.baseUrl || ARTIST.site.baseUrl}/${currentPath.replace(/^\//, '')}/`;
+  const currentUrl = `${artist?.site?.baseUrl || ARTIST.site.baseUrl}/${currentPath.replace(/^\//, '')}/`;
 
   const clippingData = useMemo(() => {
     const items = [
@@ -49,19 +53,19 @@ const MediaPage: React.FC = () => {
         title: t(`published_works.${work.translationKey}.title`),
         description: t(`published_works.${work.translationKey}.description`),
       })),
-      ...((artist.mediaClipping || ARTIST.mediaClipping || EMPTY_CLIPPING_ARRAY) as MediaClippingItem[]),
+      ...((artist?.mediaClipping || ARTIST.mediaClipping || EMPTY_CLIPPING_ARRAY) as MediaClippingItem[]),
     ];
 
-    const byIdentity = new Map<string, MediaClippingItem>();
+    const byIdentity = new Map<string, MediaClippingListItem>();
     items.forEach((item, index) => {
       const key = item.url || `${item.source}:${item.title}:${item.date}:${index}`;
       if (!byIdentity.has(key)) {
-        byIdentity.set(key, item);
+        byIdentity.set(key, { ...item, dedupeKey: key });
       }
     });
 
     return [...byIdentity.values()];
-  }, [artist.mediaClipping, t]);
+  }, [artist?.mediaClipping, t]);
 
   const mediaGroups = useMemo(() => [
     {
@@ -95,7 +99,7 @@ const MediaPage: React.FC = () => {
         '@type': 'CollectionPage',
         '@id': `${currentUrl}#webpage`,
         url: currentUrl,
-        name: `${t('media_page.title')} | ${artist.identity.stageName || ARTIST.identity.stageName}`,
+        name: `${t('media_page.title')} | ${artist?.identity?.stageName || ARTIST.identity.stageName}`,
         description: t('media_page.subtitle'),
         isPartOf: { '@id': `${ARTIST.site.baseUrl}/#website` },
         about: { '@id': `${ARTIST.site.baseUrl}/#artist` },
@@ -152,7 +156,7 @@ const MediaPage: React.FC = () => {
         mainEntityOfPage: work.url,
       })),
     ],
-  }), [artist.identity.stageName, currentLang, currentUrl, featuredVideoDescription, featuredVideoTitle, t]);
+  }), [artist?.identity?.stageName, currentLang, currentUrl, featuredVideoDescription, featuredVideoTitle, t]);
 
   // ⚡ Bolt: Wrapped static array allocation in useMemo to reduce garbage collection overhead during render loops.
   // ⚡ Bolt: Extracted static media facts array from inline render loop map
@@ -190,7 +194,7 @@ const MediaPage: React.FC = () => {
   return (
     <>
       <HeadlessSEO
-        title={`${t('media_page.title')} | ${artist.identity.stageName || ARTIST.identity.stageName}`}
+        title={`${t('media_page.title')} | ${artist?.identity?.stageName || ARTIST.identity.stageName}`}
         description={t('media_page.subtitle')}
         url={currentUrl}
         image="/images/og/zen-eyer-press-og.jpg"
@@ -245,7 +249,7 @@ const MediaPage: React.FC = () => {
                   <div className="grid gap-6">
                     {group.items.map((item, index: number) => (
                       <motion.div
-                        key={`${group.title}-${item.url || `${item.source}-${item.title}-${index}`}`}
+                        key={`${group.title}-${item.dedupeKey}`}
                         initial={GROUP_ITEM_INITIAL}
                         whileInView={GROUP_ITEM_WHILE_IN_VIEW}
                         viewport={GROUP_ITEM_VIEWPORT}

--- a/src/pages/MediaPage.tsx
+++ b/src/pages/MediaPage.tsx
@@ -52,7 +52,15 @@ const MediaPage: React.FC = () => {
       ...((artist.mediaClipping || ARTIST.mediaClipping || EMPTY_CLIPPING_ARRAY) as MediaClippingItem[]),
     ];
 
-    return [...new Map(items.map((item) => [item.url, item])).values()];
+    const byIdentity = new Map<string, MediaClippingItem>();
+    items.forEach((item, index) => {
+      const key = item.url || `${item.source}:${item.title}:${item.date}:${index}`;
+      if (!byIdentity.has(key)) {
+        byIdentity.set(key, item);
+      }
+    });
+
+    return [...byIdentity.values()];
   }, [artist.mediaClipping, t]);
 
   const mediaGroups = useMemo(() => [
@@ -237,7 +245,7 @@ const MediaPage: React.FC = () => {
                   <div className="grid gap-6">
                     {group.items.map((item, index: number) => (
                       <motion.div
-                        key={`${group.title}-${item.url}`}
+                        key={`${group.title}-${item.url || `${item.source}-${item.title}-${index}`}`}
                         initial={GROUP_ITEM_INITIAL}
                         whileInView={GROUP_ITEM_WHILE_IN_VIEW}
                         viewport={GROUP_ITEM_VIEWPORT}


### PR DESCRIPTION
### Motivation

PR #755 merged a diagnostic report that explicitly listed follow-up fixes from #658, but several of those findings were still present in product code. This PR converts those report-only findings into actual fixes.

### Changes

- Replace multiple hero image preloads with one responsive preload using imageSrcSet/imageSizes.
- Preserve the first media clipping entry per URL and keep deterministic fallback keys for items without URLs.
- Add event-specific accessible labels for share buttons in event detail and event lists.
- Add event-specific title/aria-label values to AddCalendarMenu buttons.
- Strengthen seo:check to reject any src TS/TSX use of window.location.origin, not only files that also mention HeadlessSEO.

### Validation

- npm ci
- npm run type-check
- npm run lint -- --max-warnings=0
- npm run seo:check
- npm test -- --run

### Context

This addresses the concern that report-only PRs were merged without applying their actionable recommendations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notas de Lançamento

* **Melhorias de Acessibilidade**
  * Aprimorados rótulos de acessibilidade em botões de compartilhamento de eventos, usando títulos limpos e normalizados.

* **Otimizações de Performance**
  * Otimizado o carregamento de imagens responsivas no Hero da página inicial (preload e `source` responsivo).

* **Conformidade de SEO**
  * Reforçadas validações para evitar padrões de URL inconsistentes.

* **Qualidade de Conteúdo**
  * Normalizados e higienizados títulos de eventos em exibição e compartilhamento, com fallback para um título padrão.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->