### PR TITLE
fix(seo): retire legacy URL aliases

### DIFF
--- a/.human/URL_DEINDEX_STRATEGY_2026-06-17.md
+++ b/.human/URL_DEINDEX_STRATEGY_2026-06-17.md
@@ -1,0 +1,42 @@
+# URL deindex strategy - 2026-06-17
+
+Status: active implementation note for PR review.
+
+## Goal
+
+Refresh public indexation around the current canonical URL set.
+
+The site previously kept many short or legacy aliases alive with 301 redirects.
+That was useful during migration, but it also kept old paths visible to crawlers
+as valid alternates. This PR switches those retired aliases to `410 Gone` so
+search engines can drop them faster.
+
+## Rules
+
+- Canonical URLs live in `src/config/routes-slugs.json`.
+- Sitemaps are generated only from canonical route slugs and dynamic canonical
+  event/post/release data.
+- Retired aliases must not remain as React SPA routes.
+- Retired aliases must return `410 Gone` in `public/.htaccess`.
+- Unknown URLs that are not explicitly retired continue to fall through to the
+  existing real 404 handling.
+- Technical duplicates such as `/index.html` still use 301 to the canonical
+  homepage because they are equivalent files, not retired content.
+
+## Expected crawler behavior
+
+- Current canonical pages remain indexable and appear in sitemap XML.
+- Old route aliases return 410 instead of redirecting.
+- Canonical and hreflang tags on live pages continue to point to primary slugs.
+- Search engines should gradually replace stale alias URLs with the sitemap and
+  canonical URL set.
+
+## Follow-up
+
+After deploy, inspect Search Console for:
+
+- retired aliases moving out of indexed/discovered URL buckets;
+- unexpected 410 hits on URLs that should still be live;
+- canonical pages remaining indexed;
+- sitemap discovery for `/sitemap.xml`, `/sitemap-pages.xml`,
+  `/sitemap-events.xml`, and `/sitemap-posts.xml`.

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -211,62 +211,27 @@ RewriteRule ^\.well-known/acme-challenge/file\.php$ - [G,L,NC]
 RewriteRule ^wp-\*\.php$ - [G,L,NC]
 RewriteRule ^graphql/?$ - [G,L,NC]
 
-# Legacy payment hub -> canonical support page
-RewriteRule ^payme/?$ /support-dj-zen-eyer/ [R=301,L]
-RewriteRule ^pt/pagamentos/?$ /pt/apoie-dj-zen-eyer/ [R=301,L]
+# Retired legacy URLs -> 410 Gone.
+# Sitemap and canonicals now advertise only the route SSOT in routes-slugs.json.
+# 410 is intentional here: these aliases already had a migration window via 301
+# and should now leave the index instead of continuing as crawlable alternates.
+RewriteRule ^(about|music|news|zouk-dance-news|support-the-artist|media|my-philosophy|privacy|payme|rezenha-ticket|featured-product|tribe|zen-tribe|links|zouk-terms|zouk-wiki|press-kit-dj-zen-eyer)/?$ - [G,L,NC]
+RewriteRule ^(musica|trabalhe-comigo|tribo-zen|loja|kit-imprensa)/?$ - [G,L,NC]
+RewriteRule ^pt/(sobre|musica|noticias|noticias-zouk|apoie-o-artista|media|midia|contrate|minha-filosofia|privacy-policy-2|pagamentos|press-kit|kit-de-imprensa|eventos|tribo|termos-zouk|wiki-zouk)/?$ - [G,L,NC]
+RewriteRule ^en/musica/?$ - [G,L,NC]
 
-# Legacy press kit route -> canonical press kit download route
-# REMOVIDO: press-kit agora é uma rota válida apontando para PressKitDownloadPage
-# RewriteRule ^press-kit-dj-zen-eyer/?$ /work-with-me/ [R=301,L]
-# RewriteRule ^pt/kit-de-imprensa/?$ /pt/trabalhe-comigo/ [R=301,L]
-RewriteRule ^pt/press-kit/?$ /pt/kit-de-imprensa/ [R=301,L]
+# Retired static release placeholder URLs. Real release detail pages live under
+# /zouk-music/:id and /pt/musica-zouk/:id, generated from release-slugs.json.
+RewriteRule ^releases/(dont-stop-zen-eyer-remix-kaysha|na-ponta-ela-fica-brazilian-zouk-cover|still-loving-you-sax-cover-walter-xavier|baila-flaquita-original-single|porta-do-sol-brazilian-zouk-cover|preview)/?$ - [G,L,NC]
+RewriteRule ^pt/lancamentos/(dont-stop-remix-zen-eyer-kaysha|na-ponta-ela-fica-cover-zouk-brasileiro|still-loving-you-cover-sax-walter-xavier|baila-flaquita-single-original|porta-do-sol-cover-zouk-brasileiro|preview)/?$ - [G,L,NC]
 
-# Legacy support and philosophy aliases -> canonical pages
-RewriteRule ^about/?$ /about-dj-zen-eyer/ [R=301,L,NC]
-RewriteRule ^pt/sobre/?$ /pt/sobre-dj-zen-eyer/ [R=301,L,NC]
-RewriteRule ^music/?$ /zouk-music/ [R=301,L,NC]
-RewriteRule ^en/musica/?$ /zouk-music/ [R=301,L,NC]
-RewriteRule ^musica/?$ /pt/musica-zouk/ [R=301,L,NC]
-RewriteRule ^pt/musica/?$ /pt/musica-zouk/ [R=301,L,NC]
-RewriteRule ^news/?$ /releases/ [R=301,L,NC]
-RewriteRule ^zouk-dance-news/?$ /releases/ [R=301,L,NC]
-RewriteRule ^pt/noticias/?$ /pt/lancamentos/ [R=301,L,NC]
-RewriteRule ^pt/noticias-zouk/?$ /pt/lancamentos/ [R=301,L,NC]
-
-# Legacy/static release detail placeholders -> canonical releases hub
-RewriteRule ^releases/(dont-stop-zen-eyer-remix-kaysha|na-ponta-ela-fica-brazilian-zouk-cover|still-loving-you-sax-cover-walter-xavier|baila-flaquita-original-single|porta-do-sol-brazilian-zouk-cover|preview)/?$ /releases/ [R=301,L,NC]
-RewriteRule ^pt/lancamentos/(dont-stop-remix-zen-eyer-kaysha|na-ponta-ela-fica-cover-zouk-brasileiro|still-loving-you-cover-sax-walter-xavier|baila-flaquita-single-original|porta-do-sol-cover-zouk-brasileiro|preview)/?$ /pt/lancamentos/ [R=301,L,NC]
-
-RewriteRule ^support-the-artist/?$ /support-dj-zen-eyer/ [R=301,L]
-RewriteRule ^pt/apoie-o-artista/?$ /pt/apoie-dj-zen-eyer/ [R=301,L]
-RewriteRule ^trabalhe-comigo/?$ /pt/trabalhe-comigo/ [R=301,L,NC]
-RewriteRule ^tribo-zen/?$ /pt/tribo-zen/ [R=301,L,NC]
-RewriteRule ^loja/?$ /pt/loja/ [R=301,L,NC]
-RewriteRule ^kit-imprensa/?$ /pt/trabalhe-comigo/ [R=301,L,NC]
-RewriteRule ^rezenha-ticket/?$ /shop/ [R=301,L,NC]
-RewriteRule ^featured-product/?$ /shop/ [R=301,L,NC]
-RewriteRule ^privacy/?$ /privacy-policy/ [R=301,L,NC]
-RewriteRule ^pt/contrate/?$ /pt/trabalhe-comigo/ [R=301,L]
-RewriteRule ^pt/minha-filosofia/?$ /pt/filosofia-zouk/ [R=301,L]
-RewriteRule ^my-philosophy/?$ /zouk-philosophy/ [R=301,L,NC]
-RewriteRule ^pt/privacy-policy-2/?$ /pt/privacidade/ [R=301,L]
-
-# Legacy media route -> canonical clipping pages
-RewriteRule ^media/?$ /media-clipping/ [R=301,L]
-RewriteRule ^pt/media/?$ /pt/na-midia/ [R=301,L]
-RewriteRule ^pt/midia/?$ /pt/na-midia/ [R=301,L]
-
-# Events Standardization (SSOT)
-# Redireciona slugs legados/curtos para a estrutura canônica de Zouk Events
-RewriteRule ^events/([0-9]{4}-[0-9]{2}-[0-9]{2}-.*)$ /zouk-events/$1 [R=301,L,NC]
-RewriteRule ^pt/eventos/([0-9]{4}-[0-9]{2}-[0-9]{2}-.*)$ /pt/eventos-zouk/$1 [R=301,L,NC]
-RewriteRule ^events/(.+)$ /zouk-events/$1 [R=301,L,NC]
-RewriteRule ^pt/eventos/(.+)$ /pt/eventos-zouk/$1 [R=301,L,NC]
-RewriteRule ^zouk-events/:id(?:/(.*))?$ /zouk-events/$1 [R=301,L,NC]
-RewriteRule ^pt/eventos-zouk/:id(?:/(.*))?$ /pt/eventos-zouk/$1 [R=301,L,NC]
-RewriteRule ^pt/eventos-zouk,eventos/(.+)$ /pt/eventos-zouk/$1 [R=301,L,NC]
-RewriteRule ^events/?$ /zouk-events/ [R=301,L,NC]
-RewriteRule ^pt/eventos/?$ /pt/eventos-zouk/ [R=301,L,NC]
+# Retired event aliases and malformed placeholder routes. Canonical event URLs
+# are /zouk-events/{date-slug-id} and /pt/eventos-zouk/{date-slug-id}.
+RewriteRule ^events(/.*)?$ - [G,L,NC]
+RewriteRule ^pt/eventos(/.*)?$ - [G,L,NC]
+RewriteRule ^zouk-events/:id(/.*)?$ - [G,L,NC]
+RewriteRule ^pt/eventos-zouk/:id(/.*)?$ - [G,L,NC]
+RewriteRule ^pt/eventos-zouk,eventos(/.*)?$ - [G,L,NC]
 
 # Duplicate index files -> canonical home pages
 RewriteRule ^index\.html$ / [R=301,L]

--- a/scripts/check-seo-invariants.mjs
+++ b/scripts/check-seo-invariants.mjs
@@ -79,6 +79,7 @@ if (!llmsFull.includes('This championship should not be confused with the separa
 }
 
 const routesConfig = JSON.parse(read('src/config/routes-slugs.json'));
+const htaccess = read('public/.htaccess');
 const matureIndexableRouteKeys = ['zouk-festivals'];
 for (const routeKey of matureIndexableRouteKeys) {
   const route = routesConfig.routes.find((entry) => entry.key === routeKey);
@@ -90,6 +91,63 @@ for (const routeKey of matureIndexableRouteKeys) {
     if (route[flag]) {
       failures.push(`src/config/routes-slugs.json: mature route ${routeKey} must not set ${flag}`);
     }
+  }
+}
+
+const retiredRouteAliases = new Set([
+  'events',
+  'eventos',
+  'music',
+  'musica',
+  'news',
+  'zouk-dance-news',
+  'noticias',
+  'noticias-zouk',
+  'tribe',
+  'zen-tribe',
+  'tribo',
+  'links',
+  'zouk-terms',
+  'zouk-wiki',
+  'termos-zouk',
+  'wiki-zouk',
+]);
+
+for (const route of routesConfig.routes) {
+  const aliases = route.aliases && typeof route.aliases === 'object' ? route.aliases : {};
+  for (const [lang, values] of Object.entries(aliases)) {
+    if (!Array.isArray(values)) continue;
+    for (const alias of values) {
+      if (retiredRouteAliases.has(alias)) {
+        failures.push(
+          `src/config/routes-slugs.json: retired ${lang} alias "${alias}" must not be a live SPA route; use the canonical slug and let public/.htaccess return 410 for retired URLs.`
+        );
+      }
+    }
+  }
+}
+
+const retiredRedirectTargets = [
+  'support-dj-zen-eyer',
+  'apoie-dj-zen-eyer',
+  'about-dj-zen-eyer',
+  'sobre-dj-zen-eyer',
+  'zouk-music',
+  'musica-zouk',
+  'releases',
+  'lancamentos',
+  'media-clipping',
+  'na-midia',
+  'zouk-events',
+  'eventos-zouk',
+];
+
+for (const target of retiredRedirectTargets) {
+  const legacyRedirectPattern = new RegExp(`\\[R=301,L(?:,NC)?\\].*${target}|${target}.*\\[R=301,L(?:,NC)?\\]`);
+  if (legacyRedirectPattern.test(htaccess)) {
+    failures.push(
+      `public/.htaccess: retired legacy URL strategy should not reintroduce 301 redirects to ${target}; return 410 for retired aliases and keep sitemap/canonical on the primary slug.`
+    );
   }
 }
 

--- a/src/config/routes-slugs.json
+++ b/src/config/routes-slugs.json
@@ -14,43 +14,17 @@
         {
             "key": "events",
             "en": "zouk-events",
-            "pt": "eventos-zouk",
-            "aliases": {
-                "en": [
-                    "events"
-                ],
-                "pt": [
-                    "eventos"
-                ]
-            }
+            "pt": "eventos-zouk"
         },
         {
             "key": "music",
             "en": "zouk-music",
-            "pt": "musica-zouk",
-            "aliases": {
-                "en": [
-                    "music"
-                ],
-                "pt": [
-                    "musica"
-                ]
-            }
+            "pt": "musica-zouk"
         },
         {
             "key": "news",
             "en": "releases",
-            "pt": "lancamentos",
-            "aliases": {
-                "en": [
-                    "news",
-                    "zouk-dance-news"
-                ],
-                "pt": [
-                    "noticias",
-                    "noticias-zouk"
-                ]
-            }
+            "pt": "lancamentos"
         },
         {
             "key": "philosophy",
@@ -62,16 +36,7 @@
         {
             "key": "zentribe",
             "en": "zentribe",
-            "pt": "tribo-zen",
-            "aliases": {
-                "en": [
-                    "tribe",
-                    "zen-tribe"
-                ],
-                "pt": [
-                    "tribo"
-                ]
-            }
+            "pt": "tribo-zen"
         },
         {
             "key": "booking",
@@ -98,12 +63,7 @@
             "en": "zenlink",
             "pt": "links-zen",
             "noindex": true,
-            "excludeFromSitemap": true,
-            "aliases": {
-                "en": [
-                    "links"
-                ]
-            }
+            "excludeFromSitemap": true
         },
         {
             "key": "cart",
@@ -209,17 +169,7 @@
         {
             "key": "encyclopedia",
             "en": "zouk-encyclopedia",
-            "pt": "enciclopedia-zouk",
-            "aliases": {
-                "en": [
-                    "zouk-terms",
-                    "zouk-wiki"
-                ],
-                "pt": [
-                    "termos-zouk",
-                    "wiki-zouk"
-                ]
-            }
+            "pt": "enciclopedia-zouk"
         },
         {
             "key": "encyclopedia-detail",


### PR DESCRIPTION
## Summary

Implements a dedicated legacy URL deindex strategy:

- removes retired aliases from `src/config/routes-slugs.json` so they are no longer live React SPA routes;
- replaces legacy 301 redirects in `public/.htaccess` with explicit `410 Gone` responses for retired aliases and malformed placeholder URLs;
- keeps technical duplicate `/index.html` redirects as 301 to the canonical home pages;
- adds `seo:check` invariants so retired aliases are not reintroduced as SPA aliases or 301 redirects;
- documents the sitemap/canonical/404/410 strategy in `.human/URL_DEINDEX_STRATEGY_2026-06-17.md`.

## SEO decision

The migration window for the old aliases has already existed through 301 redirects. This PR intentionally changes strategy: canonical pages remain indexable and sitemap-driven, while retired aliases return 410 so crawlers can drop them faster.

Unknown URLs that are not listed as retired still fall through to the existing real 404 handling.

## Validation

- `npm run seo:check`
- `npm run generate-sitemaps` as validation only; generated XML timestamp changes were not committed
- `git diff --check`