### PR TITLE
fix: centralize MailPoet list id cache

### DIFF
--- a/plugins/zeneyer-auth/includes/API/class-rest-routes.php
+++ b/plugins/zeneyer-auth/includes/API/class-rest-routes.php
@@ -26,6 +26,7 @@ class Rest_Routes
     const NAMESPACE = 'zeneyer-auth/v1';
     private const MAILPOET_ZEN_TRIBE_LIST_TRANSIENT = 'zeneyer_mailpoet_zen_tribe_list_id';
     private const MAILPOET_ZEN_TRIBE_LIST_MISSING = -1;
+    private const MAILPOET_ZEN_TRIBE_LIST_MISSING_TTL = 300;
     private const MAILPOET_ZEN_TRIBE_LIST_TTL = 43200;
 
     public static function register_routes()
@@ -762,7 +763,7 @@ class Rest_Routes
             }
         }
 
-        set_transient(self::MAILPOET_ZEN_TRIBE_LIST_TRANSIENT, self::MAILPOET_ZEN_TRIBE_LIST_MISSING, self::MAILPOET_ZEN_TRIBE_LIST_TTL);
+        set_transient(self::MAILPOET_ZEN_TRIBE_LIST_TRANSIENT, self::MAILPOET_ZEN_TRIBE_LIST_MISSING, self::MAILPOET_ZEN_TRIBE_LIST_MISSING_TTL);
         return null;
     }
 
@@ -832,12 +833,13 @@ class Rest_Routes
                             'last_name' => $user->last_name ?: '',
                         ], [$zen_list_id]);
                     } catch (\Exception $e) {
-                        $zen_list_id = self::get_zen_tribe_mailpoet_list_id($mailpoet_api, true);
+                        $refreshed_list_id = self::get_zen_tribe_mailpoet_list_id($mailpoet_api, true);
 
-                        if (!$zen_list_id) {
+                        if (!$refreshed_list_id || $refreshed_list_id === $zen_list_id) {
                             throw $e;
                         }
 
+                        $zen_list_id = $refreshed_list_id;
                         $subscriber = $mailpoet_api->addSubscriber([
                             'email' => $user->user_email,
                             'first_name' => $user->first_name ?: $user->display_name,
@@ -849,12 +851,13 @@ class Rest_Routes
                     try {
                         $mailpoet_api->subscribeToList($subscriber['id'], $zen_list_id);
                     } catch (\Exception $e) {
-                        $zen_list_id = self::get_zen_tribe_mailpoet_list_id($mailpoet_api, true);
+                        $refreshed_list_id = self::get_zen_tribe_mailpoet_list_id($mailpoet_api, true);
 
-                        if (!$zen_list_id) {
+                        if (!$refreshed_list_id || $refreshed_list_id === $zen_list_id) {
                             throw $e;
                         }
 
+                        $zen_list_id = $refreshed_list_id;
                         $mailpoet_api->subscribeToList($subscriber['id'], $zen_list_id);
                     }
                 }
@@ -865,12 +868,13 @@ class Rest_Routes
                     try {
                         $mailpoet_api->unsubscribeFromList($subscriber['id'], $zen_list_id);
                     } catch (\Exception $e) {
-                        $zen_list_id = self::get_zen_tribe_mailpoet_list_id($mailpoet_api, true);
+                        $refreshed_list_id = self::get_zen_tribe_mailpoet_list_id($mailpoet_api, true);
 
-                        if (!$zen_list_id) {
+                        if (!$refreshed_list_id || $refreshed_list_id === $zen_list_id) {
                             throw $e;
                         }
 
+                        $zen_list_id = $refreshed_list_id;
                         $mailpoet_api->unsubscribeFromList($subscriber['id'], $zen_list_id);
                     }
                 }
@@ -954,6 +958,10 @@ class Rest_Routes
             }
 
             $zen_list_id = self::get_zen_tribe_mailpoet_list_id($mailpoet_api);
+
+            if (!$zen_list_id) {
+                $zen_list_id = self::get_zen_tribe_mailpoet_list_id($mailpoet_api, true);
+            }
 
             if (!$zen_list_id) {
                 return rest_ensure_response([

--- a/plugins/zeneyer-auth/includes/API/class-rest-routes.php
+++ b/plugins/zeneyer-auth/includes/API/class-rest-routes.php
@@ -24,6 +24,8 @@ class Rest_Routes
 {
 
     const NAMESPACE = 'zeneyer-auth/v1';
+    private const MAILPOET_ZEN_TRIBE_LIST_TRANSIENT = 'zeneyer_mailpoet_zen_tribe_list_id';
+    private const MAILPOET_ZEN_TRIBE_LIST_TTL = 43200;
 
     public static function register_routes()
     {
@@ -732,6 +734,34 @@ class Rest_Routes
     }
 
     /**
+     * Resolve the MailPoet list used for Zen Tribe newsletter subscriptions.
+     *
+     * MailPoet list names can be changed in wp-admin, so the cache is short-lived
+     * and refreshed through one helper instead of duplicating getLists() searches.
+     */
+    private static function get_zen_tribe_mailpoet_list_id($mailpoet_api)
+    {
+        $cached_id = get_transient(self::MAILPOET_ZEN_TRIBE_LIST_TRANSIENT);
+
+        if (false !== $cached_id && (int) $cached_id > 0) {
+            return (int) $cached_id;
+        }
+
+        $lists = $mailpoet_api->getLists();
+
+        foreach ($lists as $list) {
+            if (isset($list['id'], $list['name']) && stripos((string) $list['name'], 'Zen Tribe') !== false) {
+                $list_id = (int) $list['id'];
+                set_transient(self::MAILPOET_ZEN_TRIBE_LIST_TRANSIENT, $list_id, self::MAILPOET_ZEN_TRIBE_LIST_TTL);
+                return $list_id;
+            }
+        }
+
+        delete_transient(self::MAILPOET_ZEN_TRIBE_LIST_TRANSIENT);
+        return null;
+    }
+
+    /**
      * Toggle newsletter subscription (MailPoet integration)
      */
     public static function toggle_newsletter($request)
@@ -773,16 +803,7 @@ class Rest_Routes
                 // Subscriber doesn't exist, will create if enabling
             }
 
-            // Find "Zen Tribe Newsletter" list
-            $lists = $mailpoet_api->getLists();
-            $zen_list_id = null;
-
-            foreach ($lists as $list) {
-                if (stripos($list['name'], 'Zen Tribe') !== false) {
-                    $zen_list_id = $list['id'];
-                    break;
-                }
-            }
+            $zen_list_id = self::get_zen_tribe_mailpoet_list_id($mailpoet_api);
 
             if (!$zen_list_id) {
                 // Fallback to user meta if list not found
@@ -893,16 +914,7 @@ class Rest_Routes
                 ]);
             }
 
-            // Find Zen Tribe list
-            $lists = $mailpoet_api->getLists();
-            $zen_list_id = null;
-
-            foreach ($lists as $list) {
-                if (stripos($list['name'], 'Zen Tribe') !== false) {
-                    $zen_list_id = $list['id'];
-                    break;
-                }
-            }
+            $zen_list_id = self::get_zen_tribe_mailpoet_list_id($mailpoet_api);
 
             if (!$zen_list_id) {
                 return rest_ensure_response([

--- a/plugins/zeneyer-auth/includes/API/class-rest-routes.php
+++ b/plugins/zeneyer-auth/includes/API/class-rest-routes.php
@@ -740,9 +740,9 @@ class Rest_Routes
      * MailPoet list names can be changed in wp-admin, so the cache is short-lived
      * and refreshed through one helper instead of duplicating getLists() searches.
      */
-    private static function get_zen_tribe_mailpoet_list_id($mailpoet_api)
+    private static function get_zen_tribe_mailpoet_list_id($mailpoet_api, $force_refresh = false)
     {
-        $cached_id = get_transient(self::MAILPOET_ZEN_TRIBE_LIST_TRANSIENT);
+        $cached_id = $force_refresh ? false : get_transient(self::MAILPOET_ZEN_TRIBE_LIST_TRANSIENT);
 
         if ((int) $cached_id === self::MAILPOET_ZEN_TRIBE_LIST_MISSING) {
             return null;
@@ -825,20 +825,54 @@ class Rest_Routes
             if ($enabled) {
                 if (!$subscriber) {
                     // Create new subscriber and add to list
-                    $subscriber = $mailpoet_api->addSubscriber([
-                        'email' => $user->user_email,
-                        'first_name' => $user->first_name ?: $user->display_name,
-                        'last_name' => $user->last_name ?: '',
-                    ], [$zen_list_id]);
+                    try {
+                        $subscriber = $mailpoet_api->addSubscriber([
+                            'email' => $user->user_email,
+                            'first_name' => $user->first_name ?: $user->display_name,
+                            'last_name' => $user->last_name ?: '',
+                        ], [$zen_list_id]);
+                    } catch (\Exception $e) {
+                        $zen_list_id = self::get_zen_tribe_mailpoet_list_id($mailpoet_api, true);
+
+                        if (!$zen_list_id) {
+                            throw $e;
+                        }
+
+                        $subscriber = $mailpoet_api->addSubscriber([
+                            'email' => $user->user_email,
+                            'first_name' => $user->first_name ?: $user->display_name,
+                            'last_name' => $user->last_name ?: '',
+                        ], [$zen_list_id]);
+                    }
                 } else {
                     // Add existing subscriber to list
-                    $mailpoet_api->subscribeToList($subscriber['id'], $zen_list_id);
+                    try {
+                        $mailpoet_api->subscribeToList($subscriber['id'], $zen_list_id);
+                    } catch (\Exception $e) {
+                        $zen_list_id = self::get_zen_tribe_mailpoet_list_id($mailpoet_api, true);
+
+                        if (!$zen_list_id) {
+                            throw $e;
+                        }
+
+                        $mailpoet_api->subscribeToList($subscriber['id'], $zen_list_id);
+                    }
                 }
                 $message = 'Successfully subscribed to newsletter';
             } else {
                 if ($subscriber) {
                     // Remove from list
-                    $mailpoet_api->unsubscribeFromList($subscriber['id'], $zen_list_id);
+                    try {
+                        $mailpoet_api->unsubscribeFromList($subscriber['id'], $zen_list_id);
+                    } catch (\Exception $e) {
+                        $zen_list_id = self::get_zen_tribe_mailpoet_list_id($mailpoet_api, true);
+
+                        if (!$zen_list_id) {
+                            throw $e;
+                        }
+
+                        $mailpoet_api->unsubscribeFromList($subscriber['id'], $zen_list_id);
+                    }
                 }
                 $message = 'Successfully unsubscribed from newsletter';
             }

--- a/plugins/zeneyer-auth/includes/API/class-rest-routes.php
+++ b/plugins/zeneyer-auth/includes/API/class-rest-routes.php
@@ -25,6 +25,7 @@ class Rest_Routes
 
     const NAMESPACE = 'zeneyer-auth/v1';
     private const MAILPOET_ZEN_TRIBE_LIST_TRANSIENT = 'zeneyer_mailpoet_zen_tribe_list_id';
+    private const MAILPOET_ZEN_TRIBE_LIST_MISSING = -1;
     private const MAILPOET_ZEN_TRIBE_LIST_TTL = 43200;
 
     public static function register_routes()
@@ -743,6 +744,10 @@ class Rest_Routes
     {
         $cached_id = get_transient(self::MAILPOET_ZEN_TRIBE_LIST_TRANSIENT);
 
+        if ((int) $cached_id === self::MAILPOET_ZEN_TRIBE_LIST_MISSING) {
+            return null;
+        }
+
         if (false !== $cached_id && (int) $cached_id > 0) {
             return (int) $cached_id;
         }
@@ -757,7 +762,7 @@ class Rest_Routes
             }
         }
 
-        delete_transient(self::MAILPOET_ZEN_TRIBE_LIST_TRANSIENT);
+        set_transient(self::MAILPOET_ZEN_TRIBE_LIST_TRANSIENT, self::MAILPOET_ZEN_TRIBE_LIST_MISSING, self::MAILPOET_ZEN_TRIBE_LIST_TTL);
         return null;
     }
 


### PR DESCRIPTION
﻿## Summary
- replace duplicated Zen Tribe MailPoet list lookup with one shared helper
- cache the resolved list ID in a short-lived transient
- clear the transient when the Zen Tribe list cannot be resolved

## Why
This keeps the useful performance idea from the closed bot PR, but avoids duplicated cache logic across endpoint methods.

## Validation
- php -l plugins/zeneyer-auth/includes/API/class-rest-routes.php
- git diff --check -- plugins/zeneyer-auth/includes/API/class-rest-routes.php


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Novas Funcionalidades**
  * Melhor estabilidade na integração com newsletters com resolução centralizada da lista e cache de curto prazo para reduzir buscas repetidas.

* **Correções de Bugs**
  * Aprimorado o tratamento de falhas ao criar assinantes e adicionar/remover assinaturas, com tentativa de recuperação automática e repetição da operação quando necessário.
  * O status da newsletter agora é consultado de forma mais consistente e sincronizado corretamente com os dados do usuário.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->