### PR TITLE
Chore: Ignore bots in CodeRabbit trigger

### DIFF
--- a/.github/workflows/trigger-bot-reviews.yml
+++ b/.github/workflows/trigger-bot-reviews.yml
@@ -26,6 +26,7 @@ concurrency:
 jobs:
   trigger-reviews:
     name: Trigger CodeRabbit
+    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]' && contains(github.event.pull_request.labels.*.name, 'needs-ai-review') }}
     runs-on: ubuntu-latest
     steps:
       - name: Trigger CodeRabbit review once

--- a/.github/workflows/trigger-bot-reviews.yml
+++ b/.github/workflows/trigger-bot-reviews.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   trigger-reviews:
     name: Trigger CodeRabbit
-    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]' && contains(github.event.pull_request.labels.*.name, 'needs-ai-review') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]' && contains(github.event.pull_request.labels.*.name, 'needs-ai-review')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Trigger CodeRabbit review once


### PR DESCRIPTION
Ignorando bots como dependabot para não estourar a cota de rate limit do CodeRabbit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Ajustado o fluxo de disparo da revisão automática para executar o processo somente em condições específicas, filtrando ações automatizadas e exigindo o label de prioridade na PR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->