### PR TITLE
refactor: extract getPlainTitle helper, eliminate duplicate HTML-strip logic

### DIFF
--- a/src/__tests__/components/HeadlessSEO.test.tsx
+++ b/src/__tests__/components/HeadlessSEO.test.tsx
@@ -20,6 +20,8 @@ import { describe, it, expect, vi } from 'vitest';
 import { HeadlessSEO } from '../../components/HeadlessSEO';
 import { BrandingProvider } from '../../contexts/BrandingContext';
 import { ARTIST } from '../../data/artistData';
+import { getPlainTitle } from '../../utils/events';
+import { stripHtml } from '../../utils/text';
 import type { EventSchemaData, VideoSchemaData } from '../../components/HeadlessSEO';
 
 vi.mock('react-i18next', () => ({
@@ -83,8 +85,8 @@ function buildMusicEventGraph(events: EventSchemaData[]): Array<Record<string, u
     if (!startDate) continue;
 
     const eventTitle =
-      (typeof event.title === 'object' ? event.title.rendered : event.title) ||
-      event.name ||
+      getPlainTitle(event.title) ||
+      (typeof event.name === 'string' ? stripHtml(event.name) : '') ||
       'Zouk Event';
 
     const parsedStartDate = Date.parse(startDate as string);

--- a/src/__tests__/seo/buildDynamicGraph.test.ts
+++ b/src/__tests__/seo/buildDynamicGraph.test.ts
@@ -127,6 +127,35 @@ describe('buildDynamicGraph — MusicEvent', () => {
     const ev = graph.find((n) => n['@type'] === 'MusicEvent')!;
     expect(ev.eventAttendanceMode).toBe('https://schema.org/OnlineEventAttendanceMode');
   });
+
+  it('uses a stripped plain-text title for MusicEvent name', () => {
+    const graph = buildDynamicGraph({
+      ...baseOpts,
+      events: [
+        {
+          ...futureEvent,
+          title: { rendered: '<strong>Zen Eyer</strong> &amp; Friends' },
+        },
+      ],
+    });
+    const ev = graph.find((n) => n['@type'] === 'MusicEvent')!;
+    expect(ev.name).toBe('Zen Eyer & Friends');
+  });
+
+  it('does not stringify non-string rendered titles in MusicEvent name', () => {
+    const graph = buildDynamicGraph({
+      ...baseOpts,
+      events: [
+        {
+          ...futureEvent,
+          title: { rendered: { value: 'Bad title' } },
+          name: 'Fallback Event Name',
+        },
+      ],
+    });
+    const ev = graph.find((n) => n['@type'] === 'MusicEvent')!;
+    expect(ev.name).toBe('Fallback Event Name');
+  });
 });
 
 // ── VideoObject ────────────────────────────────────────────────────────────────

--- a/src/components/Events/AddCalendarMenu.tsx
+++ b/src/components/Events/AddCalendarMenu.tsx
@@ -5,6 +5,7 @@ import { ARTIST } from '../../data/artistData';
 
 import { trackSelectContent } from '../../lib/analytics';
 import { logger } from '../../lib/logger';
+import { getPlainTitle } from '../../utils/events';
 import type { ZenBitEventListItem } from '../../types/events';
 
 interface AddCalendarMenuProps {
@@ -14,22 +15,13 @@ interface AddCalendarMenuProps {
     eventUrl?: string;
 }
 
-const getPlainEventTitle = (title: unknown) => {
-    const rawTitle = typeof title === 'string'
-        ? title
-        : typeof title === 'object' && title !== null && 'rendered' in title
-            ? String((title as { rendered?: unknown }).rendered || '')
-            : '';
-
-    return rawTitle.replace(/<\/?[^>]+(>|$)/g, "");
-};
 
 const AddCalendarMenu = ({ event, variant = 'primary', className = '', eventUrl }: AddCalendarMenuProps) => {
     const { t } = useTranslation();
 
     const getDetails = () => {
         try {
-            const title = getPlainEventTitle(event.title) || t('event_default_title');
+            const title = getPlainTitle(event.title) || t('event_default_title');
 
             // Validação de data v2 (starts_at)
             const rawDate = event.starts_at || '';

--- a/src/components/HeadlessSEO.tsx
+++ b/src/components/HeadlessSEO.tsx
@@ -62,7 +62,7 @@ export interface PreloadItem {
 }
 
 export interface EventSchemaData {
-  title?: string | { rendered?: string };
+  title?: string | { rendered?: unknown };
   name?: string;
   starts_at?: string;
   event_date?: string;

--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -7,7 +7,7 @@ import { normalizeLanguage, getLocalizedRoute, type Language } from '../config/r
 import { useEventsQuery, useEventById } from '../hooks/useQueries';
 import { safeUrl, sanitizeHtml } from '../utils/sanitize';
 import { stripHtml } from '../utils/text';
-import { extractRegions, filterEventsByRegion, groupEventsByMonth } from '../utils/events';
+import { extractRegions, filterEventsByRegion, groupEventsByMonth, getPlainTitle } from '../utils/events';
 import { logger } from '../lib/logger';
 import { ARTIST } from '../data/artistData';
 import { useBranding } from '../contexts/BrandingContext';
@@ -23,15 +23,6 @@ import type { EventSchemaData } from '../components/HeadlessSEO';
 // Static month keys stay at module scope to avoid reallocation on every render.
 const MONTH_NAMES = ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec'] as const;
 
-const getEventTitleText = (title: unknown) => {
-  const rawTitle = typeof title === 'string'
-    ? title
-    : typeof title === 'object' && title !== null && 'rendered' in title
-      ? String((title as { rendered?: unknown }).rendered || '')
-      : '';
-
-  return stripHtml(rawTitle);
-};
 
 // ============================================================================
 // SUB-COMPONENTS (SUSPENSE READY)
@@ -82,7 +73,7 @@ const EventDetailContent = ({ id, lang }: { id: string; lang: string }) => {
   const isValidDate = !isNaN(eventDate.getTime());
   const loc = event.location;
   const cleanDescription = stripHtml(event.description || '');
-  const cleanEventTitle = getEventTitleText(event.title);
+  const cleanEventTitle = getPlainTitle(event.title);
   const eventDetailUrl = event.canonical_url || `${origin}${getLocalizedRoute('events', lang as Language)}/${id}`;
 
   const share = () => {
@@ -221,7 +212,7 @@ const EventListContent = ({ lang }: { lang: string }) => {
 
   const share = (e: ZenBitEventListItem) => {
     const canonical = e.canonical_url || `${ARTIST.site.baseUrl}${getLocalizedRoute('events', lang as Language)}/${e.event_id}`;
-    const cleanEventTitle = getEventTitleText(e.title);
+    const cleanEventTitle = getPlainTitle(e.title);
     if (navigator.share) {
       navigator.share({ title: cleanEventTitle || ARTIST.identity.stageName, url: canonical });
     } else {
@@ -302,7 +293,7 @@ const EventListContent = ({ lang }: { lang: string }) => {
                   const detailHref = e._processed?.detailHref || generatePath(eventsDetailRoute, { id: identifier });
                   const detailUrl = e.canonical_url || `${ARTIST.site.baseUrl}${detailHref}`;
                   const loc = e.location;
-                  const cleanEventTitle = getEventTitleText(e.title);
+                  const cleanEventTitle = getPlainTitle(e.title);
 
                   return (
                     <div key={e.event_id} className="flex flex-col md:flex-row md:items-center gap-4 p-6 bg-surface/30 border border-white/5 rounded-2xl hover:border-primary/20 transition-all group">

--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -74,6 +74,7 @@ const EventDetailContent = ({ id, lang }: { id: string; lang: string }) => {
   const loc = event.location;
   const cleanDescription = stripHtml(event.description || '');
   const cleanEventTitle = getPlainTitle(event.title);
+  const eventSeoTitle = cleanEventTitle || t('event_default_title');
   const eventDetailUrl = event.canonical_url || `${origin}${getLocalizedRoute('events', lang as Language)}/${id}`;
 
   const share = () => {
@@ -89,11 +90,11 @@ const EventDetailContent = ({ id, lang }: { id: string; lang: string }) => {
   return (
     <div className="max-w-6xl mx-auto animate-in fade-in slide-in-from-bottom-4 duration-700">
       <HeadlessSEO
-        title={cleanEventTitle || event.title}
+        title={eventSeoTitle}
         description={cleanDescription.substring(0, 160)}
         url={`${origin}${getLocalizedRoute('events', lang as Language)}/${id}`}
         image={event.image || undefined}
-        imageAlt={t('og.image_alt.events_detail', { eventTitle: cleanEventTitle || event.title, artist: ARTIST.identity.stageName })}
+        imageAlt={t('og.image_alt.events_detail', { eventTitle: eventSeoTitle, artist: ARTIST.identity.stageName })}
         type="event"
         events={[event]}
         leadAnswer={cleanDescription ? cleanDescription.substring(0, 300) : undefined}

--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -89,11 +89,11 @@ const EventDetailContent = ({ id, lang }: { id: string; lang: string }) => {
   return (
     <div className="max-w-6xl mx-auto animate-in fade-in slide-in-from-bottom-4 duration-700">
       <HeadlessSEO
-        title={event.title}
+        title={cleanEventTitle || event.title}
         description={cleanDescription.substring(0, 160)}
         url={`${origin}${getLocalizedRoute('events', lang as Language)}/${id}`}
         image={event.image || undefined}
-        imageAlt={t('og.image_alt.events_detail', { eventTitle: event.title, artist: ARTIST.identity.stageName })}
+        imageAlt={t('og.image_alt.events_detail', { eventTitle: cleanEventTitle || event.title, artist: ARTIST.identity.stageName })}
         type="event"
         events={[event]}
         leadAnswer={cleanDescription ? cleanDescription.substring(0, 300) : undefined}

--- a/src/seo/buildDynamicGraph.ts
+++ b/src/seo/buildDynamicGraph.ts
@@ -2,6 +2,7 @@
 // No React dependency — fully testable without rendering.
 import { ARTIST_SCHEMA_SAME_AS } from '../data/artist.schema';
 import { safeUrl } from '../utils/sanitize';
+import { getPlainTitle } from '../utils/events';
 import { stripHtml } from '../utils/text';
 import type { EventSchemaData, VideoSchemaData } from '../components/HeadlessSEO';
 
@@ -88,8 +89,8 @@ export function buildDynamicGraph(opts: BuildDynamicGraphOpts): Record<string, u
       if (!startDate) continue;
 
       const eventTitle =
-        (typeof event.title === 'object' ? event.title.rendered : event.title) ||
-        event.name ||
+        getPlainTitle(event.title) ||
+        (typeof event.name === 'string' ? stripHtml(event.name) : '') ||
         'Zouk Event';
       const canonicalUrl = (event.canonical_url as string) || (event.url as string) || undefined;
       const endDateRaw = (event.ends_at as string) || (event.end_date as string);

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -6,13 +6,14 @@ import { stripHtml } from './text';
  * Handles both raw strings and `{ rendered: string }` objects, then strips HTML.
  */
 export function getPlainTitle(title: unknown): string {
-  const raw =
-    typeof title === 'string'
-      ? title
-      : typeof title === 'object' && title !== null && 'rendered' in title
-        ? String((title as { rendered?: unknown }).rendered ?? '')
-        : '';
-  return stripHtml(raw);
+  if (typeof title === 'string') {
+    return stripHtml(title);
+  }
+  if (typeof title === 'object' && title !== null && 'rendered' in title) {
+    const rendered = (title as { rendered?: unknown }).rendered;
+    return stripHtml(typeof rendered === 'string' ? rendered : String(rendered ?? ''));
+  }
+  return '';
 }
 
 /**

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -11,7 +11,9 @@ export function getPlainTitle(title: unknown): string {
   }
   if (typeof title === 'object' && title !== null && 'rendered' in title) {
     const rendered = (title as { rendered?: unknown }).rendered;
-    return stripHtml(typeof rendered === 'string' ? rendered : String(rendered ?? ''));
+    if (typeof rendered === 'string') {
+      return stripHtml(rendered);
+    }
   }
   return '';
 }

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -1,4 +1,19 @@
 import type { ZenBitEventListItem } from '../types/events';
+import { stripHtml } from './text';
+
+/**
+ * Extracts a plain-text title from a WordPress-style title field.
+ * Handles both raw strings and `{ rendered: string }` objects, then strips HTML.
+ */
+export function getPlainTitle(title: unknown): string {
+  const raw =
+    typeof title === 'string'
+      ? title
+      : typeof title === 'object' && title !== null && 'rendered' in title
+        ? String((title as { rendered?: unknown }).rendered ?? '')
+        : '';
+  return stripHtml(raw);
+}
 
 /**
  * Returns unique region names from the event list, sorted alphabetically.


### PR DESCRIPTION
﻿## Motivacao

O CodeRabbit apontou no PR #757 que `AddCalendarMenu.tsx` usava regex inline para remover HTML, enquanto o projeto ja possui `stripHtml` em `src/utils/text.ts`. A mesma logica tambem existia em `EventsPage.tsx`, criando duplicacao e risco de divergencia em campos sensiveis para SEO/AEO/GEO.

## Type of Change

- [x] Refactoring
- [x] Bug fix
- [x] Tests
- [ ] New feature
- [ ] Documentation only

## Impact Area

- [x] React components
- [x] TypeScript types
- [x] SEO metadata
- [x] Structured data / JSON-LD
- [x] Tests

## Mudancas

- `src/utils/events.ts`: adiciona `getPlainTitle(title: unknown): string` como fonte unica para extrair titulo textual de strings ou objetos WordPress `{ rendered }`.
- `src/components/Events/AddCalendarMenu.tsx`: remove helper local e regex inline; usa `getPlainTitle`.
- `src/pages/EventsPage.tsx`: usa `getPlainTitle` e fallback textual seguro em `HeadlessSEO.title` e `imageAlt`, sem voltar para `event.title` cru.
- `src/seo/buildDynamicGraph.ts`: usa `getPlainTitle` em `MusicEvent.name`, evitando HTML ou valores como `[object Object]` no JSON-LD.
- `src/components/HeadlessSEO.tsx`: ajusta tipo de `title.rendered` para representar entradas desconhecidas vindas da API.
- Testes: cobre titulo com HTML/entidades e fallback quando `rendered` nao e string.

## Testing Checklist

- [x] GitHub Actions: Build and validate
- [x] GitHub Actions: Unit & Integration Tests
- [x] GitHub Actions: Contract Tests
- [x] GitHub Actions: CodeQL
- [x] GitHub Actions: Snyk
- [x] Local: `node scripts/check-seo-invariants.mjs`
- [x] Local: `git diff --check`
- [ ] Local Vitest/TypeScript completos: nao executados neste worktree porque `node_modules` nao estava instalado; cobertos pelo GitHub Actions.

## Gate Checklist

- [x] Sem mudanca de URL publica.
- [x] Sem alteracao de sitemap/canonical/robots.
- [x] Sem dados sensiveis ou credenciais.
- [x] Mantem campos SEO como texto limpo.
- [x] Mantem JSON-LD de MusicEvent com nome textual seguro.

## Final Checklist

- [x] Reviews de Gemini e CodeRabbit verificados.
- [x] Comentarios acionaveis do CodeRabbit enderecados.
- [x] Ocorrencias equivalentes buscadas no projeto.
- [x] Branch atualizada com `main`.
- [x] PR pronto para merge se os checks permanecerem verdes.

## Impacto

Nenhuma mudanca visual intencional. A mudanca reduz risco de tags HTML, entidades nao decodificadas ou valores nao textuais vazarem para metadados, acessibilidade, compartilhamento e JSON-LD de eventos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Centralizamos a extracao e limpeza do "titulo em texto puro" de eventos em uma utilidade reutilizavel, removendo HTML e tratando entradas invalidas.
  * Aplicamos o titulo em texto puro em detalhes, listagens, compartilhamento e geracao de metadados de SEO, com fallbacks consistentes quando o titulo nao esta disponivel.

* **Tests**
  * Atualizamos e ampliamos os testes para validar o novo comportamento do titulo em SEO e na construcao do grafo dinamico.

* **Chores**
  * Ajustamos tipagens relacionadas ao conteudo do titulo para acomodar valores nao-strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
