### PR TITLE
Fix: Resolve PT/EN text mix in Events, Footer, and News

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -22,7 +22,8 @@
     "open_menu": "Open Menu",
     "main_navigation": "Main Navigation",
     "mobile_navigation": "Mobile Menu",
-    "faq": "FAQ"
+    "faq": "FAQ",
+    "contact": "Contact"
   },
   "dashboard": {
     "loading": "Syncing with the Zen Universe...",
@@ -1258,5 +1259,19 @@
     }
   },
   "share_event": "Share {{title}}",
-  "event_default_title": "Zen Eyer Event"
+  "event_default_title": "Zen Eyer Event",
+  "countries": {
+    "Brazil": "Brazil",
+    "Netherlands": "Netherlands",
+    "United States": "United States",
+    "Germany": "Germany",
+    "Spain": "Spain",
+    "France": "France",
+    "Portugal": "Portugal",
+    "Italy": "Italy",
+    "United Kingdom": "United Kingdom",
+    "Australia": "Australia",
+    "Canada": "Canada",
+    "Japan": "Japan"
+  }
 }

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -4,8 +4,8 @@
     "about": "Sobre",
     "events": "Eventos",
     "music": "Música",
-    "tribe": "Zen Tribe",
-    "presskit": "Press Kit",
+    "tribe": "Tribo Zen",
+    "presskit": "Kit de Imprensa",
     "booking": "Trabalhe Comigo",
     "media": "Imprensa",
     "shop": "Loja",
@@ -22,7 +22,8 @@
     "mobile_navigation": "Menu Mobile",
     "privacy": "Política de Privacidade",
     "terms": "Termos de Uso",
-    "faq": "FAQ"
+    "faq": "FAQ",
+    "contact": "Contato"
   },
   "dashboard": {
     "loading": "Sincronizando com o Universo Zen...",
@@ -202,7 +203,7 @@
   "events": {
     "title_part1": "Agenda de",
     "title_part2": "Eventos",
-    "press_kit": "Press Kit",
+    "press_kit": "Kit de Imprensa",
     "featured": "Evento em Destaque"
   },
   "gamification": {
@@ -781,7 +782,7 @@
   "footer_music_philosophy": "Filosofia Musical",
   "footer_press_kit_booking": "Press Kit / Booking",
   "footer_support_artist": "Apoie o Artista",
-  "footer_join_newsletter": "Assine o Newsletter",
+  "footer_join_newsletter": "Assine a Newsletter",
   "footer_newsletter_desc": "Receba atualizações exclusivas, novos lançamentos e acesso VIP a eventos diretamente no seu e-mail.",
   "footer_email_placeholder": "Seu endereço de e-mail",
   "footer_subscribe": "Inscrever-se",
@@ -1187,7 +1188,7 @@
       "meta_desc": "Quem é você na pista de dança? Faça o Quiz de Persona do Zouk e descubra se você é um Lambadeiro, Técnico ou o Cremoso!"
     }
   },
-  "contact": "contact",
+  "contact": "Contato",
   "event_desc_fallback": "event_desc_fallback",
   "events_noEvents": "events_noEvents",
   "events_subtitle": "events_subtitle",
@@ -1258,5 +1259,19 @@
   "events_venue": "Local",
   "quiz_you_are": "Você é...",
   "share_event": "Compartilhar {{title}}",
-  "event_default_title": "Evento Zen Eyer"
+  "event_default_title": "Evento Zen Eyer",
+  "countries": {
+    "Brazil": "Brasil",
+    "Netherlands": "Holanda",
+    "United States": "Estados Unidos",
+    "Germany": "Alemanha",
+    "Spain": "Espanha",
+    "France": "França",
+    "Portugal": "Portugal",
+    "Italy": "Itália",
+    "United Kingdom": "Reino Unido",
+    "Australia": "Austrália",
+    "Canada": "Canadá",
+    "Japan": "Japão"
+  }
 }

--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -298,7 +298,7 @@ const EventListContent = ({ lang }: { lang: string }) => {
                     <div key={e.event_id} className="flex flex-col md:flex-row md:items-center gap-4 p-6 bg-surface/30 border border-white/5 rounded-2xl hover:border-primary/20 transition-all group">
                       <div className="text-3xl font-black min-w-[50px]">{dayStr}</div>
                       <div className="flex-1">
-                        <div className="text-xs text-primary font-bold uppercase tracking-widest mb-1 flex items-center gap-1"><MapPin size={10} /> {loc.city}{loc.region ? `, ${loc.region}` : ''}{loc.country ? ` (${loc.country})` : ''}</div>
+                        <div className="text-xs text-primary font-bold uppercase tracking-widest mb-1 flex items-center gap-1"><MapPin size={10} /> {loc.city}{loc.region ? `, ${loc.region}` : ''}{loc.country ? ` (${t(`countries.${loc.country}`, { defaultValue: loc.country })})` : ''}</div>
                         <Link to={detailHref}>
                           <h3 className="text-xl font-bold uppercase group-hover:text-primary transition-colors" dangerouslySetInnerHTML={{ __html: sanitizeHtml(e.title) }} />
                         </Link>

--- a/src/pages/NewsPage.tsx
+++ b/src/pages/NewsPage.tsx
@@ -312,9 +312,7 @@ const NewsPage: React.FC = () => {
                 {t('news.live_feed')}
               </motion.div>
               <h1 className="text-3xl sm:text-5xl md:text-7xl font-black font-display tracking-tight text-white leading-none">
-                <Trans i18nKey="news.title">
-                  Latest <span className="text-primary">Stories</span>
-                </Trans>
+                <Trans i18nKey="news.title" components={{ 1: <span className="text-primary" /> }} />
               </h1>
             </div>
             <div className="text-right text-white/50 text-sm hidden md:block">
@@ -455,9 +453,7 @@ const NewsPage: React.FC = () => {
               )}
 
               <h2 className="text-2xl sm:text-4xl md:text-5xl font-display font-black text-center mb-10 sm:mb-16 text-white uppercase tracking-tight">
-                <Trans i18nKey="news.latest_stories_title">
-                  Trending <span className="text-primary">News</span>
-                </Trans>
+                <Trans i18nKey="news.latest_stories_title" components={{ 1: <span className="text-primary" /> }} />
               </h2>
               <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-8">
                 {secondaryPosts.map((post, index) => (


### PR DESCRIPTION
Translates hardcoded countries to the active locale, replaces fallback literals with properly translated keys in NewsPage, and fixes the 'Assine o Newsletter' grammar issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Adicionadas novas seções de FAQ e Contato na navegação
  * Nomes de países agora exibidos em múltiplos idiomas nos eventos
  * Melhorias na apresentação de títulos de notícias e informações localizadas

<!-- end of auto-generated comment: release notes by coderabbit.ai -->