### PR TITLE
fix(seo): include event address region in MusicEvent graph

### DIFF
--- a/src/components/HeadlessSEO.tsx
+++ b/src/components/HeadlessSEO.tsx
@@ -69,7 +69,7 @@ export interface EventSchemaData {
   start_date?: string;
   ends_at?: string;
   end_date?: string;
-  location?: { venue?: string; city?: string; country?: string };
+  location?: { venue?: string; city?: string; region?: string; country?: string };
   event_location?: string;
   event_ticket?: string;
   tickets?: string[];

--- a/src/seo/buildDynamicGraph.ts
+++ b/src/seo/buildDynamicGraph.ts
@@ -133,10 +133,12 @@ export function buildDynamicGraph(opts: BuildDynamicGraphOpts): Record<string, u
       }
 
       const eventCity = event.location?.city || '';
+      const eventRegion = event.location?.region || '';
       const eventCountry = event.location?.country || '';
       const isOnline = locName.toLowerCase().includes('online');
       const addressObj: Record<string, string> = { '@type': 'PostalAddress' };
       if (eventCity) addressObj['addressLocality'] = eventCity;
+      if (eventRegion) addressObj['addressRegion'] = eventRegion;
       if (eventCountry) addressObj['addressCountry'] = eventCountry;
 
       const eventDescription =


### PR DESCRIPTION
### Motivation

docs/music-event-schema-audit.md recommends follow-up fixes for MusicEvent schema quality. The backend Zen BIT normalizer already emits ddressRegion, but the frontend dynamic graph builder only carried city and country.

### Change

- Include event.location.region as location.address.addressRegion in frontend-generated MusicEvent JSON-LD.

### Notes

The other audit follow-ups appear already covered in current code: Zen BIT detail payload exposes offers/	ickets, and canonical event URLs are present in the event schemas/types.