### PR TITLE
Refine music release list layout

### DIFF
--- a/src/__tests__/pages/MusicPage.test.tsx
+++ b/src/__tests__/pages/MusicPage.test.tsx
@@ -129,13 +129,13 @@ describe('MusicPage — render', () => {
     expect(names.some((n) => n.includes('YouTube'))).toBe(true);
   });
 
-  it('renders release cards as links for each DISCOGRAPHY entry', () => {
+  it('renders release list items as links for each DISCOGRAPHY entry', () => {
     renderPage();
     const links = screen.getAllByRole('link');
     expect(links.length).toBeGreaterThanOrEqual(DISCOGRAPHY.length);
   });
 
-  it('renders release card with name of first DISCOGRAPHY entry', () => {
+  it('renders release list item with name of first DISCOGRAPHY entry', () => {
     renderPage();
     expect(screen.getByText(DISCOGRAPHY[0].name)).toBeDefined();
   });

--- a/src/__tests__/pages/MusicPage.test.tsx
+++ b/src/__tests__/pages/MusicPage.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { HelmetProvider } from 'react-helmet-async';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, vi } from 'vitest';
@@ -96,6 +96,8 @@ function getSchema(): Record<string, unknown> {
   return JSON.parse(raw) as Record<string, unknown>;
 }
 
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 // ── Render tests ──────────────────────────────────────────────────────────────
 
 describe('MusicPage — render', () => {
@@ -131,8 +133,16 @@ describe('MusicPage — render', () => {
 
   it('renders release list items as links for each DISCOGRAPHY entry', () => {
     renderPage();
-    const links = screen.getAllByRole('link');
-    expect(links.length).toBeGreaterThanOrEqual(DISCOGRAPHY.length);
+    const releasesHeading = screen.getByRole('heading', { name: 'music.releases_title' });
+    const releasesSection = releasesHeading.closest('section');
+    expect(releasesSection).not.toBeNull();
+
+    const releasesRegion = within(releasesSection as HTMLElement);
+    for (const release of DISCOGRAPHY) {
+      expect(
+        releasesRegion.getByRole('link', { name: new RegExp(escapeRegExp(release.name)) }),
+      ).toBeDefined();
+    }
   });
 
   it('renders release list item with name of first DISCOGRAPHY entry', () => {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -522,6 +522,7 @@
     "listen_now": "Listen Now",
     "releases_title": "Music releases",
     "releases_subtitle": "Release notes, credits, and official links published in Releases.",
+    "releases_archive_link": "Releases & Notes",
     "read_release": "Read release notes",
     "release_type": {
       "album": "Album",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -515,6 +515,7 @@
     "support_cta": "Contribuir com o Zen",
     "releases_title": "Lançamentos musicais",
     "releases_subtitle": "Notas de lançamento, créditos e links oficiais publicados em Lançamentos.",
+    "releases_archive_link": "Lançamentos & Notas",
     "read_release": "Ler notas do lançamento",
     "release_type": {
       "album": "Álbum",

--- a/src/pages/MusicPage.tsx
+++ b/src/pages/MusicPage.tsx
@@ -69,7 +69,7 @@ const SECONDARY_PLATFORMS = [
 ];
 
 const formatReleaseListDate = (releaseDate: string | undefined, lang: string): string => {
-  if (!releaseDate) return '';
+  if (!releaseDate || releaseDate === '2024-01-01') return '';
   return formatDateVal(releaseDate, lang === 'pt' ? 'pt-BR' : 'en', {
     year: 'numeric',
     month: 'short',

--- a/src/pages/MusicPage.tsx
+++ b/src/pages/MusicPage.tsx
@@ -15,6 +15,7 @@ import { MUSICGROUP_SCHEMA } from '../data/artist.schema';
 import { DISCOGRAPHY } from '../data/artist.discography';
 import { safeUrl } from '../utils/sanitize';
 import { buildReleaseCards, buildDiscographyListItems } from '../utils/music';
+import { getDateTimeFormatter } from '../utils/date';
 
 // --- SVG Icons for music platforms ---
 const SpotifyIcon = () => (
@@ -66,6 +67,16 @@ const SECONDARY_PLATFORMS = [
     color: 'hover:bg-[#FF0000]/20 border-[#FF0000]/20 hover:border-[#FF0000]/50',
   },
 ];
+
+const formatReleaseListDate = (releaseDate: string | undefined, lang: string): string => {
+  if (!releaseDate) return '';
+  return getDateTimeFormatter(lang === 'pt' ? 'pt-BR' : 'en', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(releaseDate));
+};
 
 const MusicPage: React.FC = () => {
   const { t, i18n } = useTranslation();
@@ -283,36 +294,33 @@ const MusicPage: React.FC = () => {
                   <p className="mt-1 text-sm text-white/50">{t('music.releases_subtitle')}</p>
                 </div>
                 <Link to={getLocalizedRoute('news', currentLang)} className="inline-flex items-center gap-2 text-sm font-bold text-primary hover:text-primary/80">
-                  <Trans i18nKey="news.title">
-                    Releases &amp; <span>Notes</span>
-                  </Trans>
+                  {t('music.releases_archive_link')}
                   <ExternalLink size={14} />
                 </Link>
               </div>
-              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <div className="overflow-hidden rounded-2xl border border-white/10 bg-surface/25">
                 {releaseCards.map((release) => (
                   <Link
                     key={release.id}
                     to={release.path}
-                    className="group flex min-h-[132px] gap-4 rounded-2xl border border-white/10 bg-surface/35 p-4 transition-colors hover:border-primary/50 hover:bg-surface/60"
+                    className="group flex items-center justify-between gap-4 border-b border-white/10 px-4 py-4 transition-colors last:border-b-0 hover:bg-surface/55 sm:px-5"
                   >
-                    <img
-                      src={safeUrl(release.image, '/images/zen-eyer-og-image.png')}
-                      alt={release.name}
-                      className="h-24 w-24 flex-none rounded-xl object-cover"
-                      width="96"
-                      height="96"
-                      loading="lazy"
-                    />
-                    <div className="min-w-0 flex-1">
-                      <div className="mb-2 inline-flex rounded-full border border-primary/20 bg-primary/10 px-2 py-1 text-[11px] font-bold uppercase tracking-wider text-primary">
-                        {t(`music.release_type.${release.type}`, { defaultValue: release.type })}
+                    <div className="min-w-0">
+                      <div className="mb-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] font-bold uppercase tracking-wider text-primary">
+                        <span>{t(`music.release_type.${release.type}`, { defaultValue: release.type })}</span>
+                        {release.releaseDate && (
+                          <span className="text-white/40">
+                            {formatReleaseListDate(release.releaseDate, currentLang)}
+                          </span>
+                        )}
                       </div>
-                      <h3 className="line-clamp-2 text-lg font-black text-white transition-colors group-hover:text-primary">
+                      <h3 className="truncate text-base font-black text-white transition-colors group-hover:text-primary sm:text-lg">
                         {release.name}
                       </h3>
-                      <p className="mt-2 text-sm text-white/50">{t('music.read_release')}</p>
                     </div>
+                    <span className="hidden shrink-0 text-sm font-bold text-white/35 transition-colors group-hover:text-primary sm:inline">
+                      {t('music.read_release')}
+                    </span>
                   </Link>
                 ))}
               </div>

--- a/src/pages/MusicPage.tsx
+++ b/src/pages/MusicPage.tsx
@@ -15,7 +15,7 @@ import { MUSICGROUP_SCHEMA } from '../data/artist.schema';
 import { DISCOGRAPHY } from '../data/artist.discography';
 import { safeUrl } from '../utils/sanitize';
 import { buildReleaseCards, buildDiscographyListItems } from '../utils/music';
-import { getDateTimeFormatter } from '../utils/date';
+import { formatDateVal } from '../utils/date';
 
 // --- SVG Icons for music platforms ---
 const SpotifyIcon = () => (
@@ -70,12 +70,12 @@ const SECONDARY_PLATFORMS = [
 
 const formatReleaseListDate = (releaseDate: string | undefined, lang: string): string => {
   if (!releaseDate) return '';
-  return getDateTimeFormatter(lang === 'pt' ? 'pt-BR' : 'en', {
+  return formatDateVal(releaseDate, lang === 'pt' ? 'pt-BR' : 'en', {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
     timeZone: 'UTC',
-  }).format(new Date(releaseDate));
+  });
 };
 
 const MusicPage: React.FC = () => {


### PR DESCRIPTION
## Summary
- Replace image-heavy release cards on the Music page with a compact text list
- Show release type and localized release date for each item
- Avoid rendering translation markup literally in the Releases & Notes link

## Validation
- npm.cmd test -- --run src/__tests__/pages/MusicPage.test.tsx
- node scripts/check-i18n-parity.mjs
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Redesenho da lista de releases, com exibição mais compacta de tipo e data
  * Adicionado link de arquivo de releases (“Releases & Notes”)
  * Melhor formatação das datas das releases, com tratamento para datas ausentes
* **Tests**
  * Atualizados testes da Music Page para validar os itens de releases como links e os textos exibidos
<!-- end of auto-generated comment: release notes by coderabbit.ai -->