### PR TITLE
fix: move remaining page copy to i18n

### DIFF
--- a/src/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb.tsx
@@ -31,7 +31,7 @@ const BreadcrumbInner: React.FC<BreadcrumbProps> = ({ items, className = '' }) =
       animate={BREADCRUMB_ANIMATE}
       transition={BREADCRUMB_TRANSITION}
     >
-      <ol className="flex flex-wrap items-center justify-start gap-2 text-xs sm:text-sm text-text/70">
+      <ol className="flex flex-wrap items-center justify-start gap-2 text-xs sm:text-sm text-text/75">
         <li>
           <Link
             to={getLocalizedRoute('home', currentLang)}
@@ -52,7 +52,7 @@ const BreadcrumbInner: React.FC<BreadcrumbProps> = ({ items, className = '' }) =
                 {item.label}
               </Link>
             ) : (
-              <span className="truncate py-1 font-semibold tracking-wide text-text/80" aria-current="page">
+              <span className="truncate py-1 font-semibold tracking-wide text-text" aria-current="page">
                 {item.label}
               </span>
             )}

--- a/src/components/Layout/Navbar/NavbarComponents.tsx
+++ b/src/components/Layout/Navbar/NavbarComponents.tsx
@@ -54,9 +54,9 @@ export const LanguageSelector: React.FC = React.memo(() => {
 
     return (
         <div className="flex items-center gap-2 border-r border-border/20 pr-4 mr-2">
-            <button onClick={() => changeLanguage('pt')} className={`text-sm font-bold transition-colors ${currentLang === 'pt' ? 'text-primary' : 'text-text/60 hover:text-text'}`}>PT</button>
+            <button onClick={() => changeLanguage('pt')} className={`text-sm font-bold transition-colors ${currentLang === 'pt' ? 'text-primary' : 'text-text/75 hover:text-text'}`}>PT</button>
             <span className="text-text/20">|</span>
-            <button onClick={() => changeLanguage('en')} className={`text-sm font-bold transition-colors ${currentLang === 'en' ? 'text-primary' : 'text-text/60 hover:text-text'}`}>EN</button>
+            <button onClick={() => changeLanguage('en')} className={`text-sm font-bold transition-colors ${currentLang === 'en' ? 'text-primary' : 'text-text/75 hover:text-text'}`}>EN</button>
         </div>
     );
 });

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -168,7 +168,7 @@ const Footer: React.FC = () => {
         </div>
 
         {/* Bottom Bar - Simplified */}
-        <div className="mt-10 pt-8 border-t border-border/10 text-center text-text/60 text-sm">
+        <div className="mt-10 pt-8 border-t border-border/10 text-center text-text/75 text-sm">
           <p>{t('footer_copyright', { year: CURRENT_YEAR })} <span className="mx-1">&bull;</span> {footerSignature}</p>
 
           <div className="flex justify-center gap-4 mt-2 text-xs uppercase tracking-wider">
@@ -177,7 +177,7 @@ const Footer: React.FC = () => {
             <Link to={routes.terms} className="hover:text-primary transition-colors">{t('common.footer_terms')}</Link>
           </div>
 
-          <div className="mt-4 text-xs opacity-80 flex justify-center gap-4">
+          <div className="mt-4 text-xs flex justify-center gap-4">
             <a href={safeUrl(ARTIST.identifiers.wikidataUrl, '/')} target="_blank" rel="noopener noreferrer" className="hover:text-primary transition-colors">
               Wikidata
             </a>

--- a/src/locales/en/conduct.json
+++ b/src/locales/en/conduct.json
@@ -1,6 +1,7 @@
 {
   "conduct_page": {
     "title": "Code of Conduct",
+    "title_rich": "Code of <1>Conduct</1>",
     "subtitle": "Learn about our expectations and standards for respectful behavior.",
     "last_updated": "Last updated",
     "last_updated_date": "January 2026",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -613,6 +613,7 @@
     "page_title": "Shop",
     "page_meta_desc": "Event tickets, exclusive merchandise, and more",
     "title": "Zen Tribe Shop",
+    "hero_title_rich": "Zen <1>Store</1>",
     "subtitle": "Exclusive merchandise and event tickets",
     "all_products": "All Products",
     "featured_title": "Featured Products",
@@ -1274,6 +1275,10 @@
   },
   "share_event": "Share {{title}}",
   "event_default_title": "Zen Eyer Event",
+  "tickets": {
+    "tbd": "TBD",
+    "location_online_tbd": "Online/TBD"
+  },
   "countries": {
     "Brazil": "Brazil",
     "Netherlands": "Netherlands",

--- a/src/locales/pt/conduct.json
+++ b/src/locales/pt/conduct.json
@@ -1,6 +1,7 @@
 {
   "conduct_page": {
     "title": "Código de Conduta",
+    "title_rich": "Código de <1>Conduta</1>",
     "subtitle": "Conheça nossas expectativas e padrões de comportamento respeitoso.",
     "last_updated": "Última atualização",
     "last_updated_date": "Janeiro 2024",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -612,7 +612,7 @@
     "page_title": "Loja",
     "page_meta_desc": "Loja oficial de Zen Eyer com produtos, ingressos e itens selecionados da Zen Tribe.",
     "title": "Loja Zen Tribe",
-    "hero_title_rich": "Zen <1>Store</1>",
+    "hero_title_rich": "Loja <1>Zen</1>",
     "subtitle": "Merchandise exclusivo e ingressos para eventos",
     "all_products": "Todos os Produtos",
     "featured_title": "Produtos em Destaque",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -612,6 +612,7 @@
     "page_title": "Loja",
     "page_meta_desc": "Loja oficial de Zen Eyer com produtos, ingressos e itens selecionados da Zen Tribe.",
     "title": "Loja Zen Tribe",
+    "hero_title_rich": "Zen <1>Store</1>",
     "subtitle": "Merchandise exclusivo e ingressos para eventos",
     "all_products": "Todos os Produtos",
     "featured_title": "Produtos em Destaque",
@@ -1274,6 +1275,10 @@
   "quiz_you_are": "Você é...",
   "share_event": "Compartilhar {{title}}",
   "event_default_title": "Evento Zen Eyer",
+  "tickets": {
+    "tbd": "A definir",
+    "location_online_tbd": "Online/a definir"
+  },
   "countries": {
     "Brazil": "Brasil",
     "Netherlands": "Holanda",

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -437,9 +437,7 @@ const AboutPage: React.FC = () => {
               viewport={VIEWPORT_ONCE}
               className="text-2xl sm:text-4xl md:text-5xl font-display font-bold text-center mb-16"
             >
-              <Trans i18nKey="about.timeline.title" ns="about">
-                Moments that <span className="text-primary">Changed Everything</span>
-              </Trans>
+              <Trans i18nKey="about.timeline.title" ns="about" components={{ 1: <span className="text-primary" /> }} />
             </motion.h2>
 
             <div className="space-y-12">
@@ -489,9 +487,7 @@ const AboutPage: React.FC = () => {
             >
               <Heart className="w-16 h-16 mx-auto mb-6 text-primary" />
               <h2 className="text-3xl md:text-4xl font-display font-bold mb-6">
-                <Trans i18nKey="about.philosophy.title" ns="about">
-                  My <span className="text-primary">Philosophy</span>
-                </Trans>
+                <Trans i18nKey="about.philosophy.title" ns="about" components={{ 1: <span className="text-primary" /> }} />
               </h2>
               <p className="text-lg text-text/80 leading-relaxed italic">
                 {t('about.philosophy.quote')}
@@ -513,9 +509,7 @@ const AboutPage: React.FC = () => {
             >
               <Sparkles className="w-12 h-12 mx-auto mb-6 text-primary" />
               <h2 className="text-3xl md:text-4xl font-display font-bold mb-6">
-                <Trans i18nKey="about.cta.title" ns="about">
-                  Let's <span className="text-primary">Talk?</span>
-                </Trans>
+                <Trans i18nKey="about.cta.title" ns="about" components={{ 1: <span className="text-primary" /> }} />
               </h2>
               <p className="text-base sm:text-xl text-text/80 mb-8 max-w-2xl mx-auto">
                 {t('about.cta.desc')}

--- a/src/pages/CodeOfConductPage.tsx
+++ b/src/pages/CodeOfConductPage.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { motion } from 'framer-motion';
 import { Heart, Users, Shield, AlertTriangle, Ban, Mail } from 'lucide-react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { HeadlessSEO } from '../components/HeadlessSEO';
 import { getLocalizedRoute, normalizeLanguage } from '../config/routes';
 
@@ -130,7 +130,7 @@ const CodeOfConductPage: React.FC = () => {
               <Heart size={40} className="text-primary" />
             </div>
             <h1 className="text-4xl md:text-6xl font-black font-display mb-6 text-text leading-tight">
-              Código de <span className="text-primary">Conduta</span>
+              <Trans i18nKey="conduct_page.title_rich" ns="conduct" components={{ 1: <span className="text-primary" /> }} />
             </h1>
             <p className="text-text/70">
               {t('conduct_page.last_updated')}: <span className="text-primary font-semibold">{lastUpdated}</span>

--- a/src/pages/NewsPage.tsx
+++ b/src/pages/NewsPage.tsx
@@ -315,7 +315,7 @@ const NewsPage: React.FC = () => {
                 <Trans i18nKey="news.title" components={{ 1: <span className="text-primary" /> }} />
               </h1>
             </div>
-            <div className="text-right text-text/50 text-sm hidden md:block">
+            <div className="text-right text-text/75 text-sm hidden md:block">
               <p>{t('news.curatorship')}</p>
               <p>{t('news.zouk_production')}</p>
               <p>{getDateTimeFormatter(i18n.language, { weekday: 'long', day: 'numeric', month: 'long' }).format(new Date())}</p>
@@ -506,7 +506,7 @@ const NewsPage: React.FC = () => {
                 ))}
               </div>
               {!featuredPost && (
-                <div className="rounded-2xl border border-border/10 bg-text/5 px-6 py-12 text-center text-text/60">
+                <div className="rounded-2xl border border-border/10 bg-text/5 px-6 py-12 text-center text-text/75">
                   {t('news.no_posts_for_filter')}
                 </div>
               )}

--- a/src/pages/ShopPage.tsx
+++ b/src/pages/ShopPage.tsx
@@ -4,7 +4,7 @@
 import React, { useState, useEffect, useCallback, useRef, memo, useMemo } from 'react';
 import { Link, generatePath } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { sanitizeHtml, safeUrl } from '../utils/sanitize';
 import { stripHtml } from '../utils/text';
 import { useShopPageQuery, useAddToCartMutation, WCProduct } from '../hooks/useQueries';
@@ -537,10 +537,10 @@ const ShopPage: React.FC = () => {
               className="max-w-4xl mx-auto"
             >
               <h1 className="text-5xl md:text-8xl font-black font-display mb-6 tracking-tighter uppercase leading-[0.8] opacity-40 hover:opacity-100 transition-opacity duration-700 select-none">
-                Zen <span className="text-primary italic">Store</span>
+                <Trans i18nKey="shop.hero_title_rich" components={{ 1: <span className="text-primary italic" /> }} />
               </h1>
               <p className="text-xl text-text/40 font-bold uppercase tracking-widest">
-                {t('shop.coming_soon_msg', 'Exclusividade em cada batida.')}
+                {t('shop.coming_soon_msg')}
               </p>
             </motion.div>
           </div>

--- a/src/pages/SupportArtistPage.tsx
+++ b/src/pages/SupportArtistPage.tsx
@@ -139,9 +139,7 @@ const SupportArtistPage: React.FC = () => {
             <Heart size={16} /> {t('common.footer_support_artist')}
           </div>
           <h1 className="text-3xl sm:text-5xl md:text-7xl font-black font-display mb-6 sm:mb-8 text-text tracking-tighter uppercase leading-[0.9]">
-            <Trans i18nKey="support.header.title">
-              Support DJ <span className="text-primary">Zen Eyer</span>
-            </Trans>
+            <Trans i18nKey="support.header.title" components={{ 1: <span className="text-primary" /> }} />
           </h1>
           <div className="text-base sm:text-xl text-text/70 max-w-2xl mx-auto leading-relaxed space-y-4">
             <p>{t('support.header.description_p1')}</p>

--- a/src/pages/TicketsPage.tsx
+++ b/src/pages/TicketsPage.tsx
@@ -85,8 +85,8 @@ const TicketsPage: React.FC = () => {
                     <div className="absolute bottom-4 left-4 right-4">
                       <h3 className="text-2xl font-bold font-display leading-tight mb-2">{ticket.name}</h3>
                       <div className="flex items-center gap-4 text-sm text-text/80">
-                        <span className="flex items-center gap-1"><Calendar size={14} /> TBD</span>
-                        <span className="flex items-center gap-1"><MapPin size={14} /> Online/TBD</span>
+                        <span className="flex items-center gap-1"><Calendar size={14} /> {t('tickets.tbd')}</span>
+                        <span className="flex items-center gap-1"><MapPin size={14} /> {t('tickets.location_online_tbd')}</span>
                       </div>
                     </div>
                   </Link>

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -32,9 +32,9 @@
   /* #FCF7ED - warm plaster */
   --color-surface-elevated: 255, 253, 247;
   /* #FFFDF7 - sunlit paper */
-  --color-text: 62, 49, 40;
-  /* #3E3128 - warm brown ink */
-  --color-text-dark: 62, 49, 40;
+  --color-text: 22, 17, 14;
+  /* #16110E - warm brown ink, dark enough for subdued UI text */
+  --color-text-dark: 22, 17, 14;
   --color-muted: 123, 109, 96;
 
   --color-primary-fg: 255, 255, 255;


### PR DESCRIPTION
## Summary
- Remove remaining literal JSX fallback copy from About, Support, Code of Conduct, Shop, and Tickets page headings/placeholders.
- Add EN/PT translation keys for rich Code of Conduct and Shop headings plus ticket placeholders.
- Improve Mediterranean theme contrast for Lighthouse accessibility warnings on home, releases, and PT events pages.
- Keep official music platform brand colors unchanged in MusicPage because they are intentional brand signals, not theme tokens.

## Type of Change
- Bug fix
- Accessibility improvement
- i18n/localization cleanup

## Impact Area
- Public React pages: About, Support Artist, Code of Conduct, Shop, Tickets, News/Releases.
- Shared UI: Breadcrumb, Footer, language selector.
- Theme tokens: Mediterranean Dusk text contrast only; Zen Night palette is unchanged.

## Testing
- `npm run i18n:check`
- `npm run type-check`
- `npm run test -- src/__tests__/utils/theme.test.ts`
- `git diff --check`
- Targeted audit for reported hardcoded copy and safeUrl empty fallback patterns.
- Contrast spot-check: `text-text/60` on Mediterranean background is now 4.55:1; footer/news adjusted text is above 7:1.

## Gate Checklist
- [x] No secrets or credentials added.
- [x] No generated lockfile or plan file added.
- [x] No direct SQL, WooCommerce, WordPress cache, or payment endpoint changes.
- [x] No ZenTribe visual/dashboard demo changes.
- [x] No PWA, sitemap, robots, or route rendering logic removed.

## Related Issues
- Addresses hardcoded visible copy identified during the i18n/theme audit.
- Addresses Lighthouse `color-contrast` warnings reported for `/`, `/releases/`, and `/pt/eventos-zouk/`.

## Notes for Reviewers
- Gemini's comment about AboutPage `<Trans>` tags was checked against `src/locales/*/about.json`; those keys use `<1>`, so the current component mapping is intentional.
- CodeRabbit's PT shop title comment was addressed by changing `Zen <1>Store</1>` to `Loja <1>Zen</1>`.

## Final Checklist
- [x] Scope is small and mergeable.
- [x] CI is expected to validate full build/test coverage.
- [x] PR remains ready for automated review once rate limits allow it.