### PR TITLE
chore(deps): bump dompurify to 3.4.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@marsidev/react-turnstile": "^1.5.3",
         "@react-oauth/google": "^0.13.5",
         "@tanstack/react-query": "^5.101.0",
-        "dompurify": "^3.4.7",
+        "dompurify": "^3.4.11",
         "framer-motion": "^12.39.0",
         "i18next": "^26.3.1",
         "i18next-browser-languagedetector": "^8.2.1",
@@ -3100,9 +3100,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
-      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@marsidev/react-turnstile": "^1.5.3",
     "@react-oauth/google": "^0.13.5",
     "@tanstack/react-query": "^5.101.0",
-    "dompurify": "^3.4.7",
+    "dompurify": "^3.4.11",
     "framer-motion": "^12.39.0",
     "i18next": "^26.3.1",
     "i18next-browser-languagedetector": "^8.2.1",


### PR DESCRIPTION
## Summary
- Upgrade DOMPurify from 3.4.10 to 3.4.11
- Addresses SNYK-JS-DOMPURIFY-17375136 reported against dompurify@3.4.10
- Keep the change restricted to package metadata and lockfile

## Validation
- npm ls dompurify
- npm audit --omit=dev --audit-level=moderate
- git diff --check
- commit hook: npm run utf8:check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Atualizada dependência de segurança para versão mais recente, incluindo melhorias e correções de compatibilidade.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->