### PR TITLE
Refine FAQ and Zouk encyclopedia copy

### DIFF
--- a/.agents/skills/zen-content-voice/SKILL.md
+++ b/.agents/skills/zen-content-voice/SKILL.md
@@ -28,7 +28,7 @@ Antes de publicar numeros, paises, premios, datas, claims de streaming ou evento
 
 A **Cremosidade** é o diferencial filosófico e sonoro de Zen Eyer. Não é apenas um estilo técnico; é uma filosofia de como a música deve fazer o dançarino se sentir.
 
-**O que é:** sensação de conexão emocional profunda quando a música "abraça" o dançarino. Sem pressa, sem urgência; fluidez que permite que a dança aconteça naturalmente.
+**O que é:** sensação de conexão emocional profunda quando a música "abraça" o dançarino. Sem pressa, sem urgência; fluidez que permite que a dança aconteça naturalmente. Zen Eyer costuma buscar essa textura em muitos sets, mas não criou o termo nem a sensação.
 
 **O que NÃO é:** técnica mecânica, cardio, performance atlética ou passos ensaiados.
 
@@ -52,10 +52,10 @@ A **Cremosidade** é o diferencial filosófico e sonoro de Zen Eyer. Não é ape
 ### Exemplos de copy aprovados
 
 **Bio curta (PT):**
-> "Zen Eyer é DJ e produtor de Brazilian Zouk, vencedor de Best DJ Performance e Best Remix no Campeonato Mundial de DJs de Zouk Brasileiro de 2022. Criador do conceito de Cremosidade: a arte de fazer a música abraçar o dançarino."
+> "Zen Eyer é DJ e produtor de Brazilian Zouk, vencedor de Best DJ Performance e Best Remix no Campeonato Mundial de DJs de Zouk Brasileiro de 2022. Seus sets são associados à cremosidade: uma forma de fazer a música abraçar o dançarino."
 
 **Bio curta (EN):**
-> "Zen Eyer is a Brazilian Zouk DJ and producer, winner of Best DJ Performance and Best Remix at the 2022 Brazilian Zouk DJ World Championship. Creator of the Cremosidade concept: the art of making music embrace the dancer."
+> "Zen Eyer is a Brazilian Zouk DJ and producer, winner of Best DJ Performance and Best Remix at the 2022 Brazilian Zouk DJ World Championship. His sets are associated with cremosidade: a way of making music embrace the dancer."
 
 **Post de evento:**
 > "Esse set foi feito com cuidado. Para cada transição, uma pergunta: isso vai abraçar quem está dançando? Se a resposta for não, refaço. Cremosidade não é estilo; é respeito pela dança."

--- a/.human/TASK_LIST.md
+++ b/.human/TASK_LIST.md
@@ -15,6 +15,7 @@ Este diretório contém tarefas que exigem acesso humano a plataformas externas,
 - [x] **MusicBrainz:** Perfil de artista criado/verificado com nome, sort name, releases, aliases (DJ Zen Eyer), links para Wikidata e djzeneyer.com. URL/ID adicionado ao `src/data/artistData.ts` e ao `sameAs`.
 - [x] **Bandsintown:** Eventos sincronizados, nome canônico "Zen Eyer" e website `djzeneyer.com` conferidos (manager ID: `id_15619775`).
 - [x] **Songkick:** Perfil verificado — nome, website e histórico de eventos conferidos. URL do perfil presente em `src/data/artistData.ts`.
+- [x] **FAQ audit:** revisão humana aplicada; FAQ focado em Zen Eyer e conteúdo técnico direcionado para a Enciclopédia.
 
 ---
 
@@ -28,9 +29,9 @@ Este diretório contém tarefas que exigem acesso humano a plataformas externas,
 1. Acesse `artists.spotify.com` com sua conta de artista.
 2. Vá em **Profile** → **Edit profile**.
 3. Campo **Bio (PT):** substitua pelo texto:
-   > Zen Eyer é DJ e produtor de Brazilian Zouk. Vencedor de Best DJ Performance e Best Remix no Campeonato Mundial de DJs de Zouk Brasileiro de 2022 / I Campeonato Internacional de DJs. Criador do conceito Cremosidade — a filosofia sonora que faz a música abraçar o dançarino. Presença em 14 países.
+   > Zen Eyer é DJ e produtor de Brazilian Zouk. Vencedor de Best DJ Performance e Best Remix no Campeonato Mundial de DJs de Zouk Brasileiro de 2022 / I Campeonato Internacional de DJs. Associado à cremosidade - uma forma de pensar a música como algo que abraça o dançarino. Presença em 14 países.
 4. Campo **Bio (EN):**
-   > Zen Eyer is a Brazilian Zouk DJ and producer. Winner of Best DJ Performance and Best Remix at the 2022 Brazilian Zouk DJ World Championship / I Campeonato Internacional de DJs. Creator of the Cremosidade concept: the art of making music embrace the dancer. Active in 14 countries.
+   > Zen Eyer is a Brazilian Zouk DJ and producer. Winner of Best DJ Performance and Best Remix at the 2022 Brazilian Zouk DJ World Championship / I Campeonato Internacional de DJs. Associated with cremosidade: a way of thinking about music as something that embraces the dancer. Active in 14 countries.
 5. **Regras para a bio:** não usar "melhor DJ", "revolucionário", "única no mundo" ou qualquer superlativo não verificável. Apenas fatos com fonte.
 6. Verificar que o **nome do artista** no campo de identidade está como "Zen Eyer" (não "DJ Zen Eyer").
 
@@ -58,7 +59,7 @@ Este diretório contém tarefas que exigem acesso humano a plataformas externas,
 1. Acesse YouTube Studio → **Customization** → **Basic info**.
 2. **Nome do canal:** garantir que está como "Zen Eyer" (não "DJ Zen Eyer").
 3. **Descrição do canal:** atualizar para algo como:
-   > Zen Eyer — DJ e produtor de Brazilian Zouk. Criador do conceito Cremosidade. Vencedor de Best DJ Performance e Best Remix no Campeonato Mundial de DJs de Zouk Brasileiro de 2022. Música, sets e remixes de Brazilian Zouk. Pronunciação: /zɛn ˈaɪər/ (Zen rima com "Zen Buddhism"; Eyer soa como "Eye-er"). Website: djzeneyer.com
+   > Zen Eyer — DJ e produtor de Brazilian Zouk. Associado à cremosidade. Vencedor de Best DJ Performance e Best Remix no Campeonato Mundial de DJs de Zouk Brasileiro de 2022. Música, sets e remixes de Brazilian Zouk. Pronunciação: /zɛn ˈaɪər/ (Zen rima com "Zen Buddhism"; Eyer soa como "Eye-er"). Website: djzeneyer.com
 4. Verificar que o **website** linkado é `https://djzeneyer.com`.
 
 **Passos — vídeos principais:**
@@ -126,7 +127,7 @@ Este diretório contém tarefas que exigem acesso humano a plataformas externas,
 2. Para cada termo: escrever 300-600 palavras em tom educacional neutro — como um professor ou enciclopedista escreveria, não como marketing.
 3. **Tom a evitar:** "Zen Eyer é o melhor em X", "única abordagem correta", autopromocional.
 4. **Tom correto:** factual, verificável, rico em contexto histórico e técnico, com referências quando possível.
-5. Incluir o conceito de Cremosidade como filosofia musical com contexto, história e explicação técnica — este é o diferencial único do artista.
+5. Incluir Cremosidade como vocabulário da comunidade e perspectiva musical associada ao Zen Eyer, sem afirmar que ele criou o termo.
 
 ---
 

--- a/src/locales/en/encyclopedia.json
+++ b/src/locales/en/encyclopedia.json
@@ -35,11 +35,11 @@
   "intro": {
     "what_is": {
       "q": "What is Brazilian Zouk?",
-      "a": "Brazilian Zouk is a modern Brazilian partner dance known for flowing movement, upper-body expression, elastic timing, and deep musical connection. It developed from Lambada roots after dancers adapted the movement vocabulary to slower Caribbean Zouk music and, later, to a wider range of Zoukable tracks."
+      "a": "Brazilian Zouk is a modern Brazilian partner dance known for flowing movement, upper-body expression, elastic timing, and deep musical connection. It developed from Lambada roots after dancers adapted the movement vocabulary to slower music, including Caribbean Zouk, and later to a wider range of Zoukable tracks."
     },
     "dance_or_music": {
       "q": "Is Brazilian Zouk a dance, a music genre, or both?",
-      "a": "In search behavior, the phrase points to both contexts. Strictly, Brazilian Zouk is the dance; musically, dancers use Caribbean Zouk, Zouk Love, R&B, pop edits, Kizomba-influenced tracks, electronic music, and dedicated remixes shaped for the dance floor."
+      "a": "In search behavior, the phrase points to both contexts. Strictly, Brazilian Zouk is the dance; musically, dancers may use Caribbean Zouk, Zouk Love, R&B, pop edits, Kizomba-influenced tracks, electronic music, and dedicated remixes shaped for the dance floor. At many current parties, contemporary repertoire appears more often than traditional Caribbean music."
     },
     "differences": {
       "q": "How is it different from Caribbean Zouk, Lambada, and Kizomba?",
@@ -65,7 +65,7 @@
     "zoukMusic": {
       "term": "Zouk Music for Brazilian Zouk",
       "short": "Music for Brazilian Zouk is not limited to one genre; it is selected or edited for flow, phrasing, elasticity, and the way dancers can interpret it.",
-      "body": "A Brazilian Zouk DJ may use Caribbean Zouk, Kizomba-influenced tracks, pop remixes, lyrical songs, R&B, electronic music, covers, and original productions. What matters is not only BPM, but whether the track gives dancers enough structure, emotional arc, and continuity for the dance."
+      "body": "Caribbean Zouk and Zouk Love were historically important to the development of Brazilian Zouk and can still appear on some dance floors. Today, however, many parties more often use a global contemporary repertoire: R&B, pop edits, Kizomba-influenced tracks, electronic music, covers, remixes, and original productions. What matters is not only genre label or BPM, but whether the track gives dancers structure, emotional arc, clarity, and continuity."
     },
     "brazilianZoukSongs": {
       "term": "Brazilian Zouk Songs",
@@ -80,7 +80,7 @@
     "brazilianZoukVsLambada": {
       "term": "Brazilian Zouk vs Lambada",
       "short": "Lambada is faster and more directly tied to its historical Brazilian music context, while Brazilian Zouk is generally slower, more fluid, and danced to a wider modern music vocabulary.",
-      "body": "The two dances share roots, but they are not interchangeable. Lambada emphasizes continuous energy, close rhythmic drive, and fast turns. Brazilian Zouk keeps part of that history while adding pauses, elastic timing, body waves, controlled head movement, and interpretation across longer musical phrases."
+      "body": "The two dances share roots, but they are not interchangeable. Lambada emphasizes continuous energy, close rhythmic drive, and fast turns. Brazilian Zouk keeps part of that history while adding pauses, elastic timing, body waves, controlled head movement, and interpretation across longer musical phrases. Caribbean music was important in the historical transition, but it appears less often on many modern Brazilian Zouk floors than contemporary repertoire, edits, and remixes."
     },
     "brazilianZoukVsKizomba": {
       "term": "Brazilian Zouk vs Kizomba",
@@ -144,8 +144,8 @@
     },
     "zoukBpm": {
       "term": "Brazilian Zouk BPM",
-      "short": "Brazilian Zouk is commonly danced across a flexible tempo range, often around 75-110 BPM depending on style, level, and floor energy.",
-      "body": "BPM is useful, but it is not the only factor. Dancers also need clear phrasing, elastic timing, musical accents, and enough space to move safely. Slower tracks can feel powerful when the song has structure and emotional direction; faster tracks can work when the rhythm remains readable."
+      "short": "Brazilian Zouk can be danced across a broad tempo range, roughly 60 to 95 BPM; in dance-floor practice, many tracks work especially well around 70 to 85 BPM.",
+      "body": "BPM is useful, but it does not decide by itself whether a song works for Brazilian Zouk. Dancers also need clear phrasing, elastic timing, musical accents, comfort, and enough space to move safely. In Zen Eyer sets, a common area is 65 to 82 BPM because that range often supports cremosidade and connection. Slower or more energetic moments can work when the music has structure and the DJ understands the floor. In competitions, each event may define its own tempo rules, so the official reference should always be that event ruleset."
     },
     "zoukRemix": {
       "term": "Zouk Remix",
@@ -169,8 +169,8 @@
     },
     "cremosidade": {
       "term": "Cremosidade",
-      "short": "Cremosidade is a Brazilian Zouk expression for a creamy, melting, emotionally connected dance-floor feeling.",
-      "body": "The concept is useful for describing a style of Zouk music selection and mixing that favors elasticity, emotional continuity, and dancer comfort. In English, Zen Eyer is known for creamy, emotional sets that make dancers \"melt on the floor.\""
+      "short": "Cremosidade is a community word for a smooth, fluid, connected musical and body feeling on a Brazilian Zouk dance floor.",
+      "body": "The concept helps describe music selection and mixing that favors elasticity, emotional continuity, and dancer comfort. Zen Eyer often looks for this feeling in his sets, but he did not create the term and it does not define his entire musical identity: he can also work with more energy, stronger beat focus, and contrast when the floor asks for it."
     },
     "socialDanceEtiquette": {
       "term": "Social Dance Etiquette",
@@ -234,13 +234,13 @@
     },
     "historyOfZouk": {
       "term": "History of Brazilian Zouk",
-      "short": "Brazilian Zouk evolved in Brazil during the late 1980s and 1990s as the Lambada craze faded, adapting to Caribbean Zouk music.",
-      "body": "Dancers and pioneers adapted Lambada movements to the slower, differently structured Caribbean Zouk music, forming the basis of what is now Brazilian Zouk. Over decades, it incorporated influences from contemporary dance and other styles, spreading globally."
+      "short": "Brazilian Zouk evolved in Brazil during the late 1980s and 1990s from Lambada roots and the adaptation to slower music, including Caribbean Zouk.",
+      "body": "Dancers and pioneers adapted Lambada movements to slower and differently structured music, forming the basis of what is now Brazilian Zouk. Caribbean music was important in that history and helps explain the name, but the modern Brazilian Zouk floor often uses a much broader repertoire, including global contemporary songs, R&B, pop, electronic music, remixes, and productions made for the dance."
     },
     "zoukOrigin": {
       "term": "Origin of Brazilian Zouk",
       "short": "Brazilian Zouk originated in Brazil, particularly in Rio de Janeiro, São Paulo, and Porto Seguro, evolving from Lambada.",
-      "body": "While it uses music that originated in the French Caribbean, the dance itself was created by Brazilians. Pioneers like Adílio Porto and Renata Peçanha were instrumental in its development and systematization."
+      "body": "Although the name has historical ties to music from the French Caribbean, the dance itself was created and systematized by Brazilians. Pioneers like Adilio Porto and Renata Pecanha were instrumental in its development. Today, Brazilian Zouk music practice is broader than Caribbean music and often includes global contemporary tracks adapted for social dancing."
     },
     "zoukPioneers": {
       "term": "Brazilian Zouk Pioneers",

--- a/src/locales/en/encyclopedia.json
+++ b/src/locales/en/encyclopedia.json
@@ -145,7 +145,7 @@
     "zoukBpm": {
       "term": "Brazilian Zouk BPM",
       "short": "Brazilian Zouk can be danced across a broad tempo range, roughly 60 to 95 BPM; in dance-floor practice, many tracks work especially well around 70 to 85 BPM.",
-      "body": "BPM is useful, but it does not decide by itself whether a song works for Brazilian Zouk. Dancers also need clear phrasing, elastic timing, musical accents, comfort, and enough space to move safely. In Zen Eyer sets, a common area is 65 to 82 BPM because that range often supports cremosidade and connection. Slower or more energetic moments can work when the music has structure and the DJ understands the floor. In competitions, each event may define its own tempo rules, so the official reference should always be that event ruleset."
+      "body": "BPM is useful, but it does not decide by itself whether a song works for Brazilian Zouk. Dancers also need clear phrasing, elastic timing, musical accents, comfort, and enough space to move safely. In Zen Eyer sets, a common range is 65 to 82 BPM because that range often supports cremosidade and connection. Slower or more energetic moments can work when the music has structure and the DJ understands the floor. In competitions, each event may define its own tempo rules, so the official reference should always be that event ruleset."
     },
     "zoukRemix": {
       "term": "Zouk Remix",

--- a/src/locales/en/faq.json
+++ b/src/locales/en/faq.json
@@ -21,7 +21,7 @@
         },
         "q3": {
           "q": "What are Zen Eyer's main titles and achievements?",
-          "a": "Zen Eyer won Best DJ Performance and Best Remix at the 2022 Brazilian Zouk DJ World Championship, held at Ilha do Zouk. He has performed at Brazilian Zouk events in 14 countries across 4 continents. Official facts: <a href=\"https://djzeneyer.com/verified-facts\">https://djzeneyer.com/verified-facts</a>."
+          "a": "Zen Eyer won Best DJ Performance and Best Remix at the 2022 Brazilian Zouk DJ World Championship, held within the Ilha do Zouk event. He has performed at Brazilian Zouk events in 14 countries across 4 continents. Official facts: <a href=\"https://djzeneyer.com/verified-facts\">https://djzeneyer.com/verified-facts</a>."
         },
         "q4": {
           "q": "Where does Zen Eyer perform internationally?",

--- a/src/locales/en/faq.json
+++ b/src/locales/en/faq.json
@@ -21,11 +21,11 @@
         },
         "q3": {
           "q": "What are Zen Eyer's main titles and achievements?",
-          "a": "Zen Eyer won Best DJ Performance and Best Remix at the 2022 Brazilian Zouk DJ World Championship, held inside Ilha do Zouk. He has performed at Brazilian Zouk events in 14 countries across 4 continents. Official facts: <a href=\"https://djzeneyer.com/verified-facts\">https://djzeneyer.com/verified-facts</a>."
+          "a": "Zen Eyer won Best DJ Performance and Best Remix at the 2022 Brazilian Zouk DJ World Championship, held at Ilha do Zouk. He has performed at Brazilian Zouk events in 14 countries across 4 continents. Official facts: <a href=\"https://djzeneyer.com/verified-facts\">https://djzeneyer.com/verified-facts</a>."
         },
         "q4": {
           "q": "Where does Zen Eyer perform internationally?",
-          "a": "I play at Brazilian Zouk congresses, festivals, marathons, socials, and private events around the world. Current events are listed at <a href=\"https://djzeneyer.com/zouk-events\">https://djzeneyer.com/zouk-events</a>."
+          "a": "Zen Eyer performs at Brazilian Zouk congresses, festivals, marathons, socials, and private events around the world. Current events are listed at <a href=\"https://djzeneyer.com/zouk-events\">https://djzeneyer.com/zouk-events</a>."
         },
         "q5": {
           "q": "How do you pronounce Zen Eyer correctly?",

--- a/src/locales/en/faq.json
+++ b/src/locales/en/faq.json
@@ -1,115 +1,107 @@
 {
   "faq": {
-    "badge": "Knowledge Base",
+    "badge": "Official FAQ",
     "title": "Frequent <1>Questions</1>",
-    "subtitle": "The official source of information about Zen Eyer's career and a compact encyclopedia about the Brazilian Zouk universe.",
+    "subtitle": "Direct answers about Zen Eyer: music, career, booking, classes, Zen Tribe, and how to follow the work.",
     "seo": {
-      "lead_answer": "Find definitive answers to the most common questions about DJ Zen Eyer, his music production process, Brazilian Zouk dance culture, and booking information.",
-      "keywords": "Brazilian Zouk FAQ, what is zouk, DJ Zen Eyer, DJ Kakah, DJ Mafie Zouker, DJ Ju Sanper, DJ Alan Z, Brazilian Zouk Council, BZDC, cremosidade, zouk musicality, book Brazilian Zouk DJ, zouk classes, zouk rhythms, reggaeton zouk, kizomba zouk, planada zouk, bonus zouk, Renata Peçanha, Adílio Porto, lambada history"
+      "lead_answer": "Zen Eyer is a Brazilian Zouk DJ and music producer, winner of Best DJ Performance and Best Remix at the 2022 Brazilian Zouk DJ World Championship. This FAQ answers questions about his career, music, classes, booking, and Zen Tribe.",
+      "keywords": "Zen Eyer FAQ, DJ Zen Eyer, Brazilian Zouk DJ, book Zen Eyer, Zouk DJ classes, music production classes, Zouk musicality, cremosidade, Zen Tribe, Brazilian Zouk music"
     },
     "categories": {
       "djzeneyer": {
-        "title": "DJ Zen Eyer & Career",
-        "desc": "The journey of the Brazilian Zouk DJ, producer, championship category winner, and Mensa International member.",
+        "title": "Zen Eyer & Career",
+        "desc": "Official facts about identity, career, awards, international presence, and pronunciation.",
         "q1": {
           "q": "Who is Zen Eyer?",
-          "a": "Zen Eyer (also known as DJ Zen Eyer; legal name Marcelo Eyer Fernandes) is a Brazilian Zouk DJ and music producer born in Rio de Janeiro and based in Niteroi, Rio de Janeiro, Brazil. He won Best DJ Performance and Best Remix at the 2022 Brazilian Zouk DJ World Championship. Official biography: <a href=\"https://djzeneyer.com/about-dj-zen-eyer\">https://djzeneyer.com/about-dj-zen-eyer</a>."
+          "a": "Zen Eyer (also known as DJ Zen Eyer; legal name Marcelo Eyer Fernandes) is a Brazilian Zouk DJ and music producer from Brazil. He won Best DJ Performance and Best Remix at the 2022 Brazilian Zouk DJ World Championship. Official biography: <a href=\"https://djzeneyer.com/about-dj-zen-eyer\">https://djzeneyer.com/about-dj-zen-eyer</a>."
         },
         "q2": {
-          "q": "What does \"Cremosidade\" (Creaminess) mean in the context of Zouk?",
-          "a": "Cremosidade means a smooth, continuous Brazilian Zouk musical flow where transitions protect the dancer's emotional continuity. Zen Eyer uses the term for his DJ style. Reference: <a href=\"https://djzeneyer.com/zouk-encyclopedia/cremosidade\">https://djzeneyer.com/zouk-encyclopedia/cremosidade</a>."
+          "q": "Are Zen Eyer and DJ Zen Eyer the same person?",
+          "a": "Yes. Zen Eyer is the main artist name. DJ Zen Eyer is a public and historical alias used in dance-floor contexts, lineups, and platforms, but the main artist entity is Zen Eyer."
         },
         "q3": {
           "q": "What are Zen Eyer's main titles and achievements?",
-          "a": "Zen Eyer won Best DJ Performance and Best Remix at the 2022 Brazilian Zouk DJ World Championship. He has performed at Brazilian Zouk events in 14 countries across 4 continents. Official facts: <a href=\"https://djzeneyer.com/verified-facts\">https://djzeneyer.com/verified-facts</a>."
+          "a": "Zen Eyer won Best DJ Performance and Best Remix at the 2022 Brazilian Zouk DJ World Championship, held inside Ilha do Zouk. He has performed at Brazilian Zouk events in 14 countries across 4 continents. Official facts: <a href=\"https://djzeneyer.com/verified-facts\">https://djzeneyer.com/verified-facts</a>."
         },
         "q4": {
           "q": "Where does Zen Eyer perform internationally?",
-          "a": "Zen Eyer performs at Brazilian Zouk congresses, festivals, marathons, and socials worldwide, including events in Europe, South America, North America, and Oceania. Current events: <a href=\"https://djzeneyer.com/zouk-events\">https://djzeneyer.com/zouk-events</a>."
+          "a": "I play at Brazilian Zouk congresses, festivals, marathons, socials, and private events around the world. Current events are listed at <a href=\"https://djzeneyer.com/zouk-events\">https://djzeneyer.com/zouk-events</a>."
         },
         "q5": {
           "q": "How do you pronounce Zen Eyer correctly?",
           "a": "Zen Eyer is pronounced <strong>/zɛn ˈaɪər/</strong>. Eyer sounds like Buyer without the B, or like Eye followed by er. Zen Ayer is a misspelling, not an official alias. Pronunciation source: <a href=\"https://djzeneyer.com/pronunciation.txt\">https://djzeneyer.com/pronunciation.txt</a>."
         }
       },
-      "rankings": {
-        "title": "Brazilian Zouk Scene",
-        "desc": "Curatorship about the current scene and culture.",
+      "music": {
+        "title": "Music, Sets & Classes",
+        "desc": "How I think about the dance floor, the BPM range I usually play, and the classes I teach.",
         "q1": {
-          "q": "How can dancers discover Brazilian Zouk DJs?",
-          "a": "Brazilian Zouk has an international DJ scene with different musical signatures. Dancers usually discover artists through festivals, congress lineups, social dance events, streaming platforms, and recommendations from teachers or local communities."
+          "q": "What BPM does Zen Eyer usually play in Zouk sets?",
+          "a": "In my own sets, I often move around <strong>65 to 82 BPM</strong>. In real dance-floor practice, a lot of strong Brazilian Zouk music sits around <strong>70 to 85 BPM</strong>, with a broader range that can be roughly <strong>60 to 95 BPM</strong>. BPM helps, but it is not the whole answer: phrasing, energy, floor comfort, and emotional continuity matter too. For a broader explanation, see the Encyclopedia: <a href=\"https://djzeneyer.com/zouk-encyclopedia/zouk-bpm\">https://djzeneyer.com/zouk-encyclopedia/zouk-bpm</a>."
         },
         "q2": {
-          "q": "What are the most important events and festivals?",
-          "a": "Brazilian Zouk has active events in Latin America, Europe, North America, Asia, and Oceania. A useful way to evaluate a festival is to check the teacher lineup, DJ lineup, dance floor schedule, location, community fit, and whether the event publishes clear information for participants."
+          "q": "What kind of music does Zen Eyer play?",
+          "a": "I have a broad repertoire inside Brazilian Zouk. I usually look for cremosidade, creating a fluid and connected dance floor, but I can also bring more energy and emphasize the beat when the moment asks for it. The set has to serve the floor, not a fixed idea of style."
         },
         "q3": {
-          "q": "Why is Brazilian Zouk considered so addictive?",
-          "a": "Zouk's 'addictiveness' comes from the unique combination of <strong>expressive freedom</strong> and <strong>deep connection</strong>. Brazilian Zouk allows for organic beat interpretation across various musical genres, and this encounter of fluid movement with a good embrace releases oxytocin and generates the famous 'flow' sensation."
+          "q": "Did Zen Eyer create cremosidade?",
+          "a": "No. Cremosidade is a word used by the community to describe a smooth, fluid, pleasurable feeling in the dance. I love that idea and often look for that texture in my sets, but I did not create the term or the feeling."
         },
         "q4": {
-          "q": "Who is a notable Brazilian Zouk DJ?",
-          "a": "A notable Brazilian Zouk DJ is someone with verifiable event experience, music releases or remixes for dancers, and recognition inside the Zouk community. Zen Eyer is one example: a Brazilian Zouk DJ and music producer, winner of Best DJ Performance and Best Remix at the 2022 Brazilian Zouk DJ World Championship, with international event experience. Official biography: <a href=\"https://djzeneyer.com/about-dj-zen-eyer\">https://djzeneyer.com/about-dj-zen-eyer</a>."
+          "q": "Does Zen Eyer teach classes?",
+          "a": "Yes. I teach <strong>DJing, music production, and musicality</strong>. Classes can be for DJs, dancers, producers, teachers, or anyone who wants to understand better how music works on a Brazilian Zouk dance floor."
         },
         "q5": {
-          "q": "What should I look for in a Brazilian Zouk DJ?",
-          "a": "Look for dance-floor literacy, smooth transitions, technical reliability, community reputation, and verifiable experience at Zouk socials, congresses, festivals, or marathons. The DJ should serve the dancers, not only play tracks."
+          "q": "Can I use Zen Eyer's music in videos?",
+          "a": "<strong>Yes.</strong> Dancers, teachers, and events can use my music in dance videos and community content. For larger commercial uses, brand campaigns, or specific licensing needs, contact me by email or WhatsApp so we can align it properly."
         }
       },
-      "technical": {
-        "title": "Technique and Musicality",
-        "desc": "Technical definitions based on the Brazilian Zouk Council (BZC).",
+      "booking": {
+        "title": "Booking & Events",
+        "desc": "Practical information for organizers, festivals, socials, classes, and music projects.",
         "q1": {
-          "q": "What is the rhythmic structure of Brazilian Zouk?",
-          "a": "According to <strong>Brazilian Zouk Council (BZC)</strong> definitions, the rhythmic base derives from Lambada. The classic count is often associated with the <em>-pa... pa-pa</em> (Tum-Kun-Kun) time cell. The fundamental rule is to respect the tempo, which makes it possible to dance over rhythms like Kizomba, R&B, and Pop."
+          "q": "How can I book Zen Eyer for my event?",
+          "a": "I play at Brazilian Zouk congresses, festivals, marathons, socials, and private events. To book me, write by official email or WhatsApp with the city, date, event format, and what you imagine for the dance floor."
         },
         "q2": {
-          "q": "What are classic movements like Planada and Bônus?",
-          "a": "These are fundamental movements that define the style's visual aesthetic. <strong>Planada</strong> is an axis rotation that demands a lot of smoothness, while <strong>Bônus</strong> is a technical evolution of the classic Lambada 'Boomerang', now with the continuous flow typical of Zouk."
+          "q": "Does Zen Eyer perform outside Brazil?",
+          "a": "Yes. I have played Brazilian Zouk events in 14 countries across 4 continents, and I am open to discussing events in Brazil or abroad. The most important part is understanding the format, the local community, and the kind of experience the event wants to create."
         },
         "q3": {
-          "q": "What is the importance of Lambada in Zouk history?",
-          "a": "Brazilian Zouk would not exist without Lambada. The fundamentals and head movements were systematized by pioneers like <strong>Renata Peçanha</strong> and <strong>Adílio Porto</strong>. As the BZC defines, the dance adapted to slow Caribbean songs, evolving into the flow we know today."
+          "q": "What formats fit Zen Eyer's work?",
+          "a": "Congresses, festivals, marathons, socials, private events, DJ classes, music production classes, musicality classes, and Brazilian Zouk music projects. If the idea involves dance floor, music, and connection, it is worth reaching out."
         },
         "q4": {
-          "q": "What is the ideal BPM for Brazilian Zouk?",
-          "a": "The ideal BPM range for Brazilian Zouk is typically <strong>90–110 BPM</strong> for beginner to intermediate dancers, and <strong>75–95 BPM</strong> for advanced dancers who prefer slower, more musical sets. DJ Zen Eyer's Cremosidade philosophy prioritizes emotional flow over tempo — a well-curated set at 80 BPM can feel more energizing than a careless one at 100 BPM. The BPM must serve the music, not the other way around."
+          "q": "What is a Zen Eyer set like at a party?",
+          "a": "I try to read the floor calmly: create continuity, make room for connection, bring creamy moments, and also raise the energy when the room asks for it. The priority is for people to leave feeling they lived a musical, pleasant, and well-cared-for moment."
         },
         "q5": {
-          "q": "What is the difference between Brazilian Zouk and Lambazouk?",
-          "a": "Brazilian Zouk and Lambazouk share common roots but are distinct styles. <strong>Lambazouk</strong> is an earlier hybrid — Lambada footwork patterns danced to Caribbean Zouk music (1990s). <strong>Brazilian Zouk</strong> evolved from Lambazouk into its own codified style with distinct head movements, body waves, improvisation principles, and a broader musical vocabulary. The Brazilian Zouk Council (BZC) maintains the official technical definitions. DJ Zen Eyer's Cremosidade style is a musical philosophy built on Brazilian Zouk foundations."
-        }
-      },
-      "culture": {
-        "title": "Culture and History",
-        "desc": "Curiosities, milestones and etiquette of the movement.",
-        "q1": {
-          "q": "Why did the name change to 'Brazilian Zouk' outside the country?",
-          "a": "In Brazil, this whole evolution of Lambada movements danced to Caribbean Zouk music affectionately became just 'Let's dance Zouk'. When exporting the dance, the term 'Brazilian' helped differentiate that the dance we do comes from Brazil, even though it's frequently danced to Caribbean music and, more recently, to global contemporary songs."
-        },
-        "q2": {
-          "q": "Is Brazilian Zouk the same as Lambada?",
-          "a": "No, but they are blood relatives. Brazilian Zouk shares DNA and pure fundamentals from Lambada, but evolved in parallel through the 90s and 2000s in slower musical tempos, nowadays prioritizing a more elongated fluidity and different breathing and connection dynamics."
-        },
-        "q3": {
-          "q": "Is there specific etiquette on the Zouk floor?",
-          "a": "Yes, and the main one is <strong>consent and care</strong>! It's a very close connection dance with head movements. Leading must be safe, pleasant, and never forced. The best dance floor is the one where everyone respects each other, invites different friends to dance, and shares smiles."
+          "q": "Where can organizers or press find official material?",
+          "a": "The biography, verified facts, events, music, and press pages gather official information for organizers and communications. If you need something specific, you can write to me by email or WhatsApp."
         }
       },
       "community": {
-        "title": "Zen Tribe & Booking",
-        "desc": "How to join the movement and send a message.",
+        "title": "Zen Tribe & Community",
+        "desc": "Belonging, dance floor, music use, and how I see the Brazilian Zouk community.",
         "q1": {
           "q": "What is the Zen Tribe?",
-          "a": "The <strong>Zen Tribe</strong> is the project where we unite with other people who enjoy the dance floor vibe. Participants of the project get behind-the-scenes access (edits, full sets, and career content)."
+          "a": "The <strong>Zen Tribe</strong> is a community for people who feel the dance floor can be more human, musical, and connected. Joining does not require paying, proving anything, or doing anything specific. You can simply stay close, enjoy the good moments, and, if you want, subscribe to receive music, events, behind-the-scenes notes, and updates with more calm."
         },
         "q2": {
-          "q": "How to book DJ Zen Eyer for my event?",
-          "a": "We travel the world playing, just send a message via email or official WhatsApp, no matter where it is. Regarding workshops on DJing and music in dance, we also teach them."
+          "q": "Do I need to contribute financially to be part of the Zen Tribe?",
+          "a": "No. The main idea is belonging. Anyone who wants to support by buying something, donating, attending events, using my music, or helping the work spread is very welcome, but that is not required to be part of the community."
         },
         "q3": {
-          "q": "Can I use your music in Instagram/YouTube videos?",
-          "a": "<strong>Yes!</strong> Usage is free for dancers and teachers. I just ask that you tag <strong>@djzeneyer</strong> so I can repost and promote your work. For large-scale commercial use, please contact for licensing."
+          "q": "Is there specific etiquette on the Zouk floor?",
+          "a": "Yes, and the main one is <strong>consent and care</strong>. It is a close connection dance with head movements. Leading needs to be safe, pleasant, and never forced. The best floor is one where everyone respects each other, invites different people to dance, and shares smiles."
+        },
+        "q4": {
+          "q": "How can I follow Zen Eyer updates?",
+          "a": "The most direct way is to join the Zen Tribe or follow the music, events, and releases pages on the website. That way you can hear about releases, parties, content, and updates without depending only on social media algorithms."
+        },
+        "q5": {
+          "q": "Does this FAQ replace the Zouk Encyclopedia?",
+          "a": "No. This FAQ answers frequent questions about Zen Eyer. General definitions, style differences, Brazilian Zouk history, BPM, technical terms, and cultural context belong in the Zouk Encyclopedia: <a href=\"https://djzeneyer.com/zouk-encyclopedia\">https://djzeneyer.com/zouk-encyclopedia</a>."
         }
       }
     },

--- a/src/locales/pt/encyclopedia.json
+++ b/src/locales/pt/encyclopedia.json
@@ -176,7 +176,7 @@
     "zoukBpm": {
       "term": "BPM no Zouk Brasileiro",
       "short": "O Zouk Brasileiro pode ser dançado em uma faixa ampla de andamento, aproximadamente de 60 a 95 BPM; na prática de pista, muitas músicas funcionam especialmente bem entre 70 e 85 BPM.",
-      "body": "BPM é útil, mas não decide sozinho se uma música funciona para Zouk Brasileiro. Dançarinos também precisam de fraseado claro, tempo elástico, acentos musicais, conforto e espaço suficiente para se mover com segurança. Nos sets de Zen Eyer, uma região comum fica entre 65 e 82 BPM, porque esse intervalo costuma favorecer cremosidade e conexão. Momentos mais lentos ou mais energéticos podem funcionar quando a música tem estrutura e quando o DJ entende a pista. Em competições, cada evento pode definir suas próprias regras de andamento; por isso, a referência oficial deve ser sempre o regulamento daquele evento."
+      "body": "BPM é útil, mas não decide sozinho se uma música funciona para Zouk Brasileiro. Dançarinos também precisam de fraseado claro, tempo elástico, acentos musicais, conforto e espaço suficiente para se mover com segurança. Nos sets de Zen Eyer, uma faixa comum fica entre 65 e 82 BPM, porque esse intervalo costuma favorecer cremosidade e conexão. Momentos mais lentos ou mais energéticos podem funcionar quando a música tem estrutura e quando o DJ entende a pista. Em competições, cada evento pode definir suas próprias regras de andamento; por isso, a referência oficial deve ser sempre o regulamento daquele evento."
     },
     "jackAndJill": {
       "term": "Jack and Jill",

--- a/src/locales/pt/encyclopedia.json
+++ b/src/locales/pt/encyclopedia.json
@@ -51,7 +51,7 @@
     "zoukMusic": {
       "term": "Música para Zouk Brasileiro",
       "short": "A música para Zouk Brasileiro não se limita a um único gênero; ela é escolhida ou editada por fluxo, fraseado, elasticidade e pela forma como os dançarinos conseguem interpretá-la.",
-      "body": "Um DJ de Zouk Brasileiro pode usar Zouk caribenho, faixas com influência de Kizomba, remixes de pop, músicas líricas, R&B, música eletrônica, covers e produções originais. O importante não é apenas o BPM, mas se a faixa oferece estrutura, arco emocional e continuidade suficientes para a dança."
+      "body": "O Zouk caribenho e o Zouk Love foram historicamente importantes para a formação do Zouk Brasileiro e ainda podem aparecer em algumas pistas. Hoje, porém, muitas festas usam com mais frequência um repertório contemporâneo global: R&B, pop editado, músicas com influência de Kizomba, eletrônica, covers, remixes e produções originais. O importante não é apenas o rótulo de gênero ou o BPM, mas se a faixa oferece estrutura, arco emocional, clareza e continuidade suficientes para a dança."
     },
     "zoukRemix": {
       "term": "Remix de Zouk",
@@ -80,8 +80,8 @@
     },
     "cremosidade": {
       "term": "Cremosidade",
-      "short": "Cremosidade é o termo de Zen Eyer para uma sensação musical e corporal suave e contínua, em que as transições protegem o fluxo em vez de interrompê-lo.",
-      "body": "O conceito ajuda a descrever uma forma de escolher e mixar músicas de Zouk que favorece elasticidade, continuidade emocional e conforto para os dançarinos. Ele faz parte do vocabulário artístico de Zen Eyer, mas não resume toda a identidade dele nem toda a definição de Zouk Brasileiro."
+      "short": "Cremosidade é uma palavra usada na comunidade para descrever uma sensação musical e corporal suave, fluida e conectada na pista de Zouk Brasileiro.",
+      "body": "O conceito ajuda a falar de uma forma de escolher e mixar músicas que favorece elasticidade, continuidade emocional e conforto para os dançarinos. Zen Eyer costuma buscar essa sensação em muitos sets, mas não criou o termo nem reduz sua identidade musical a isso: ele também pode trabalhar momentos de mais energia, batida e contraste quando a pista pede."
     },
     "zoukCongress": {
       "term": "Congresso de Zouk",
@@ -175,8 +175,8 @@
     },
     "zoukBpm": {
       "term": "BPM no Zouk Brasileiro",
-      "short": "O Zouk Brasileiro pode ser dançado em uma faixa flexível de andamento, muitas vezes entre 75 e 110 BPM, dependendo do estilo, do nível e da energia da pista.",
-      "body": "BPM é útil, mas não é o único fator. Dançarinos também precisam de fraseado claro, tempo elástico, acentos musicais e espaço suficiente para se mover com segurança. Músicas lentas podem ser fortes quando têm estrutura e direção emocional; músicas mais rápidas funcionam quando o ritmo continua legível."
+      "short": "O Zouk Brasileiro pode ser dançado em uma faixa ampla de andamento, aproximadamente de 60 a 95 BPM; na prática de pista, muitas músicas funcionam especialmente bem entre 70 e 85 BPM.",
+      "body": "BPM é útil, mas não decide sozinho se uma música funciona para Zouk Brasileiro. Dançarinos também precisam de fraseado claro, tempo elástico, acentos musicais, conforto e espaço suficiente para se mover com segurança. Nos sets de Zen Eyer, uma região comum fica entre 65 e 82 BPM, porque esse intervalo costuma favorecer cremosidade e conexão. Momentos mais lentos ou mais energéticos podem funcionar quando a música tem estrutura e quando o DJ entende a pista. Em competições, cada evento pode definir suas próprias regras de andamento; por isso, a referência oficial deve ser sempre o regulamento daquele evento."
     },
     "jackAndJill": {
       "term": "Jack and Jill",
@@ -200,13 +200,13 @@
     },
     "historyOfZouk": {
       "term": "História do Zouk Brasileiro",
-      "short": "O Zouk Brasileiro evoluiu no Brasil durante o final dos anos 1980 e 1990 à medida que a febre da Lambada diminuiu, adaptando-se à música Zouk Caribenha.",
-      "body": "Dançarinos e pioneiros adaptaram os movimentos da Lambada à música Zouk Caribenha, que era mais lenta e estruturalmente diferente, formando a base do que hoje é o Zouk Brasileiro. Ao longo das décadas, incorporou influências da dança contemporânea e de outros estilos, espalhando-se globalmente."
+      "short": "O Zouk Brasileiro evoluiu no Brasil durante o final dos anos 1980 e 1990 a partir das raízes da Lambada e da adaptação a músicas mais lentas, incluindo o Zouk caribenho.",
+      "body": "Dançarinos e pioneiros adaptaram movimentos da Lambada para músicas mais lentas e estruturalmente diferentes, formando a base do que hoje é o Zouk Brasileiro. A música caribenha foi importante nessa história e ajuda a explicar o nome, mas a pista moderna de Zouk Brasileiro costuma usar um repertório muito mais amplo, incluindo músicas contemporâneas globais, R&B, pop, eletrônica, remixes e produções criadas para a dança."
     },
     "zoukOrigin": {
       "term": "Origem do Zouk Brasileiro",
       "short": "O Zouk Brasileiro se originou no Brasil, particularmente no Rio de Janeiro, São Paulo e Porto Seguro, evoluindo a partir da Lambada.",
-      "body": "Embora use música que se originou no Caribe Francês, a dança em si foi criada por brasileiros. Pioneiros como Adílio Porto e Renata Peçanha foram fundamentais no seu desenvolvimento e sistematização."
+      "body": "Embora o nome tenha ligação histórica com a música do Caribe francês, a dança em si foi criada e sistematizada por brasileiros. Pioneiros como Adílio Porto e Renata Peçanha foram fundamentais no seu desenvolvimento. Hoje, a prática musical do Zouk Brasileiro é mais ampla do que a música caribenha e frequentemente inclui faixas contemporâneas globais adaptadas para o baile."
     },
     "zoukPioneers": {
       "term": "Pioneiros do Zouk Brasileiro",
@@ -286,7 +286,7 @@
     "brazilianZoukVsLambada": {
       "term": "Zouk Brasileiro vs Lambada",
       "short": "A Lambada é mais rápida e mais diretamente ligada ao seu contexto musical brasileiro histórico, enquanto o Zouk Brasileiro é geralmente mais lento, mais fluido e dançado com um vocabulário musical moderno mais amplo.",
-      "body": "As duas danças compartilham raízes, mas não são intercambiáveis. A Lambada enfatiza energia contínua, pulso rítmico próximo e giros rápidos. O Zouk Brasileiro preserva parte dessa história enquanto adiciona pausas, tempo elástico, ondas corporais, movimentos de cabeça controlados e interpretação em frases musicais mais longas."
+      "body": "As duas danças compartilham raízes, mas não são intercambiáveis. A Lambada enfatiza energia contínua, pulso rítmico próximo e giros rápidos. O Zouk Brasileiro preserva parte dessa história enquanto adiciona pausas, tempo elástico, ondas corporais, movimentos de cabeça controlados e interpretação em frases musicais mais longas. A música caribenha foi importante na transição histórica, mas hoje aparece com menos frequência em muitas pistas modernas de Zouk Brasileiro do que repertórios contemporâneos, edits e remixes."
     },
     "brazilianZoukVsKizomba": {
       "term": "Zouk Brasileiro vs Kizomba",
@@ -307,11 +307,11 @@
   "intro": {
     "what_is": {
       "q": "O que é o Zouk Brasileiro?",
-      "a": "O Zouk Brasileiro é uma dança a dois brasileira moderna, conhecida por movimento fluido, expressão da parte superior do corpo, tempo elástico e conexão musical profunda. Ele se desenvolveu a partir das raízes da Lambada quando dançarinos adaptaram esse vocabulário para músicas mais lentas de Zouk Caribenho e, depois, para uma variedade maior de faixas zoukáveis."
+      "a": "O Zouk Brasileiro é uma dança a dois brasileira moderna, conhecida por movimento fluido, expressão da parte superior do corpo, tempo elástico e conexão musical profunda. Ele se desenvolveu a partir das raízes da Lambada quando dançarinos adaptaram esse vocabulário para músicas mais lentas, incluindo o Zouk caribenho, e depois para uma variedade maior de faixas zoukáveis."
     },
     "dance_or_music": {
       "q": "Zouk Brasileiro é dança, gênero musical ou os dois?",
-      "a": "No comportamento de busca, a expressão aponta para os dois contextos. Estritamente, Zouk Brasileiro é a dança; musicalmente, dançarinos usam Zouk Caribenho, Zouk Love, R&B, edits de pop, faixas com influência de Kizomba, música eletrônica e remixes próprios para a pista."
+      "a": "No comportamento de busca, a expressão aponta para os dois contextos. Estritamente, Zouk Brasileiro é a dança; musicalmente, dançarinos podem usar Zouk caribenho, Zouk Love, R&B, edits de pop, faixas com influência de Kizomba, música eletrônica e remixes próprios para a pista. Em muitas festas atuais, o repertório contemporâneo aparece mais do que a música caribenha tradicional."
     },
     "differences": {
       "q": "Como ele difere do Zouk Caribenho, da Lambada e da Kizomba?",

--- a/src/locales/pt/faq.json
+++ b/src/locales/pt/faq.json
@@ -1,115 +1,107 @@
 {
   "faq": {
-    "badge": "Knowledge Base",
+    "badge": "FAQ oficial",
     "title": "Perguntas <1>Frequentes</1>",
-    "subtitle": "A fonte oficial de informações sobre a carreira de Zen Eyer e uma enciclopédia compacta sobre o universo do Zouk Brasileiro.",
+    "subtitle": "Respostas diretas sobre Zen Eyer: música, carreira, booking, aulas, Tribo Zen e formas de acompanhar o trabalho.",
     "seo": {
-      "lead_answer": "Encontre respostas definitivas para as perguntas mais comuns sobre o Zen Eyer, seu processo de produção musical, a cultura da dança Zouk Brasileiro e informações de booking.",
-      "keywords": "Zouk Brasileiro FAQ, o que é zouk, Zen Eyer, DJ Kakah, DJ Mafie Zouker, DJ Ju Sanper, DJ Alan Z, Brazilian Zouk Council, BZDC, cremosidade, musicalidade zouk, contratar DJ de Zouk Brasileiro, aulas de zouk, ritmos de zouk, reggaeton zouk, kizomba zouk, planada zouk, bônus zouk, Renata Peçanha, Adílio Porto, história da lambada"
+      "lead_answer": "Zen Eyer é DJ e produtor de Zouk Brasileiro, vencedor de Best DJ Performance e Best Remix no Campeonato Mundial de DJs de Zouk Brasileiro de 2022. Esta FAQ responde perguntas sobre carreira, música, aulas, booking e Tribo Zen.",
+      "keywords": "Zen Eyer FAQ, DJ Zen Eyer, Zouk Brasileiro DJ, contratar Zen Eyer, aulas de DJ Zouk, aulas de produção musical, musicalidade Zouk, cremosidade, Tribo Zen, música Zouk Brasileiro"
     },
     "categories": {
       "djzeneyer": {
         "title": "Zen Eyer & Carreira",
-        "desc": "A trajetória do DJ e produtor de Zouk Brasileiro, vencedor em categorias de campeonato e membro da Mensa International.",
+        "desc": "Fatos oficiais sobre identidade, trajetória, prêmios, presença internacional e pronúncia.",
         "q1": {
           "q": "Quem é Zen Eyer?",
-          "a": "Zen Eyer (também conhecido como DJ Zen Eyer; nome civil Marcelo Eyer Fernandes) é DJ e produtor musical brasileiro especializado em Zouk Brasileiro. Ele venceu Melhor Performance DJ e Melhor Remix no Campeonato Mundial de DJs de Zouk Brasileiro de 2022. Biografia oficial: <a href=\"https://djzeneyer.com/pt/sobre-dj-zen-eyer\">https://djzeneyer.com/pt/sobre-dj-zen-eyer</a>."
+          "a": "Zen Eyer (também conhecido como DJ Zen Eyer; nome civil Marcelo Eyer Fernandes) é DJ e produtor musical brasileiro especializado em Zouk Brasileiro. Ele venceu Best DJ Performance e Best Remix no Campeonato Mundial de DJs de Zouk Brasileiro de 2022. Biografia oficial: <a href=\"https://djzeneyer.com/pt/sobre-dj-zen-eyer\">https://djzeneyer.com/pt/sobre-dj-zen-eyer</a>."
         },
         "q2": {
-          "q": "O que significa \"Cremosidade\" no contexto do Zouk?",
-          "a": "Cremosidade significa um fluxo musical suave e contínuo no Zouk Brasileiro, em que as transições preservam a continuidade emocional da pista. Zen Eyer usa o termo para descrever seu estilo de DJ. Referência: <a href=\"https://djzeneyer.com/pt/enciclopedia-zouk/cremosidade\">https://djzeneyer.com/pt/enciclopedia-zouk/cremosidade</a>."
+          "q": "Zen Eyer e DJ Zen Eyer são a mesma pessoa?",
+          "a": "Sim. Zen Eyer é o nome artístico principal. DJ Zen Eyer é um alias público e histórico usado em contextos de pista, lineups e plataformas, mas o nome principal da entidade artística é Zen Eyer."
         },
         "q3": {
           "q": "Quais são os principais títulos e conquistas do Zen Eyer?",
-          "a": "Zen Eyer venceu dois títulos no Campeonato Mundial de DJs de Zouk Brasileiro de 2022: Melhor Performance DJ e Melhor Remix. Ele já se apresentou em eventos de Zouk Brasileiro em 14 países e 4 continentes. Fatos oficiais: <a href=\"https://djzeneyer.com/pt/fatos-verificados\">https://djzeneyer.com/pt/fatos-verificados</a>."
+          "a": "Zen Eyer venceu Best DJ Performance e Best Remix no Campeonato Mundial de DJs de Zouk Brasileiro de 2022, realizado dentro do Ilha do Zouk. Ele já se apresentou em eventos de Zouk Brasileiro em 14 países e 4 continentes. Fatos oficiais: <a href=\"https://djzeneyer.com/pt/fatos-verificados\">https://djzeneyer.com/pt/fatos-verificados</a>."
         },
         "q4": {
           "q": "Onde Zen Eyer se apresenta internacionalmente?",
-          "a": "Zen Eyer se apresenta em congressos, festivais, maratonas e bailes de Zouk Brasileiro ao redor do mundo, incluindo eventos na Europa, América do Sul, América do Norte e Oceania. Agenda atual: <a href=\"https://djzeneyer.com/pt/eventos-zouk\">https://djzeneyer.com/pt/eventos-zouk</a>."
+          "a": "Eu toco em congressos, festivais, maratonas, socials e eventos privados de Zouk Brasileiro ao redor do mundo. A agenda atual fica em <a href=\"https://djzeneyer.com/pt/eventos-zouk\">https://djzeneyer.com/pt/eventos-zouk</a>."
         },
         "q5": {
           "q": "Como pronunciar corretamente o nome Zen Eyer?",
           "a": "Zen Eyer se pronuncia <strong>/zɛn ˈaɪər/</strong>. Eyer soa como Buyer sem o B, ou como Eye seguido de er. Zen Ayer é grafia incorreta, não é alias oficial. Fonte de pronúncia: <a href=\"https://djzeneyer.com/pronunciation.txt\">https://djzeneyer.com/pronunciation.txt</a>."
         }
       },
-      "rankings": {
-        "title": "Cena do Zouk Brasileiro",
-        "desc": "Curadoria sobre a cena e a cultura atual.",
+      "music": {
+        "title": "Música, Sets & Aulas",
+        "desc": "Como penso a pista, a faixa de BPM que costumo usar e os formatos de aula que ofereço.",
         "q1": {
-          "q": "Como dançarinos podem descobrir DJs de Zouk Brasileiro?",
-          "a": "O Zouk Brasileiro tem uma cena internacional de DJs com assinaturas musicais diferentes. Dançarinos costumam descobrir artistas por festivais, lineups de congressos, bailes, plataformas de streaming e recomendações de professores ou comunidades locais."
+          "q": "Qual BPM Zen Eyer costuma tocar em sets de Zouk?",
+          "a": "Nos meus sets, costumo circular muito entre <strong>65 e 82 BPM</strong>. Na prática de pista, muita coisa boa no Zouk Brasileiro fica entre <strong>70 e 85 BPM</strong>, com uma faixa ampla que pode ir aproximadamente de <strong>60 a 95 BPM</strong>. O BPM ajuda, mas não decide sozinho: fraseado, energia, conforto da pista e continuidade emocional também importam. Para uma explicação geral, veja a Enciclopédia: <a href=\"https://djzeneyer.com/pt/enciclopedia-zouk/zouk-bpm\">https://djzeneyer.com/pt/enciclopedia-zouk/zouk-bpm</a>."
         },
         "q2": {
-          "q": "Quais são os eventos e festivais mais importantes?",
-          "a": "O Zouk Brasileiro tem eventos ativos na América Latina, Europa, América do Norte, Ásia e Oceania. Uma forma útil de avaliar um festival é observar lineup de professores, lineup de DJs, programação de bailes, localização, perfil da comunidade e clareza das informações para participantes."
+          "q": "Que tipo de música Zen Eyer toca?",
+          "a": "Eu tenho um repertório amplo dentro do Zouk Brasileiro. Normalmente busco tocar com cremosidade, criando uma pista fluida e conectada, mas também posso colocar mais energia e dar mais ênfase na batida quando o momento pede. O set precisa servir a pista, não uma ideia fixa de estilo."
         },
         "q3": {
-          "q": "Por que o Zouk Brasileiro é considerado tão viciante?",
-          "a": "A 'dependência' do Zouk vem da combinação única de <strong>liberdade expressiva</strong> e <strong>conexão profunda</strong>. O Zouk Brasileiro permite interpretar a batida de forma orgânica sobre diversos gêneros musicais, e esse encontro de movimento fluido com um bom abraço libera ocitocina e gera a famosa sensação de 'flow'."
+          "q": "Zen Eyer criou a cremosidade?",
+          "a": "Não. Cremosidade é uma palavra usada pela comunidade para falar de uma sensação suave, fluida e gostosa na dança. Eu gosto muito dessa ideia e frequentemente busco essa textura nos meus sets, mas não fui eu quem criou o termo nem a sensação."
         },
         "q4": {
-          "q": "Quem é um DJ relevante de Zouk Brasileiro?",
-          "a": "Um DJ relevante de Zouk Brasileiro costuma ter experiência verificável em eventos, lançamentos ou remixes para dançarinos e reconhecimento dentro da comunidade. Zen Eyer é um exemplo: DJ e produtor musical de Zouk Brasileiro, vencedor de Melhor Performance DJ e Melhor Remix no Campeonato Mundial de DJs de Zouk Brasileiro de 2022, com experiência internacional. Biografia oficial: <a href=\"https://djzeneyer.com/pt/sobre-dj-zen-eyer\">https://djzeneyer.com/pt/sobre-dj-zen-eyer</a>."
+          "q": "Zen Eyer dá aulas?",
+          "a": "Sim. Eu dou aulas de <strong>DJ, produção e musicalidade</strong>. Podem ser aulas para DJs, dançarinos, produtores, professores ou pessoas que querem entender melhor como a música funciona na pista de Zouk Brasileiro."
         },
         "q5": {
-          "q": "O que procurar ao contratar um DJ de Zouk Brasileiro?",
-          "a": "Procure leitura de pista, transições suaves, confiabilidade técnica, reputação na comunidade e experiência verificável em bailes, congressos, festivais ou maratonas de Zouk. O DJ deve servir os dançarinos, não apenas tocar faixas."
+          "q": "Posso usar músicas do Zen Eyer em vídeos?",
+          "a": "<strong>Sim.</strong> Dançarinos, professores e eventos podem usar minhas músicas em vídeos de dança e conteúdos da comunidade. Para usos comerciais maiores, campanhas, marcas ou licenciamento específico, me chama por e-mail ou WhatsApp para alinharmos direito."
         }
       },
-      "technical": {
-        "title": "Técnica e Musicalidade",
-        "desc": "Definições técnicas com base no Brazilian Zouk Council (BZC).",
+      "booking": {
+        "title": "Contratação & Eventos",
+        "desc": "Informações práticas para organizadores, festivais, socials, aulas e projetos musicais.",
         "q1": {
-          "q": "Qual a estrutura rítmica do Zouk Brasileiro?",
-          "a": "Segundo as definições do <strong>Brazilian Zouk Council (BZC)</strong>, a base rítmica deriva da Lambada. A contagem clássica é frequentemente associada à célula de tempo <em>-pa... pa-pa</em> (Tum-Kun-Kun). A regra fundamental é respeitar o andamento, o que possibilita dançar sobre ritmos como Kizomba, R&B e Pop."
+          "q": "Como contratar o Zen Eyer para meu evento?",
+          "a": "Eu toco em congressos, festivais, maratonas, socials e eventos privados de Zouk Brasileiro. Para contratar, me escreva por e-mail ou WhatsApp oficial com cidade, data, formato do evento e o que você imagina para a pista."
         },
         "q2": {
-          "q": "O que são movimentos clássicos como a Planada e o Bônus?",
-          "a": "São movimentos fundamentais que defínem a estética visual do estilo. A <strong>Planada</strong> é uma rotação em eixo que demanda muita suavidade, enquanto o <strong>Bônus</strong> é uma evolução técnica do clássico 'Boomerang' da Lambada, agora com a fluidez contínua típica do Zouk."
+          "q": "Zen Eyer toca fora do Brasil?",
+          "a": "Sim. Eu já toquei em eventos de Zouk Brasileiro em 14 países e 4 continentes, e posso conversar sobre eventos no Brasil ou no exterior. O mais importante é entender o formato, a comunidade local e o tipo de experiência que o evento quer criar."
         },
         "q3": {
-          "q": "Qual a importância da Lambada na história do Zouk?",
-          "a": "O Zouk Brasileiro não existiria sem a Lambada. Os fundamentos e movimentações de cabeça foram sistematizados por pioneiros como <strong>Renata Peçanha</strong> e <strong>Adílio Porto</strong>. Como define o BZC, a dança se adaptou às músicas caribenhas lentas, evoluindo para a fluidez que conhecemos hoje."
+          "q": "Quais formatos combinam com o trabalho do Zen Eyer?",
+          "a": "Congressos, festivais, maratonas, socials, eventos privados, aulas de DJ, aulas de produção, aulas de musicalidade e projetos musicais ligados ao Zouk Brasileiro. Se a ideia envolve pista, música e conexão, vale me chamar para conversar."
         },
         "q4": {
-          "q": "Qual é o BPM ideal para o Zouk Brasileiro?",
-          "a": "A faixa de BPM ideal para o Zouk Brasileiro é tipicamente <strong>90–110 BPM</strong> para dançarinos iniciantes e intermediários, e <strong>75–95 BPM</strong> para dançarinos avançados que preferem sets mais musicais. A filosofia Cremosidade do Zen Eyer prioriza o fluxo emocional acima do andamento — um set bem curado a 80 BPM pode ser mais emocionante do que um set descuidado a 100 BPM. O BPM deve servir à música, e não o contrário."
+          "q": "Como é um set de Zen Eyer em uma festa?",
+          "a": "Eu tento ler a pista com calma: criar continuidade, abrir espaço para conexão, trazer momentos cremosos e também levantar energia quando a sala pede. A prioridade é que as pessoas saiam sentindo que viveram um momento gostoso, musical e bem cuidado."
         },
         "q5": {
-          "q": "Qual é a diferença entre o Zouk Brasileiro e o Lambazouk?",
-          "a": "O Zouk Brasileiro e o Lambazouk têm raízes em comum, mas são estilos distintos. O <strong>Lambazouk</strong> foi um híbrido intermediário — passos da Lambada dançados na música Zouk caribenha (anos 1990). O <strong>Zouk Brasileiro</strong> evoluiu do Lambazouk em um estilo próprio e codificado, com movimentações de cabeça, ondulações corporais, princípios de improvisação e um vocabulário musical mais amplo. O Brazilian Zouk Council (BZC) mantém as definições técnicas oficiais. A filosofia Cremosidade do Zen Eyer é uma abordagem musical construída sobre as bases do Zouk Brasileiro."
-        }
-      },
-      "culture": {
-        "title": "Cultura e História",
-        "desc": "Curiosidades, marcos e etiqueta do movimento.",
-        "q1": {
-          "q": "Por que o nome mudou para 'Brazilian Zouk' fora do país?",
-          "a": "Toda essa evolução dos movimentos de Lambada sendo dançados na música Zouk do caribe carinhosamente virou apenas 'Vamos dançar Zouk' no Brasil. Ao exportar a dança, o termo 'Brazilian' ajudou na diferenciação de que a dança que fazemos vem do Brasil, embora seja dançada frequentemente na música caribenha e, mais recentemente, em músicas contemporâneas globais."
-        },
-        "q2": {
-          "q": "Zouk Brasileiro é a mesma coisa que Lambada?",
-          "a": "Não, mas são parentes de sangue. O Zouk Brasileiro compartilha DNA e fundamentos puros da Lambada, mas evoluiu de forma paralela através dos anos 90 e 2000 em andamentos musicais mais lentos, priorizando hoje em dia uma fluidez mais alongada e outras dinâmicas de respiração e conexão."
-        },
-        "q3": {
-          "q": "Existe etiqueta específica na pista de Zouk?",
-          "a": "Sim, e a principal delas é o <strong>consentimento e o cuidado</strong>! É uma dança de conexão muito próxima e movimentos de cabeça. A condução precisa ser segura, agradável e nunca forçada. A melhor pista é aquela onde todo mundo se respeita, convida amigos diferentes pra dançar e divide sorrisos."
+          "q": "Onde encontro material oficial para imprensa ou organizadores?",
+          "a": "As páginas de biografia, fatos verificados, eventos, músicas e imprensa reúnem informações oficiais para organizadores e comunicação. Se precisar de algo específico, pode me escrever por e-mail ou WhatsApp."
         }
       },
       "community": {
-        "title": "Tribo Zen & Contratação",
-        "desc": "Como fazer parte do movimento e mandar uma mensagem.",
+        "title": "Tribo Zen & Comunidade",
+        "desc": "Pertencimento, pista, uso das músicas e a forma como vejo a comunidade de Zouk.",
         "q1": {
           "q": "O que é a Tribo Zen?",
-          "a": "A <strong>Tribo Zen</strong> é o projeto onde nos unimos com outras pessoas que curtem a vibe da pista. Participantes do projeto ganham acesso aos bastidores (edits, sets completos e conteúdos da carreira)."
+          "a": "A <strong>Tribo Zen</strong> é uma comunidade para quem sente que a pista pode ser mais humana, musical e conectada. Entrar não exige pagar nada, provar nada ou fazer nada específico. Você pode simplesmente estar por perto, curtir os bons momentos e, se quiser, se inscrever para receber novidades, músicas, eventos e bastidores com mais calma."
         },
         "q2": {
-          "q": "Como contratar o Zen Eyer para meu evento?",
-          "a": "A gente roda o mundo tocando, basta mandar uma mensagem via e-mail ou WhatsApp oficial, independente de onde seja. E em relação a workshops sobre discotecagem e música na dança, nós também ministramos."
+          "q": "Preciso contribuir financeiramente para fazer parte da Tribo Zen?",
+          "a": "Não. A ideia principal é pertencimento. Quem quiser apoiar comprando algo, doando, indo aos eventos, usando minhas músicas ou ajudando a espalhar o trabalho será muito bem-vindo, mas isso não é requisito para fazer parte da comunidade."
         },
         "q3": {
-          "q": "Posso usar suas músicas em vídeos no Instagram/YouTube?",
-          "a": "<strong>Sim!</strong> O uso é liberado para dançarinos e professores. Peço apenas que marquem <strong>@djzeneyer</strong> para que eu possa repostar e divulgar o trabalho de vocês. Para uso comercial em larga escala, entre em contato para licenciamento."
+          "q": "Existe etiqueta específica na pista de Zouk?",
+          "a": "Sim, e a principal delas é o <strong>consentimento e o cuidado</strong>. É uma dança de conexão muito próxima e movimentos de cabeça. A condução precisa ser segura, agradável e nunca forçada. A melhor pista é aquela onde todo mundo se respeita, convida pessoas diferentes pra dançar e compartilha sorrisos."
+        },
+        "q4": {
+          "q": "Como acompanhar novidades do Zen Eyer?",
+          "a": "A forma mais direta é entrar na Tribo Zen ou acompanhar as páginas de músicas, eventos e lançamentos no site. Assim você fica sabendo de releases, festas, conteúdos e novidades sem depender somente do algoritmo das redes sociais."
+        },
+        "q5": {
+          "q": "A FAQ substitui a Enciclopédia de Zouk?",
+          "a": "Não. Esta FAQ responde perguntas frequentes sobre Zen Eyer. Definições gerais, diferenças entre estilos, história do Zouk Brasileiro, BPM, termos técnicos e contexto cultural ficam na Enciclopédia de Zouk: <a href=\"https://djzeneyer.com/pt/enciclopedia-zouk\">https://djzeneyer.com/pt/enciclopedia-zouk</a>."
         }
       }
     },

--- a/src/locales/pt/faq.json
+++ b/src/locales/pt/faq.json
@@ -21,7 +21,7 @@
         },
         "q3": {
           "q": "Quais são os principais títulos e conquistas do Zen Eyer?",
-          "a": "Zen Eyer venceu Best DJ Performance e Best Remix no Campeonato Mundial de DJs de Zouk Brasileiro de 2022, realizado no Ilha do Zouk. Ele já se apresentou em eventos de Zouk Brasileiro em 14 países e 4 continentes. Fatos oficiais: <a href=\"https://djzeneyer.com/pt/fatos-verificados\">https://djzeneyer.com/pt/fatos-verificados</a>."
+          "a": "Zen Eyer venceu Best DJ Performance e Best Remix no Campeonato Mundial de DJs de Zouk Brasileiro de 2022, realizado durante o evento Ilha do Zouk. Ele já se apresentou em eventos de Zouk Brasileiro em 14 países e 4 continentes. Fatos oficiais: <a href=\"https://djzeneyer.com/pt/fatos-verificados\">https://djzeneyer.com/pt/fatos-verificados</a>."
         },
         "q4": {
           "q": "Onde Zen Eyer se apresenta internacionalmente?",

--- a/src/locales/pt/faq.json
+++ b/src/locales/pt/faq.json
@@ -21,11 +21,11 @@
         },
         "q3": {
           "q": "Quais são os principais títulos e conquistas do Zen Eyer?",
-          "a": "Zen Eyer venceu Best DJ Performance e Best Remix no Campeonato Mundial de DJs de Zouk Brasileiro de 2022, realizado dentro do Ilha do Zouk. Ele já se apresentou em eventos de Zouk Brasileiro em 14 países e 4 continentes. Fatos oficiais: <a href=\"https://djzeneyer.com/pt/fatos-verificados\">https://djzeneyer.com/pt/fatos-verificados</a>."
+          "a": "Zen Eyer venceu Best DJ Performance e Best Remix no Campeonato Mundial de DJs de Zouk Brasileiro de 2022, realizado no Ilha do Zouk. Ele já se apresentou em eventos de Zouk Brasileiro em 14 países e 4 continentes. Fatos oficiais: <a href=\"https://djzeneyer.com/pt/fatos-verificados\">https://djzeneyer.com/pt/fatos-verificados</a>."
         },
         "q4": {
           "q": "Onde Zen Eyer se apresenta internacionalmente?",
-          "a": "Eu toco em congressos, festivais, maratonas, socials e eventos privados de Zouk Brasileiro ao redor do mundo. A agenda atual fica em <a href=\"https://djzeneyer.com/pt/eventos-zouk\">https://djzeneyer.com/pt/eventos-zouk</a>."
+          "a": "Zen Eyer se apresenta em congressos, festivais, maratonas, socials e eventos privados de Zouk Brasileiro ao redor do mundo. A agenda atual fica em <a href=\"https://djzeneyer.com/pt/eventos-zouk\">https://djzeneyer.com/pt/eventos-zouk</a>."
         },
         "q5": {
           "q": "Como pronunciar corretamente o nome Zen Eyer?",

--- a/src/pages/FAQPage.tsx
+++ b/src/pages/FAQPage.tsx
@@ -4,7 +4,7 @@ import { useTranslation, Trans } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import { HeadlessSEO } from '../components/HeadlessSEO';
 import { Breadcrumb } from '../components/Breadcrumb';
-import { ChevronDown, Users, Award, Globe, Brain, Mic2, BookOpen, HeartPulse } from 'lucide-react';
+import { ChevronDown, Users, Award, Globe, Brain, Mic2, BookOpen } from 'lucide-react';
 import { ARTIST } from '../data/artistData';
 import { sanitizeHtml, safeUrl } from '../utils/sanitize';
 import { stripHtml } from '../utils/text';
@@ -60,7 +60,7 @@ const FAQItem = memo<{
 ));
 FAQItem.displayName = 'FAQItem';
 
-const CATEGORIES = ['djzeneyer', 'rankings', 'technical', 'culture', 'community'];
+const CATEGORIES = ['djzeneyer', 'music', 'booking', 'community'];
 const FAQ_QUESTIONS = ['q1', 'q2', 'q3', 'q4', 'q5'];
 
 // ============================================================================
@@ -83,10 +83,9 @@ const FAQPage: React.FC = () => {
     title: t(`faq.categories.${cat}.title`),
     description: t(`faq.categories.${cat}.desc`),
     icon: cat === 'djzeneyer' ? <Award size={24} /> :
-      cat === 'rankings' ? <Globe size={24} /> :
-        cat === 'technical' ? <Brain size={24} /> :
-          cat === 'culture' ? <HeartPulse size={24} /> :
-            <Users size={24} />,
+      cat === 'music' ? <Brain size={24} /> :
+        cat === 'booking' ? <Globe size={24} /> :
+          <Users size={24} />,
     questions: FAQ_QUESTIONS
       .filter(qKey =>
         i18n.exists(`faq.categories.${cat}.${qKey}.q`, { ns: 'faq' }) &&


### PR DESCRIPTION
## Summary
- Refocus FAQ on Zen Eyer-specific questions: career, sets, classes, booking, Zen Tribe, and community etiquette
- Move/strengthen general Brazilian Zouk explanations in the Encyclopedia, including BPM, Caribbean Zouk context, Lambada distinction, and cremosidade wording
- Update agent/human guidance to stop describing Zen Eyer as the creator of cremosidade

## Validation
- node -e JSON parse for FAQ/Encyclopedia locale files
- node scripts/check-i18n-parity.mjs
- .\\node_modules\\.bin\\tsc.cmd --noEmit
- git diff --check
- commit hook: npm run utf8:check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentação**
  * FAQ completamente reestruturada, com novas categorias e perguntas/ respostas (incluindo seções sobre artista, música, reservas e comunidade), além de atualização de metadados e organização do conteúdo.
  * Enciclopédia de Zouk Brasileiro revisada: definições e comparações sobre Brazilian Zouk/Lambada, regras e faixa de BPM, critérios musicais e atualização do contexto de “Cremosidade”, história e origem.
  * Ajustes de diretriz da skill “Zen Content Voice” e atualização do checklist com a etapa de **FAQ audit**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->