### PR TITLE
perf: fetch sitemap post pages concurrently

### DIFF
--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -314,7 +314,13 @@ async function fetchPostsForLang(lang) {
       console.warn(`Posts (${lang}, page=${page}): API respondeu ${res.status}.`);
       return { posts: [], totalPages: page === 1 ? 0 : null };
     }
-    const data = await res.json();
+    let data;
+    try {
+      data = await res.json();
+    } catch (error) {
+      console.warn(`Error parsing JSON for posts (lang=${lang}, page=${page}):`, error instanceof Error ? error.message : String(error));
+      return { posts: [], totalPages: page === 1 ? 0 : null };
+    }
     return {
       posts: normalizePostPage(data),
       totalPages: page === 1 ? parseInt(res.headers.get('X-WP-TotalPages') || '1', 10) : null,
@@ -328,13 +334,16 @@ async function fetchPostsForLang(lang) {
     return posts;
   }
 
-  const pageRequests = [];
-  for (let page = 2; page <= totalPages; page++) {
-    pageRequests.push(fetchPostPage(page));
-  }
-  const remainingPages = await Promise.all(pageRequests);
-  for (const pageResult of remainingPages) {
-    posts.push(...pageResult.posts);
+  const concurrencyLimit = 5;
+  for (let i = 2; i <= totalPages; i += concurrencyLimit) {
+    const batch = [];
+    for (let j = 0; j < concurrencyLimit && (i + j) <= totalPages; j++) {
+      batch.push(fetchPostPage(i + j));
+    }
+    const batchResults = await Promise.all(batch);
+    for (const pageResult of batchResults) {
+      posts.push(...pageResult.posts);
+    }
   }
   return posts;
 }

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -295,34 +295,49 @@ async function fetchPostsFromZenSeoSitemap() {
 async function fetchPostsForLang(lang) {
   const fields = 'id,date,modified,slug,link,featured_image_src,featured_image_src_full,zen_seo,zen_translations';
   const posts = [];
-  let page = 1;
-  while (true) {
-    const url = `${REST_BASE_URL}/wp/v2/posts?lang=${lang}&per_page=100&page=${page}&status=publish&orderby=modified&order=desc&_fields=${encodeURIComponent(fields)}`;
+  const buildPostsUrl = (page) =>
+    `${REST_BASE_URL}/wp/v2/posts?lang=${lang}&per_page=100&page=${page}&status=publish&orderby=modified&order=desc&_fields=${encodeURIComponent(fields)}`;
+  const normalizePostPage = (data) =>
+    Array.isArray(data)
+      ? data.map(post => normalizePost(post, lang)).filter(post => post.slug && !post.noindex)
+      : [];
+  const fetchPostPage = async (page) => {
+    const url = buildPostsUrl(page);
     let res;
     try {
       res = await fetch(url, { headers: { Accept: 'application/json' } });
     } catch (error) {
-      console.warn(`⚠️ Error fetching posts (lang=${lang}, page=${page}):`, error instanceof Error ? error.message : String(error));
-      break;
+      console.warn(`Error fetching posts (lang=${lang}, page=${page}):`, error instanceof Error ? error.message : String(error));
+      return { posts: [], totalPages: page === 1 ? 0 : null };
     }
     if (!res.ok) {
-      console.warn(`⚠️ Posts (${lang}): API respondeu ${res.status}.`);
-      break;
+      console.warn(`Posts (${lang}, page=${page}): API respondeu ${res.status}.`);
+      return { posts: [], totalPages: page === 1 ? 0 : null };
     }
     const data = await res.json();
-    if (!Array.isArray(data) || data.length === 0) break;
-    posts.push(
-      ...data
-        .map(post => normalizePost(post, lang))
-        .filter(post => post.slug && !post.noindex)
-    );
-    const totalPages = parseInt(res.headers.get('X-WP-TotalPages') || '1', 10);
-    if (page >= totalPages) break;
-    page++;
+    return {
+      posts: normalizePostPage(data),
+      totalPages: page === 1 ? parseInt(res.headers.get('X-WP-TotalPages') || '1', 10) : null,
+    };
+  };
+
+  const firstPage = await fetchPostPage(1);
+  posts.push(...firstPage.posts);
+  const totalPages = Number.isFinite(firstPage.totalPages) ? firstPage.totalPages : 0;
+  if (totalPages <= 1) {
+    return posts;
+  }
+
+  const pageRequests = [];
+  for (let page = 2; page <= totalPages; page++) {
+    pageRequests.push(fetchPostPage(page));
+  }
+  const remainingPages = await Promise.all(pageRequests);
+  for (const pageResult of remainingPages) {
+    posts.push(...pageResult.posts);
   }
   return posts;
 }
-
 async function fetchPosts() {
   const endpointPosts = await fetchPostsFromZenSeoSitemap();
   if (endpointPosts.length > 0) {


### PR DESCRIPTION
## Summary
- Recreates the useful idea from the closed sitemap optimization PRs without generated XML churn.
- Fetches the first wp/v2 posts page to read X-WP-TotalPages, then fetches remaining pages concurrently with Promise.all.
- Keeps failure handling page-local so one failed page does not abort the whole sitemap fallback.

## Validation
- npm run lint
- node scripts/check-utf8-content.mjs
- node --check scripts/generate-sitemap.js

## Notes
No sitemap XML files are committed in this PR. The generated files should continue to be produced by the existing sitemap generation flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Melhorias**
  * Otimizado o processamento de geração de sitemap através de carregamento paralelo de múltiplas páginas, acelerando significativamente toda a execução
  * Aprimorado o tratamento de erros durante o processamento: falhas em páginas individuais não mais interrompem o fluxo geral, garantindo que todas as páginas disponíveis sejam incluídas no resultado final do sitemap

<!-- end of auto-generated comment: release notes by coderabbit.ai -->