### PR TITLE
docs: mark audit reports superseded

### DIFF
--- a/.human/PR_AUDIT_2026-06-17_RECENT_PRS.md
+++ b/.human/PR_AUDIT_2026-06-17_RECENT_PRS.md
@@ -1,3 +1,11 @@
+> [!IMPORTANT]
+> Status: superseded by implementation PRs #757 and #758.
+>
+> This file is retained as historical audit evidence. Do not treat the actionable
+> follow-ups below as open backlog without first checking the implementation PRs:
+> #757 covers the PR #658 audit follow-ups, and #758 covers the MusicEvent
+> address-region schema follow-up.
+
 # 🧾 Auditoria de PRs recentes — 2026-05-23 a 2026-06-02
 
 > **Status do relatório:** inventário operacional para desenvolvedores humanos e agentes. Atualizado com a verificação de que o PR #658 foi mergeado em 2026-06-03.

--- a/.human/PR_AUDIT_2026-06-17_RECENT_PRS.md
+++ b/.human/PR_AUDIT_2026-06-17_RECENT_PRS.md
@@ -3,8 +3,9 @@
 >
 > This file is retained as historical audit evidence. Do not treat the actionable
 > follow-ups below as open backlog without first checking the implementation PRs:
-> #757 covers the PR #658 audit follow-ups, and #758 covers the MusicEvent
-> address-region schema follow-up.
+> #757 covers the PR #658 audit follow-ups (accessibility labels on share buttons,
+> responsive hero image preload, and media clipping deduplication), and #758 covers
+> the MusicEvent address-region schema follow-up.
 
 # 🧾 Auditoria de PRs recentes — 2026-05-23 a 2026-06-02
 

--- a/.human/recent-closed-prs-audit-2026-06-17.md
+++ b/.human/recent-closed-prs-audit-2026-06-17.md
@@ -1,3 +1,11 @@
+> [!IMPORTANT]
+> Status: partially superseded by implementation PRs #757 and #758.
+>
+> This file is retained as historical audit evidence. Its corrective checklist
+> should not be treated as fresh backlog without first checking the newer PRs:
+> #757 addresses the accessibility, preload and media clipping follow-ups, and
+> #758 addresses the MusicEvent address-region follow-up.
+
 # Audit of the 10 most recent closed PRs - 2026-06-17
 
 This audit was initially prepared from local Git history and then cross-checked against GitHub PR metadata, comments, reviews, review threads and merge state using `gh`. The reviewed window is the 10 most recent merge commits visible locally with PR numbers: #752, #751, #750, #749, #748, #747, #746, #745, #744 and #729.


### PR DESCRIPTION
## Summary

Marks the two recent PR audit reports as historical/superseded context instead of leaving their action items looking like open backlog.

## Why

PR #759 mixed documentation cleanup with unrelated and risky changes: `.htaccess` redirect removal, dependency churn, workflow changes, and code regressions from older branches. This replacement keeps the useful part only: preserving the audit files while making their status clear for future agents and human reviewers.

## Scope intentionally excluded

- No `.htaccess` redirect changes.
- No dependency updates.
- No workflow/bot-review behavior changes.
- No deletion of `.human` audit files.

## Validation

- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Versão

* **Documentação**
  * Adicionados avisos informativos nos documentos de auditoria esclarecendo que conteúdos específicos foram supersedidos por implementações recentes.
  * Documentos mantidos como evidência histórica; recomenda-se verificar atualizações antes de processar itens de follow-up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->