### PR TITLE
fix: prioritize payment currency options

### DIFF
--- a/src/components/auth/AuthModal.tsx
+++ b/src/components/auth/AuthModal.tsx
@@ -245,7 +245,7 @@ const AuthModal: React.FC<AuthModalProps> = ({ isOpen, onClose, onSuccess }) => 
                         <GoogleLogin
                           onSuccess={handleGoogleSuccess}
                           onError={() => setError(t('auth.errors.google_connect_error'))}
-                          theme="filled_black"
+                          theme="outline"
                           size="large"
                           text={mode === 'login' ? 'signin_with' : 'signup_with'}
                           width={368}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1084,22 +1084,24 @@
     },
     "seo": {
       "title": "Support Zen Eyer | Payment Information",
-      "description": "Official payment information for supporting Zen Eyer or paying booking-related fees in BRL, USD, Wise, and PayPal.",
+      "description": "Official payment information for supporting Zen Eyer or paying booking-related fees in EUR, BRL, USD, Wise, and PayPal.",
       "keywords": "support artist, hire dj, payment methods, international payments, brazilian zouk dj"
     },
     "header": {
       "title": "Support DJ <1>Zen Eyer</1>",
       "description_p1": "If you're the kind of person who believes dancing can be more than steps — if you want more connection, human music, and real presence — supporting my work costs less than a water bottle at a zouk party.",
-      "description_p2": "For you, it's almost nothing. For me, it makes a big difference at the end of the month.",
+      "description_p2": "For you, it's almost nothing. For me, it makes all the difference.",
       "description_p3": "Consider contributing and helping this project keep existing, with new music, sets, and experiences made for those who don't want to stay on the surface."
     },
     "payment": {
       "title": "Payment Methods",
       "by_currency": "Choose your Currency",
+      "eur_title": "Euro (EUR)",
       "brl_title": "Real (BRL/PIX)",
       "usd_title": "US Dollar (USD)",
       "global_title": "Global (Wise/PayPal)",
-      "global_note": "Use Wise for EUR, AUD, PayID, and other currencies when the payer prefers local details, a link, or a QR code. For USD, Inter remains the preferred path.",
+      "eur_note": "Use these details to receive payments in euros through Wise, especially from SEPA countries and places where IBAN works best.",
+      "global_note": "Use Wise, PayID, or PayPal for AUD and other currencies when the payer prefers local details, a link, or a QR code. For EUR, BRL, and USD, use the specific options above.",
       "wise_title": "Wise",
       "wise_eur_title": "Wise EUR",
       "wise_aud_payid_title": "Wise AUD / PayID",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -1080,22 +1080,24 @@
     },
     "seo": {
       "title": "Apoie Zen Eyer | Informações de Pagamento",
-      "description": "Informações oficiais de pagamento para apoiar Zen Eyer ou pagar valores relacionados a booking em BRL, USD, Wise e PayPal.",
+      "description": "Informações oficiais de pagamento para apoiar Zen Eyer ou pagar valores relacionados a booking em EUR, BRL, USD, Wise e PayPal.",
       "keywords": "apoiar artista, contratar dj, métodos de pagamento, pagamentos internacionais, brazilian zouk dj"
     },
     "header": {
       "title": "Apoie o DJ <1>Zen Eyer</1>",
       "description_p1": "Se você é do tipo de pessoa que acredita que dançar pode ser mais do que passos, se você quer mais conexão, música humana e presença de verdade, apoiar o meu trabalho custa menos que uma garrafinha de água em uma festa de zouk.",
-      "description_p2": "Para você é quase nada. Para mim, faz uma grande diferença no fim do mês.",
+      "description_p2": "Para você é quase nada. Para mim, faz toda a diferença.",
       "description_p3": "Considere colaborar e ajudar esse projeto a continuar existindo, com novas músicas, sets e experiências feitas para quem não quer ficar só na superfície."
     },
     "payment": {
       "title": "Métodos de Pagamento",
       "by_currency": "Escolha sua Moeda",
+      "eur_title": "Euro (EUR)",
       "brl_title": "Real (BRL/PIX)",
       "usd_title": "Dólar (USD)",
       "global_title": "Global (Wise/PayPal)",
-      "global_note": "Use Wise para EUR, AUD, PayID e outras moedas quando o pagador preferir dados locais, link ou QR code. Para USD, o Inter continua sendo o caminho preferencial.",
+      "eur_note": "Use estes dados para receber pagamentos em euro pela Wise, especialmente da zona SEPA e de países que trabalham melhor com IBAN.",
+      "global_note": "Use Wise, PayID ou PayPal para AUD e outras moedas quando o pagador preferir dados locais, link ou QR code. Para EUR, BRL e USD, use as opções específicas acima.",
       "wise_title": "Wise",
       "wise_eur_title": "Wise EUR",
       "wise_aud_payid_title": "Wise AUD / PayID",

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -262,7 +262,7 @@ const HomePage: React.FC = () => {
             </h1>
 
             {currentTheme === 'mediterranean-dusk' && (
-              <div className="flex items-center gap-3 mb-6 max-w-[260px]" aria-hidden="true">
+              <div className="mx-auto md:mx-0 flex w-full max-w-[34rem] items-center gap-3 mb-6" aria-hidden="true">
                 <div className="h-px bg-secondary/60 flex-1" />
                 <span className="text-secondary/80 text-base leading-none select-none">✦</span>
                 <div className="h-px bg-secondary/60 flex-1" />

--- a/src/pages/PressKitPage.tsx
+++ b/src/pages/PressKitPage.tsx
@@ -129,25 +129,25 @@ const PressKitPage: React.FC = () => {
         number: artist.stats.countriesPlayed.toString(),
         label: t('presskit.stats.countries'),
         icon: <Globe size={32} />,
-        color: 'bg-gradient-to-br from-primary/80 to-primary/60'
+        color: 'bg-gradient-to-br from-primary/65 to-primary/40'
       },
       {
         number: `${new Date().getFullYear() - artist.stats.startingYear}+`,
         label: t('presskit.stats.years'),
         icon: <Calendar size={32} />,
-        color: 'bg-gradient-to-br from-secondary/80 to-secondary/60'
+        color: 'bg-gradient-to-br from-secondary/65 to-secondary/40'
       },
       {
         number: '2',
         label: t('presskit.stats.titles'),
         icon: <Award size={32} />,
-        color: 'bg-gradient-to-br from-accent/80 to-accent/60'
+        color: 'bg-gradient-to-br from-accent/65 to-accent/40'
       },
       {
         number: 'Mensa',
         label: t('presskit.stats.mensa'),
         icon: <Star size={32} />,
-        color: 'bg-gradient-to-br from-success/80 to-success/60'
+        color: 'bg-gradient-to-br from-success/65 to-success/40'
       }
     ],
     [t, artist]

--- a/src/pages/SupportArtistPage.tsx
+++ b/src/pages/SupportArtistPage.tsx
@@ -180,6 +180,32 @@ const SupportArtistPage: React.FC = () => {
           </h2>
 
           <div className="max-w-4xl mx-auto">
+            {/* EUR / EURO */}
+            <CurrencyAccordion
+              title={t('support.payment.eur_title')}
+              icon={Globe}
+              isOpen={openCurrency === 'EUR'}
+              onToggle={() => handleToggle('EUR')}
+            >
+              <div className="space-y-6">
+                <div className="p-6 bg-success/5 rounded-2xl border border-success/20">
+                  <h4 className="flex items-center gap-2 font-bold mb-4 text-success uppercase text-sm tracking-widest">
+                    <Globe size={18} /> {t('support.payment.wise_eur_title')}
+                  </h4>
+                  <p className="mb-4 text-sm leading-relaxed text-text/65">
+                    {t('support.payment.eur_note')}
+                  </p>
+                  <div className="grid md:grid-cols-2 gap-4 mb-4">
+                    <DetailCard label={t('support.accountName')} value={ARTIST.payment.wise.eur.accountName} />
+                    <DetailCard label={t('support.iban')} value={ARTIST.payment.wise.eur.iban} />
+                    <DetailCard label={t('support.swiftCode')} value={ARTIST.payment.wise.eur.swiftCode} />
+                    <DetailCard label={t('support.bank')} value={ARTIST.payment.wise.eur.bankName} />
+                    <DetailCard label={t('support.bankAddress')} value={ARTIST.payment.wise.eur.bankAddress} />
+                  </div>
+                </div>
+              </div>
+            </CurrencyAccordion>
+
             {/* BRL / REAL */}
             <CurrencyAccordion
               title={t('support.payment.brl_title')}
@@ -239,24 +265,11 @@ const SupportArtistPage: React.FC = () => {
               <div className="space-y-6">
                 <div className="p-6 bg-success/5 rounded-2xl border border-success/20">
                   <h4 className="flex items-center gap-2 font-bold mb-4 text-success uppercase text-sm tracking-widest">
-                    <Globe size={18} /> {t('support.payment.wise_eur_title')}
+                    <Globe size={18} /> {t('support.payment.wise_aud_payid_title')}
                   </h4>
                   <p className="mb-4 text-sm leading-relaxed text-text/65">
                     {t('support.payment.global_note')}
                   </p>
-                  <div className="grid md:grid-cols-2 gap-4 mb-4">
-                    <DetailCard label={t('support.accountName')} value={ARTIST.payment.wise.eur.accountName} />
-                    <DetailCard label={t('support.iban')} value={ARTIST.payment.wise.eur.iban} />
-                    <DetailCard label={t('support.swiftCode')} value={ARTIST.payment.wise.eur.swiftCode} />
-                    <DetailCard label={t('support.bank')} value={ARTIST.payment.wise.eur.bankName} />
-                    <DetailCard label={t('support.bankAddress')} value={ARTIST.payment.wise.eur.bankAddress} />
-                  </div>
-                </div>
-
-                <div className="p-6 bg-success/5 rounded-2xl border border-success/20">
-                  <h4 className="flex items-center gap-2 font-bold mb-4 text-success uppercase text-sm tracking-widest">
-                    <Globe size={18} /> {t('support.payment.wise_aud_payid_title')}
-                  </h4>
                   <div className="grid md:grid-cols-2 gap-4 mb-4">
                     <DetailCard label={t('support.accountName')} value={ARTIST.payment.wise.aud.accountName} />
                     <DetailCard label={t('support.payIdPhone')} value={ARTIST.payment.wise.aud.payIdPhone} />
@@ -275,8 +288,8 @@ const SupportArtistPage: React.FC = () => {
                   </a>
                 </div>
 
-                <div className="p-6 bg-blue-500/5 rounded-2xl border border-blue-500/20">
-                  <h4 className="flex items-center gap-2 font-bold mb-4 text-blue-400 uppercase text-sm tracking-widest">
+                <div className="p-6 bg-primary/5 rounded-2xl border border-primary/20">
+                  <h4 className="flex items-center gap-2 font-bold mb-4 text-primary uppercase text-sm tracking-widest">
                     <CreditCard size={18} /> {t('support.payment.paypal_title')}
                   </h4>
                   <div className="grid gap-4 sm:grid-cols-2">


### PR DESCRIPTION
## Summary
- Add Euro as its own first payment option on the support page.
- Reorder payment options as EUR, BRL, USD, then Global.
- Keep Global focused on Wise/PayID/PayPal fallback options for other currencies.
- Update PT/EN support copy, including the shorter Portuguese support sentence.
- Reposition the Mediterranean hero ornament line under the Zen Eyer title on desktop and mobile.
- Lighten Work With Me/press stats card gradients in the Mediterranean palette.
- Use the light Google OAuth button style instead of the dark theme button.

## Validation
- npm run i18n:check
- npm run type-check
- npm run build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Novas Funcionalidades**
  * Adicionado um acordeão de **EUR** na página de apoio ao artista com instruções detalhadas para pagamento via **Wise**.
* **Melhorias**
  * Atualizados textos de **SEO** e de cabeçalho na página de apoio para contemplar pagamentos em **EUR**, além de **BRL/USD** (e opções via Wise/PayPal).
  * Ajustadas as orientações da seção de pagamento **GLOBAL** para melhor direcionar o uso por moeda, incluindo **AUD** e outras moedas.
  * Atualizada a estilização do cartão de **PayPal** (GLOBAL) para o novo padrão visual.
  * Ajustes de layout no destaque do tema “mediterranean-dusk” na home e aprimoradas as gradientes dos cards de estatísticas no Press Kit.
* **Correções**
  * Alterado o tema do botão de login com Google para melhorar o visual do componente de autenticação.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->