### PR TITLE
chore: tighten Jules performance PR gate

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -115,6 +115,7 @@
 **Action:** Do not open standalone PRs just to hoist repeated `getLocalizedRoute` calls or similar cheap deterministic helpers. Fold this cleanup into nearby feature work only when it improves readability, or require profiler/benchmark evidence that the render path is actually hot.
 
 ## 2026-06-27 - Inline Spread of Arrays in React Render Cycles
+
 **Learning:** Inline array spreads allocate a new array, but that is only meaningful for large arrays, frequent renders, memoized child boundaries, or measured UI stutter.
 **Action:** Prefer clarity for small arrays. Use `useMemo` for array combinations only when the array is large, passed as a stable prop/dependency, or a profiler/benchmark shows material cost.
 
@@ -124,6 +125,7 @@
 **Action:** Extract static arrays or replace allocating string operations only for large/measured render paths, shared constants, or code touched for another reason. Do not create standalone PRs for this pattern without evidence.
 
 ## 2024-05-18 - Replacing `String.prototype.split()` with zero-allocation alternatives
+
 **Learning:** `String.prototype.split()` creates an intermediate array, which adds overhead and garbage collection pressure, particularly in hot paths like routing maps or render loops.
 **Action:** When extracting substrings or indices in performance-critical code paths, utilize zero-allocation native string methods like `indexOf()` combined with `slice()` instead of chained `.split()` calls. Focus primarily on hot paths and leave isolated, infrequent calls alone.
 

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -111,17 +111,17 @@
 
 ## 2026-06-26 - Prevent redundant function calls during render cycles
 
-**Learning:** Repeatedly calling a deterministic function like `getLocalizedRoute` with the same dynamic arguments multiple times within a component's render body (e.g. passing it to multiple `<Link to={...}>` elements) leads to redundant O(N) calculations on every React reconciliation cycle.
-**Action:** Consolidate these multiple calls into a single object map wrapped in `useMemo` with the dynamic argument as its dependency. This evaluates the localized paths only once when the language changes, rather than recalculating them on every unrelated state or context update.
+**Learning:** Repeated local helper calls inside render can be worth consolidating only when the helper is expensive, the call sits in a large or frequently updated loop, or the result participates in memoized child props/hook dependencies. In the current router, `getLocalizedRoute` already uses lookup maps; a few repeated calls for the same route are not a standalone performance problem.
+**Action:** Do not open standalone PRs just to hoist repeated `getLocalizedRoute` calls or similar cheap deterministic helpers. Fold this cleanup into nearby feature work only when it improves readability, or require profiler/benchmark evidence that the render path is actually hot.
 
 ## 2026-06-27 - Inline Spread of Arrays in React Render Cycles
-**Learning:** Using the spread operator (e.g., `[...array1, ...array2]`) inline directly within a component's render body (like for `.map()` iteration) forces JavaScript to allocate a completely new array object on *every single render cycle*, regardless of whether the source arrays have changed. In highly re-rendered components, this causes significant garbage collection overhead and potential performance stutters.
-**Action:** Always extract dynamic array combinations/spreads into a `useMemo` hook, using the source arrays (or their parent objects) as the dependency array, to preserve reference equality and eliminate O(N) reallocation overhead.
+**Learning:** Inline array spreads allocate a new array, but that is only meaningful for large arrays, frequent renders, memoized child boundaries, or measured UI stutter.
+**Action:** Prefer clarity for small arrays. Use `useMemo` for array combinations only when the array is large, passed as a stable prop/dependency, or a profiler/benchmark shows material cost.
 
 ## 2026-06-28 - Render Loop Overhead via Inline Array Allocation and Split
 
-**Learning:** Allocating a static array (`['jan', 'feb', ...]`) and performing string splitting (`key.split('-')`) inside the callback of a `.map()` iteration forces continuous garbage collection overhead on every React rendering cycle, significantly impacting performance on large lists.
-**Action:** Always extract static array configurations to the module scope (outside the component) and replace allocating string operations like `split()` with non-allocating alternatives like `slice()` when iterating over datasets in render loops.
+**Learning:** Static arrays and `split()` inside render loops can be wasteful in large datasets, but are not automatically a performance issue in small UI lists.
+**Action:** Extract static arrays or replace allocating string operations only for large/measured render paths, shared constants, or code touched for another reason. Do not create standalone PRs for this pattern without evidence.
 
 ## 2024-05-18 - Replacing `String.prototype.split()` with zero-allocation alternatives
 **Learning:** `String.prototype.split()` creates an intermediate array, which adds overhead and garbage collection pressure, particularly in hot paths like routing maps or render loops.

--- a/.jules/instructions.md
+++ b/.jules/instructions.md
@@ -54,15 +54,15 @@ Antes de abrir PR, confirme todos os itens:
 2. O diff resolve uma causa real, não apenas uma hipótese genérica extraída de comentário ou learning.
 3. O PR é pequeno, tem um domínio único e não duplica PR aberto.
 4. Existe validação proporcional ao risco (`npm run lint`, teste específico, diff manual ou benchmark reproduzível).
-5. Para performance, existe evidência objetiva de impacto: profiler, benchmark, Core Web Vitals, endpoint lento, lista grande, render frequente em hot path, N+1 real, ou regressão visível.
+5. Para desempenho, existe evidência objetiva de impacto: profiler, benchmark, Core Web Vitals, endpoint lento, lista grande, render frequente em hot path, N+1 real, ou regressão visível.
 
 Não abrir PR automaticamente para:
 
 - Limpeza de comentários, docblocks, changelog ou palavras como `FIX`, `CRITICAL`, `TODO`, salvo pedido humano explícito.
 - Micro-otimizações de renderização sem evidência de profiler, hot path ou regressão visível.
 - Trocar chamadas locais repetidas por constantes, `useMemo`, `useCallback`, arrays estáveis ou mapas quando o valor não atravessa fronteira de memoização, não alimenta dependência de hook, não roda sobre lista grande e não tem métrica antes/depois.
-- PRs com título/body que vendem melhoria como `memoize`, `O(N)`, `N+1`, `GC pressure` ou `performance bottleneck` sem demonstrar a cardinalidade real e o custo medido no código atual.
-- Refactors de performance em PHP/GamiPress/WooCommerce sem benchmark, fixture ou revisão manual planejada.
+- PRs com título/descrição que vendem melhoria como `memoize`, `O(N)`, `N+1`, `GC pressure` ou `gargalo de desempenho` sem demonstrar a cardinalidade real e o custo medido no código atual.
+- Refactors de desempenho em PHP/GamiPress/WooCommerce sem benchmark, fixture ou revisão manual planejada.
 - Mudanças em arquivos de contexto, workflows, autenticação, SEO/head, rotas ou deploy sem pedido explícito.
 - Alterações geradas apenas por `.jules/bolt.md`. Esse arquivo é memória, não backlog; em auditorias programadas ele pode orientar a busca, mas não substitui evidência no código.
 
@@ -72,7 +72,7 @@ Em rotina programada de auditoria, abrir PR apenas para achados relevantes:
 - Cache ausente, cache mal invalidado ou transiente que causa resposta errada/lenta.
 - Segurança: input sem sanitização, redirect inseguro, nonce/auth incorreto, exposição de dado privado.
 - SEO técnico: soft 404, canonical incorreto, rotas inválidas, head duplicado, schema falso/invisível.
-- Performance frontend em hot path comprovado por lista grande, render frequente, profiler, métrica ou custo algorítmico claro.
+- Desempenho frontend em hot path comprovado por lista grande, render frequente, profiler, métrica ou custo algorítmico claro.
 
 Regra de escala: micro-otimização de render no cliente não aumenta a capacidade de tráfego do site. Cada visitante executa seu próprio JavaScript; mais usuários simultâneos afetam principalmente backend, CDN, cache, payload, imagens, Core Web Vitals e APIs. Otimize render local somente quando a experiência de um usuário real for afetada.
 

--- a/.jules/instructions.md
+++ b/.jules/instructions.md
@@ -54,11 +54,14 @@ Antes de abrir PR, confirme todos os itens:
 2. O diff resolve uma causa real, não apenas uma hipótese genérica extraída de comentário ou learning.
 3. O PR é pequeno, tem um domínio único e não duplica PR aberto.
 4. Existe validação proporcional ao risco (`npm run lint`, teste específico, diff manual ou benchmark reproduzível).
+5. Para performance, existe evidencia objetiva de impacto: profiler, benchmark, Core Web Vitals, endpoint lento, lista grande, render frequente em hot path, N+1 real, ou regressao visivel.
 
 Não abrir PR automaticamente para:
 
 - Limpeza de comentários, docblocks, changelog ou palavras como `FIX`, `CRITICAL`, `TODO`, salvo pedido humano explícito.
 - Micro-otimizações de renderização sem evidência de profiler, hot path ou regressão visível.
+- Trocar chamadas locais repetidas por constantes, `useMemo`, `useCallback`, arrays estaveis ou mapas quando o valor nao atravessa fronteira de memoizacao, nao alimenta dependencia de hook, nao roda sobre lista grande e nao tem metrica antes/depois.
+- PRs com titulo/body que vendem melhoria como `memoize`, `O(N)`, `N+1`, `GC pressure` ou `performance bottleneck` sem demonstrar a cardinalidade real e o custo medido no codigo atual.
 - Refactors de performance em PHP/GamiPress/WooCommerce sem benchmark, fixture ou revisão manual planejada.
 - Mudanças em arquivos de contexto, workflows, autenticação, SEO/head, rotas ou deploy sem pedido explícito.
 - Alterações geradas apenas por `.jules/bolt.md`. Esse arquivo é memória, não backlog; em auditorias programadas ele pode orientar a busca, mas não substitui evidência no código.
@@ -70,6 +73,8 @@ Em rotina programada de auditoria, abrir PR apenas para achados relevantes:
 - Segurança: input sem sanitização, redirect inseguro, nonce/auth incorreto, exposição de dado privado.
 - SEO técnico: soft 404, canonical incorreto, rotas inválidas, head duplicado, schema falso/invisível.
 - Performance frontend em hot path comprovado por lista grande, render frequente, profiler, métrica ou custo algorítmico claro.
+
+Regra de escala: micro-otimizacao de render no cliente nao aumenta a capacidade de trafego do site. Cada visitante executa seu proprio JavaScript; mais usuarios simultaneos afetam principalmente backend, CDN, cache, payload, imagens, Core Web Vitals e APIs. Otimize render local somente quando a experiencia de um usuario real for afetada.
 
 ---
 

--- a/.jules/instructions.md
+++ b/.jules/instructions.md
@@ -54,14 +54,14 @@ Antes de abrir PR, confirme todos os itens:
 2. O diff resolve uma causa real, não apenas uma hipótese genérica extraída de comentário ou learning.
 3. O PR é pequeno, tem um domínio único e não duplica PR aberto.
 4. Existe validação proporcional ao risco (`npm run lint`, teste específico, diff manual ou benchmark reproduzível).
-5. Para performance, existe evidencia objetiva de impacto: profiler, benchmark, Core Web Vitals, endpoint lento, lista grande, render frequente em hot path, N+1 real, ou regressao visivel.
+5. Para performance, existe evidência objetiva de impacto: profiler, benchmark, Core Web Vitals, endpoint lento, lista grande, render frequente em hot path, N+1 real, ou regressão visível.
 
 Não abrir PR automaticamente para:
 
 - Limpeza de comentários, docblocks, changelog ou palavras como `FIX`, `CRITICAL`, `TODO`, salvo pedido humano explícito.
 - Micro-otimizações de renderização sem evidência de profiler, hot path ou regressão visível.
-- Trocar chamadas locais repetidas por constantes, `useMemo`, `useCallback`, arrays estaveis ou mapas quando o valor nao atravessa fronteira de memoizacao, nao alimenta dependencia de hook, nao roda sobre lista grande e nao tem metrica antes/depois.
-- PRs com titulo/body que vendem melhoria como `memoize`, `O(N)`, `N+1`, `GC pressure` ou `performance bottleneck` sem demonstrar a cardinalidade real e o custo medido no codigo atual.
+- Trocar chamadas locais repetidas por constantes, `useMemo`, `useCallback`, arrays estáveis ou mapas quando o valor não atravessa fronteira de memoização, não alimenta dependência de hook, não roda sobre lista grande e não tem métrica antes/depois.
+- PRs com título/body que vendem melhoria como `memoize`, `O(N)`, `N+1`, `GC pressure` ou `performance bottleneck` sem demonstrar a cardinalidade real e o custo medido no código atual.
 - Refactors de performance em PHP/GamiPress/WooCommerce sem benchmark, fixture ou revisão manual planejada.
 - Mudanças em arquivos de contexto, workflows, autenticação, SEO/head, rotas ou deploy sem pedido explícito.
 - Alterações geradas apenas por `.jules/bolt.md`. Esse arquivo é memória, não backlog; em auditorias programadas ele pode orientar a busca, mas não substitui evidência no código.
@@ -74,7 +74,7 @@ Em rotina programada de auditoria, abrir PR apenas para achados relevantes:
 - SEO técnico: soft 404, canonical incorreto, rotas inválidas, head duplicado, schema falso/invisível.
 - Performance frontend em hot path comprovado por lista grande, render frequente, profiler, métrica ou custo algorítmico claro.
 
-Regra de escala: micro-otimizacao de render no cliente nao aumenta a capacidade de trafego do site. Cada visitante executa seu proprio JavaScript; mais usuarios simultaneos afetam principalmente backend, CDN, cache, payload, imagens, Core Web Vitals e APIs. Otimize render local somente quando a experiencia de um usuario real for afetada.
+Regra de escala: micro-otimização de render no cliente não aumenta a capacidade de tráfego do site. Cada visitante executa seu próprio JavaScript; mais usuários simultâneos afetam principalmente backend, CDN, cache, payload, imagens, Core Web Vitals e APIs. Otimize render local somente quando a experiência de um usuário real for afetada.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ Padronização obrigatória:
 - **URL canônica em páginas:** Nunca hardcodar paths como `/about`. Usar `getLocalizedRoute('about', currentLang)`.
 - **Class components:** Não podem usar `useTranslation()` — usar `withTranslation()` HOC.
 - **Jules PRs duplicados:** Jules tende a criar PRs duplicados. Verificar antes de mergear.
-- **Jules/Bolt micro-otimizacoes:** Jules le este `AGENTS.md` automaticamente. Nao abrir PR autonomo para trocar chamadas locais repetidas, mover constantes, adicionar `useMemo` ou reduzir alocacoes pequenas sem profiler, hot path comprovado, lista grande, regressao visivel ou benchmark reproduzivel. Se a melhoria for apenas higiene local, registrar como sugestao e aguardar pedido humano.
+- **Jules/Bolt micro-otimizações:** Jules lê este `AGENTS.md` automaticamente. Não abrir PR autônomo para trocar chamadas locais repetidas, mover constantes, adicionar `useMemo` ou reduzir alocações pequenas sem profiler, hot path comprovado, lista grande, regressão visível ou benchmark reproduzível. Se a melhoria for apenas higiene local, registrar como sugestão e aguardar pedido humano.
 - **`social.YouTube` / `social.YouTubeMusic`:** Em `src/data/artistData.ts`, ambas as chaves usam Y e T maiusculos. Nao usar `social.youtube` nem `social.youtubeMusic` — essas variantes em lowercase nao existem no objeto e causam silently undefined.
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,7 @@ Padronização obrigatória:
 - **URL canônica em páginas:** Nunca hardcodar paths como `/about`. Usar `getLocalizedRoute('about', currentLang)`.
 - **Class components:** Não podem usar `useTranslation()` — usar `withTranslation()` HOC.
 - **Jules PRs duplicados:** Jules tende a criar PRs duplicados. Verificar antes de mergear.
+- **Jules/Bolt micro-otimizacoes:** Jules le este `AGENTS.md` automaticamente. Nao abrir PR autonomo para trocar chamadas locais repetidas, mover constantes, adicionar `useMemo` ou reduzir alocacoes pequenas sem profiler, hot path comprovado, lista grande, regressao visivel ou benchmark reproduzivel. Se a melhoria for apenas higiene local, registrar como sugestao e aguardar pedido humano.
 - **`social.YouTube` / `social.YouTubeMusic`:** Em `src/data/artistData.ts`, ambas as chaves usam Y e T maiusculos. Nao usar `social.youtube` nem `social.youtubeMusic` — essas variantes em lowercase nao existem no objeto e causam silently undefined.
 
 ---


### PR DESCRIPTION
## Summary
- Add a root AGENTS.md instruction for Jules/Bolt to avoid standalone micro-optimization PRs without evidence.
- Tighten .jules/instructions.md with measurable performance gates and clearer scale guidance.
- Revise .jules/bolt.md learnings that were encouraging cheap-helper/useMemo churn.

## Rationale
Jules official docs say it automatically reads AGENTS.md, and Jules changelog documents proactive Suggested Tasks/performance optimization surfacing. There does not appear to be a documented repo config key for a minimum-impact threshold, so the reliable project-level control is explicit instruction in AGENTS.md plus the local .jules guidance.

## Validation
- git diff --check
- commit hook: npm run utf8:check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Atualizamos as diretrizes internas sobre performance para evitar recomendações absolutas em micro-otimizações de render.
  * Passamos a exigir evidência concreta de impacto antes de tratar ajustes de performance como mudanças prioritárias.
  * Reforçamos critérios para abrir PRs apenas quando houver benefício real e mensurável.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->