### PR TITLE
perf(i18n): split Home translations into namespace

### DIFF
--- a/src/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb.tsx
@@ -1,13 +1,8 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { ChevronRight, Home } from 'lucide-react';
-import { motion } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
 import { getLocalizedRoute, normalizeLanguage } from '../config/routes';
-
-const BREADCRUMB_INITIAL = { opacity: 0, y: -8 };
-const BREADCRUMB_ANIMATE = { opacity: 1, y: 0 };
-const BREADCRUMB_TRANSITION = { duration: 0.4, ease: 'easeOut' };
 
 export interface BreadcrumbItem {
   label: string;
@@ -24,12 +19,9 @@ const BreadcrumbInner: React.FC<BreadcrumbProps> = ({ items, className = '' }) =
   const currentLang = normalizeLanguage(i18n.language);
 
   return (
-    <motion.nav
+    <nav
       aria-label={t('nav.breadcrumb')}
-      className={`${className} w-full text-left`}
-      initial={BREADCRUMB_INITIAL}
-      animate={BREADCRUMB_ANIMATE}
-      transition={BREADCRUMB_TRANSITION}
+      className={`${className} w-full text-left motion-safe:animate-fade-down`}
     >
       <ol className="flex flex-wrap items-center justify-start gap-2 text-xs sm:text-sm text-text/75">
         <li>
@@ -59,7 +51,7 @@ const BreadcrumbInner: React.FC<BreadcrumbProps> = ({ items, className = '' }) =
           </li>
         ))}
       </ol>
-    </motion.nav>
+    </nav>
   );
 };
 

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -6,21 +6,20 @@ import { Music, Music2, MessageCircle, SendHorizontal, Heart } from 'lucide-reac
 import { FacebookIcon, InstagramIcon, YouTubeIcon } from '../icons/BrandIcons';
 import { ARTIST, CURRENT_YEAR } from '../../data/artistData';
 import { getLocalizedRoute, normalizeLanguage } from '../../config/routes';
-import { useSubscriptionMutation } from '../../hooks/useQueries';
+import { subscribeToNewsletter } from '../../services/newsletterService';
 import { safeUrl } from '../../utils/sanitize';
 
 
 const Footer: React.FC = () => {
   const { t, i18n } = useTranslation();
   const [email, setEmail] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitMessage, setSubmitMessage] = useState<string | null>(null);
   const [submitSuccess, setSubmitSuccess] = useState<boolean | null>(null);
   const currentLang = normalizeLanguage(i18n.language);
   const location = useLocation();
   const footerSignatures = [t('footer_signature_cremosidade'), t('footer_signature_terror')];
   const footerSignature = footerSignatures[location.pathname.length % footerSignatures.length];
-
-  const { mutate: subscribe, isPending: isSubmitting } = useSubscriptionMutation();
 
   // This avoids recalculating static footer hrefs on every render cycle.
   const routes = useMemo(() => ({
@@ -40,7 +39,7 @@ const Footer: React.FC = () => {
     terms: getLocalizedRoute('terms', currentLang),
   }), [currentLang]);
 
-  const handleNewsletterSubmit = (e: React.FormEvent) => {
+  const handleNewsletterSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setSubmitMessage(null);
     setSubmitSuccess(null);
@@ -51,18 +50,19 @@ const Footer: React.FC = () => {
       return;
     }
 
-    subscribe(email, {
-      onSuccess: (data) => {
-        setSubmitMessage(data.message || t('footer_subscribe_success'));
-        setSubmitSuccess(true);
-        setEmail('');
-      },
-      onError: (err: unknown) => {
-        const error = err as Error;
-        setSubmitMessage(error.message || t('footer_subscribe_error'));
-        setSubmitSuccess(false);
-      },
-    });
+    setIsSubmitting(true);
+    try {
+      const data = await subscribeToNewsletter(email);
+      setSubmitMessage(data.message || t('footer_subscribe_success'));
+      setSubmitSuccess(true);
+      setEmail('');
+    } catch (err) {
+      const error = err as Error;
+      setSubmitMessage(error.message || t('footer_subscribe_error'));
+      setSubmitSuccess(false);
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   const whatsappLink = `https://wa.me/${ARTIST.contact.whatsapp.number}`;

--- a/src/components/ui/PageHeader.tsx
+++ b/src/components/ui/PageHeader.tsx
@@ -1,11 +1,5 @@
 import React from 'react';
 import { Breadcrumb, type BreadcrumbItem } from '../Breadcrumb';
-import { motion } from 'framer-motion';
-
-// Issue B — Framer Motion inline objects extracted to module scope (Style Rule 6)
-const PAGE_HEADER_INITIAL = { opacity: 0, y: 20 };
-const PAGE_HEADER_ANIMATE = { opacity: 1, y: 0 };
-const PAGE_HEADER_TRANSITION = { duration: 0.6 };
 
 interface PageHeaderProps {
   /** First part of the title (rendered with the semantic text token) */
@@ -39,17 +33,14 @@ export const PageHeader: React.FC<PageHeaderProps> = ({
       )}
 
       {/* Title - Standardized Display Font, Blue and White */}
-      <motion.h1
-        initial={PAGE_HEADER_INITIAL}
-        animate={PAGE_HEADER_ANIMATE}
-        transition={PAGE_HEADER_TRANSITION}
+      <h1
         className={`text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-black font-display uppercase tracking-tighter text-text ${
           hasBreadcrumbs ? 'pt-16' : ''
-        } ${centerTitle ? 'text-center' : 'text-left'}`}
+        } ${centerTitle ? 'text-center' : 'text-left'} motion-safe:animate-fade-up`}
       >
         {titlePart1}{' '}
         {titlePart2 && <span className="text-primary">{titlePart2}</span>}
-      </motion.h1>
+      </h1>
     </header>
   );
 };

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -12,6 +12,7 @@ type SupportedNamespace =
   | 'conduct'
   | 'privacy'
   | 'about'
+  | 'home'
   | 'zentribe'
   | 'newsletter';
 type TranslationLoader = () => Promise<Record<string, unknown>>;
@@ -31,6 +32,7 @@ const namespaceLoaders: Record<SupportedLang, Record<SupportedNamespace, Transla
     conduct: async () => (await import('./locales/en/conduct.json')).default as Record<string, unknown>,
     privacy: async () => (await import('./locales/en/privacy.json')).default as Record<string, unknown>,
     about: async () => (await import('./locales/en/about.json')).default as Record<string, unknown>,
+    home: async () => (await import('./locales/en/home.json')).default as Record<string, unknown>,
     zentribe: async () => (await import('./locales/en/zentribe.json')).default as Record<string, unknown>,
     newsletter: async () => (await import('./locales/en/newsletter.json')).default as Record<string, unknown>,
   },
@@ -43,6 +45,7 @@ const namespaceLoaders: Record<SupportedLang, Record<SupportedNamespace, Transla
     conduct: async () => (await import('./locales/pt/conduct.json')).default as Record<string, unknown>,
     privacy: async () => (await import('./locales/pt/privacy.json')).default as Record<string, unknown>,
     about: async () => (await import('./locales/pt/about.json')).default as Record<string, unknown>,
+    home: async () => (await import('./locales/pt/home.json')).default as Record<string, unknown>,
     zentribe: async () => (await import('./locales/pt/zentribe.json')).default as Record<string, unknown>,
     newsletter: async () => (await import('./locales/pt/newsletter.json')).default as Record<string, unknown>,
   },
@@ -80,7 +83,7 @@ i18n
     debug: false,
     showSupportNotice: false,
     supportedLngs: ['en', 'pt'],
-    ns: ['translation', 'quiz', 'encyclopedia', 'faq', 'legal', 'conduct', 'privacy', 'about', 'zentribe', 'newsletter'],
+    ns: ['translation', 'quiz', 'encyclopedia', 'faq', 'legal', 'conduct', 'privacy', 'about', 'home', 'zentribe', 'newsletter'],
     defaultNS: 'translation',
     load: 'languageOnly',
     nonExplicitSupportedLngs: true,

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -83,7 +83,7 @@ i18n
     debug: false,
     showSupportNotice: false,
     supportedLngs: ['en', 'pt'],
-    ns: ['translation', 'quiz', 'encyclopedia', 'faq', 'legal', 'conduct', 'privacy', 'about', 'home', 'zentribe', 'newsletter'],
+    ns: ['translation', 'quiz', 'encyclopedia', 'faq', 'legal', 'conduct', 'privacy', 'about', 'zentribe', 'newsletter'],
     defaultNS: 'translation',
     load: 'languageOnly',
     nonExplicitSupportedLngs: true,

--- a/src/index.css
+++ b/src/index.css
@@ -302,6 +302,12 @@
   .animate-glow {
     animation: glow 2s ease-in-out infinite alternate;
   }
+  .animate-fade-up {
+    animation: fade-up 0.6s ease-out both;
+  }
+  .animate-fade-down {
+    animation: fade-down 0.4s ease-out both;
+  }
   @keyframes glow {
     from {
       box-shadow: 0 0 20px rgba(var(--color-primary), 0.5);
@@ -310,6 +316,33 @@
       box-shadow:
         0 0 30px rgba(var(--color-primary), 0.8),
         0 0 60px rgba(var(--color-primary), 0.5);
+    }
+  }
+  @keyframes fade-up {
+    from {
+      opacity: 0;
+      transform: translateY(20px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  @keyframes fade-down {
+    from {
+      opacity: 0;
+      transform: translateY(-8px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .animate-fade-up,
+    .animate-fade-down,
+    .animate-glow {
+      animation: none;
     }
   }
   .font-hero-display {

--- a/src/locales/en/home.json
+++ b/src/locales/en/home.json
@@ -1,0 +1,82 @@
+{
+  "site_desc": "Official website of Zen Eyer, also known as DJ Zen Eyer, Brazilian Zouk DJ and music producer",
+  "page_title": "Zen Eyer | Brazilian Zouk DJ & Music Producer",
+  "page_meta_desc": "Zen Eyer, Brazilian Zouk DJ and music producer, winner of Best DJ Performance and Best Remix at the 2022 Brazilian Zouk DJ World Championship. Book for international events.",
+  "headline": "Experience the <1>Zen</1> in Brazilian Zouk",
+  "subheadline": "Transforming dance floors into immersive audio experiences",
+  "welcome": "Welcome to Zen Eyer",
+  "tagline": "Brazilian Zouk DJ & Producer",
+  "cta": "Explore My Music",
+  "features_title": "Why Join the Zen Tribe?",
+  "features_subtitle": "Unlock exclusive benefits and be part of an engaged community",
+  "feat_exclusive_title": "Exclusive Music",
+  "feat_exclusive_desc": "Early access to releases and exclusive remixes",
+  "feat_achievements_title": "Achievements & Rewards",
+  "feat_achievements_desc": "Earn XP, unlock badges, and level up",
+  "feat_community_title": "Active Community",
+  "feat_community_desc": "Connect with music lovers and Zen Eyer",
+  "cta_title": "Ready to Join the Zen Tribe?",
+  "cta_subtitle": "Join thousands of members and transform your experience",
+  "hero_badge": "Best DJ Performance + Best Remix - 2022 Brazilian Zouk DJ World Championship",
+  "hero_title": "Zen Eyer",
+  "hero_subtitle": "Brazilian Zouk DJ & Music Producer",
+  "introduction_aria": "Zen Eyer introduction",
+  "pronunciation_summary": " (Phonetic: /zɛn ˈaɪər/. Eyer sounds like Buyer without the B, or like 'Eye' followed by 'er').",
+  "hero_slogan": "Haste is the enemy of creaminess",
+  "hero_cta_text": "Full sets and remixes. For more streaming and download options, go to <0>Music</0>.",
+  "stat_champion": "Championship Awards",
+  "stat_countries": "Countries",
+  "stat_events": "Events",
+  "stat_years": "Years Active",
+  "bio_p1": "is a Brazilian DJ and producer focused on Brazilian Zouk. In 2022, I had the honor of winning Best Remix and Best DJ Performance at the Brazilian Zouk DJ World Championship, consolidating a journey that started early on the dance floor and now takes me to play in 14 countries.",
+  "bio_p2": "Known for a sound focused on the pure 'flow' of the dance — a vibe our community affectionately calls 'cremosidade' —, I prioritize sets where the energy builds gradually, giving the dancer time and space to connect without rush.",
+  "bio_p3": "Whether at reZENha, at Renata Peçanha's Rio Zouk Congress (where I have the honor of playing annually), or at festivals around the world, the mission is always the same: to create the perfect atmosphere for those who love Brazilian Zouk.",
+  "festivals_title": "Performed at International Festivals",
+  "festivals_subtitle": "Recognized at major Zouk events worldwide",
+  "festivals_more": "many more",
+  "press_desc": "Complete press kit, high-resolution photos, releases, and interviews available.",
+  "press_cta": "DOWNLOAD PRESS KIT 2025",
+  "booking_title": "Bookers & Promoters",
+  "booking_desc": "Available for congresses, festivals, workshops, and exclusive events in Brazil and abroad.",
+  "booking_cta": "REQUEST QUOTE",
+  "authority_title": "Verified Profiles",
+  "tribe": {
+    "title": "Join the <0>Zen Tribe</0>",
+    "subtitle": "No rush here. Just prolonged melting.",
+    "desc": "Access exclusive content, behind-the-scenes, and be part of the official DJ Zen Eyer community.",
+    "cta": "Join the Tribe"
+  },
+  "cta_soundcloud": "Listen on SoundCloud",
+  "cta_booking": "Booking / Press Kit",
+  "cta_music": "Explore Music",
+  "bio_title": "Who is DJ Zen Eyer?",
+  "bio_intro": "<strong>DJ Zen Eyer</strong> (Marcelo Eyer Fernandes) is a <strong>Brazilian Zouk DJ</strong> and music producer. In 2022, he won the Best Remix and Best DJ Performance awards at the Brazilian Zouk DJ World Championship, recognized for his technical precision and musical sensitivity.",
+  "bio_style": "Known for his \"creamy\" and engaging style, Zen prioritizes connection. No rush. His signature drop <em>\"Zen? Zen? Zen? Eyer? Eyer?\"</em> is already a classic at festivals.",
+  "bio_mensa": "Member of <strong>Mensa International</strong>, he creates perfect emotional journeys for the \"flow\" in dance. He is a regular at major stages like Rio Zouk Congress.",
+  "verified": "Verified Profiles",
+  "bookers": {
+    "title": "Bookers & Promoters",
+    "desc": "Available for congresses, festivals, workshops, and exclusive events in Brazil and abroad.",
+    "cta": "REQUEST QUOTE"
+  },
+  "seo": {
+    "keywords": "Zen Eyer, Brazilian Zouk DJ, Zouk Music Producer, Best DJ Performance, Best Remix, Zen Tribe",
+    "lead_answer": "Zen Eyer is a Brazilian Zouk DJ and music producer who won Best DJ Performance and Best Remix at the 2022 Brazilian Zouk DJ World Championship.",
+    "title": "Zen Eyer | Brazilian Zouk DJ & Music Producer",
+    "description": "Zen Eyer, Brazilian Zouk DJ and music producer."
+  },
+  "shows": {
+    "title": "Upcoming Events",
+    "cta": "View All Events",
+    "bandsintown_aria": "Follow Zen Eyer on Bandsintown"
+  },
+  "festivals": {
+    "presence": "International Festival Presence",
+    "many_more": "many more"
+  },
+  "press": {
+    "title": "Press & Media",
+    "desc": "Complete press kit, high-resolution photos, releases, and interviews available.",
+    "cta": "DOWNLOAD PRESS KIT 2025"
+  }
+}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -185,7 +185,8 @@
     "title_part1": "Events",
     "title_part2": "Schedule",
     "press_kit": "Press Kit",
-    "featured": "Featured Event"
+    "featured": "Featured Event",
+    "press_title": "For Press & Media"
   },
   "gamification": {
     "zenTribe": "Zen Tribe",
@@ -361,89 +362,6 @@
   "explore_music_button": "Explore Music",
   "play_featured_mix": "Play Featured Mix",
   "upcoming_events": "Upcoming Events",
-  "home": {
-    "site_desc": "Official website of Zen Eyer, also known as DJ Zen Eyer, Brazilian Zouk DJ and music producer",
-    "page_title": "Zen Eyer | Brazilian Zouk DJ & Music Producer",
-    "page_meta_desc": "Zen Eyer, Brazilian Zouk DJ and music producer, winner of Best DJ Performance and Best Remix at the 2022 Brazilian Zouk DJ World Championship. Book for international events.",
-    "headline": "Experience the <1>Zen</1> in Brazilian Zouk",
-    "subheadline": "Transforming dance floors into immersive audio experiences",
-    "welcome": "Welcome to Zen Eyer",
-    "tagline": "Brazilian Zouk DJ & Producer",
-    "cta": "Explore My Music",
-    "features_title": "Why Join the Zen Tribe?",
-    "features_subtitle": "Unlock exclusive benefits and be part of an engaged community",
-    "feat_exclusive_title": "Exclusive Music",
-    "feat_exclusive_desc": "Early access to releases and exclusive remixes",
-    "feat_achievements_title": "Achievements & Rewards",
-    "feat_achievements_desc": "Earn XP, unlock badges, and level up",
-    "feat_community_title": "Active Community",
-    "feat_community_desc": "Connect with music lovers and Zen Eyer",
-    "cta_title": "Ready to Join the Zen Tribe?",
-    "cta_subtitle": "Join thousands of members and transform your experience",
-    "hero_badge": "Best DJ Performance + Best Remix - 2022 Brazilian Zouk DJ World Championship",
-    "hero_title": "Zen Eyer",
-    "hero_subtitle": "Brazilian Zouk DJ & Music Producer",
-    "introduction_aria": "Zen Eyer introduction",
-    "pronunciation_summary": " (Phonetic: /zɛn ˈaɪər/. Eyer sounds like Buyer without the B, or like 'Eye' followed by 'er').",
-    "hero_slogan": "Haste is the enemy of creaminess",
-    "hero_cta_text": "Full sets and remixes. For more streaming and download options, go to <0>Music</0>.",
-    "stat_champion": "Championship Awards",
-    "stat_countries": "Countries",
-    "stat_events": "Events",
-    "stat_years": "Years Active",
-    "bio_p1": "is a Brazilian DJ and producer focused on Brazilian Zouk. In 2022, I had the honor of winning Best Remix and Best DJ Performance at the Brazilian Zouk DJ World Championship, consolidating a journey that started early on the dance floor and now takes me to play in 14 countries.",
-    "bio_p2": "Known for a sound focused on the pure 'flow' of the dance — a vibe our community affectionately calls 'cremosidade' —, I prioritize sets where the energy builds gradually, giving the dancer time and space to connect without rush.",
-    "bio_p3": "Whether at reZENha, at Renata Peçanha's Rio Zouk Congress (where I have the honor of playing annually), or at festivals around the world, the mission is always the same: to create the perfect atmosphere for those who love Brazilian Zouk.",
-    "festivals_title": "Performed at International Festivals",
-    "festivals_subtitle": "Recognized at major Zouk events worldwide",
-    "festivals_more": "many more",
-    "press_title": "For Press & Media",
-    "press_desc": "Complete press kit, high-resolution photos, releases, and interviews available.",
-    "press_cta": "DOWNLOAD PRESS KIT 2025",
-    "booking_title": "Bookers & Promoters",
-    "booking_desc": "Available for congresses, festivals, workshops, and exclusive events in Brazil and abroad.",
-    "booking_cta": "REQUEST QUOTE",
-    "authority_title": "Verified Profiles",
-    "tribe": {
-      "title": "Join the <0>Zen Tribe</0>",
-      "subtitle": "No rush here. Just prolonged melting.",
-      "desc": "Access exclusive content, behind-the-scenes, and be part of the official DJ Zen Eyer community.",
-      "cta": "Join the Tribe"
-    },
-    "cta_soundcloud": "Listen on SoundCloud",
-    "cta_booking": "Booking / Press Kit",
-    "cta_music": "Explore Music",
-    "bio_title": "Who is DJ Zen Eyer?",
-    "bio_intro": "<strong>DJ Zen Eyer</strong> (Marcelo Eyer Fernandes) is a <strong>Brazilian Zouk DJ</strong> and music producer. In 2022, he won the Best Remix and Best DJ Performance awards at the Brazilian Zouk DJ World Championship, recognized for his technical precision and musical sensitivity.",
-    "bio_style": "Known for his \"creamy\" and engaging style, Zen prioritizes connection. No rush. His signature drop <em>\"Zen? Zen? Zen? Eyer? Eyer?\"</em> is already a classic at festivals.",
-    "bio_mensa": "Member of <strong>Mensa International</strong>, he creates perfect emotional journeys for the \"flow\" in dance. He is a regular at major stages like Rio Zouk Congress.",
-    "verified": "Verified Profiles",
-    "bookers": {
-      "title": "Bookers & Promoters",
-      "desc": "Available for congresses, festivals, workshops, and exclusive events in Brazil and abroad.",
-      "cta": "REQUEST QUOTE"
-    },
-    "seo": {
-      "keywords": "Zen Eyer, Brazilian Zouk DJ, Zouk Music Producer, Best DJ Performance, Best Remix, Zen Tribe",
-      "lead_answer": "Zen Eyer is a Brazilian Zouk DJ and music producer who won Best DJ Performance and Best Remix at the 2022 Brazilian Zouk DJ World Championship.",
-      "title": "Zen Eyer | Brazilian Zouk DJ & Music Producer",
-      "description": "Zen Eyer, Brazilian Zouk DJ and music producer."
-    },
-    "shows": {
-      "title": "Upcoming Events",
-      "cta": "View All Events",
-      "bandsintown_aria": "Follow Zen Eyer on Bandsintown"
-    },
-    "festivals": {
-      "presence": "International Festival Presence",
-      "many_more": "many more"
-    },
-    "press": {
-      "title": "Press & Media",
-      "desc": "Complete press kit, high-resolution photos, releases, and interviews available.",
-      "cta": "DOWNLOAD PRESS KIT 2025"
-    }
-  },
   "news_page_title": "Releases & Notes | Zen Eyer",
   "news_page_meta_desc": "Official music releases, short event notes, festival reviews, and selected updates from Zen Eyer.",
   "news": {

--- a/src/locales/pt/home.json
+++ b/src/locales/pt/home.json
@@ -1,0 +1,82 @@
+{
+  "site_desc": "Site oficial de Zen Eyer, DJ e produtor musical de Zouk Brasileiro, também conhecido como DJ Zen Eyer.",
+  "page_title": "Zen Eyer | DJ e Produtor de Zouk Brasileiro",
+  "page_meta_desc": "Zen Eyer, vencedor de Melhor Remix e Melhor Performance DJ no Campeonato Mundial de DJs de Zouk Brasileiro de 2022. Contrate para eventos internacionais.",
+  "headline": "Experiencie o <1>Zen</1> no Zouk Brasileiro",
+  "subheadline": "A pressa é inimiga da cremosidade. Mergulhe no som de Zen Eyer.",
+  "welcome": "Bem-vindo ao Zen Eyer",
+  "tagline": "DJ e Produtor de Zouk Brasileiro",
+  "cta": "Explorar Músicas",
+  "features_title": "Por Que Entrar na Zen Tribe?",
+  "features_subtitle": "Desbloqueie benefícios exclusivos e faça parte de uma comunidade engajada",
+  "feat_exclusive_title": "Música Exclusiva",
+  "feat_exclusive_desc": "Acesso antecipado a lançamentos e remixes exclusivos",
+  "feat_achievements_title": "Conquistas & Recompensas",
+  "feat_achievements_desc": "Ganhe XP, desbloqueie badges e suba de nível",
+  "feat_community_title": "Comunidade Ativa",
+  "feat_community_desc": "Conecte-se com amantes de música e Zen Eyer",
+  "cta_title": "Pronto para Entrar na <1>Zen Tribe</1>?",
+  "cta_subtitle": "Junte-se a milhares de membros e transforme sua experiência com o Zouk.",
+  "hero_badge": "Best DJ Performance + Best Remix - Campeonato Mundial de DJs de Zouk Brasileiro de 2022",
+  "hero_title": "Zen Eyer",
+  "hero_subtitle": "DJ e Produtor de Zouk Brasileiro",
+  "introduction_aria": "Introdução de Zen Eyer",
+  "pronunciation_summary": " (Fonética: /zɛn ˈaɪər/. Eyer soa como Buyer sem o B, ou 'Eye' seguido de 'er').",
+  "hero_slogan": "A pressa é inimiga da cremosidade",
+  "hero_cta_text": "Sets completos e remixes. Para mais opções de streaming e downloads, vá em <0>Músicas</0>.",
+  "stat_champion": "Prêmios no Campeonato",
+  "stat_countries": "Países",
+  "stat_events": "Eventos",
+  "stat_years": "Experiência",
+  "bio_p1": "é um DJ e produtor brasileiro focado em Brazilian Zouk. Em 2022, tive a honra de vencer Best Remix e Best DJ Performance no Campeonato Mundial de DJs de Zouk Brasileiro, consolidando uma jornada que começou cedo na pista e hoje me leva a tocar em 14 países.",
+  "bio_p2": "Conhecido por um som focado no 'flow' puro da dança — a vibe que a nossa comunidade chama de 'cremosidade' —, priorizo sets onde a energia cresce gradualmente, dando ao dançarino tempo e espaço para se conectar sem pressa.",
+  "bio_p3": "Seja na reZENha, no Rio Zouk Congress da Renata Peçanha (onde tenho a honra de tocar anualmente) ou em festivais pelo mundo, a missão é a mesma: criar o clima perfeito para quem ama o Zouk Brasileiro.",
+  "festivals_title": "Festivais & Eventos",
+  "festivals_subtitle": "Muito feliz de ter levado o Zouk para esses lugares",
+  "festivals_more": "e outras cidades incríveis",
+  "press_desc": "Fotos para divulgação, infos e rider técnico.",
+  "press_cta": "ACESSAR PRESS KIT",
+  "booking_title": "Bookings",
+  "booking_desc": "Quer levar o som da Tribo Zen para a sua cidade? Mande uma mensagem.",
+  "booking_cta": "ENTRAR EM CONTATO",
+  "authority_title": "Perfis Verificados",
+  "tribe": {
+    "title": "Junte-se à <0>Zen Tribe</0>",
+    "subtitle": "Sem pressa aqui. Apenas derretimento prolongado.",
+    "desc": "Não é só sobre música. É sobre vibração. Entre para a lista VIP.",
+    "cta": "Entrar na Tribo"
+  },
+  "cta_soundcloud": "Ouvir no SoundCloud",
+  "cta_booking": "Booking / Press Kit",
+  "cta_music": "Explorar Músicas",
+  "bio_title": "Quem é Zen Eyer?",
+  "bio_intro": "<strong>Zen Eyer</strong> (Marcelo Eyer Fernandes) é <strong>DJ de Brazilian Zouk</strong> e produtor musical. Em 2022, conquistou os prêmios de Melhor Remix e Melhor Performance DJ no Campeonato Mundial de DJs de Zouk Brasileiro, sendo reconhecido pela precisão técnica e sensibilidade musical.",
+  "bio_style": "Conhecido pelo estilo \"cremoso\" e envolvente, Zen prioriza a conexão. Sem pressa. Seu drop assinatura <em>\"Zen… Zen… Zen… Eyer… Eyer…\"</em> já é um clássico nos festivais.",
+  "bio_mensa": "Membro da <strong>Mensa International</strong>, ele cria jornadas emocionais perfeitas para o \"flow\" na dança. Frequenta palcos de peso como o Rio Zouk Congress.",
+  "verified": "Perfis Verificados",
+  "bookers": {
+    "title": "Bookings",
+    "desc": "Quer levar o som da Tribo Zen para a sua cidade? Mande uma mensagem.",
+    "cta": "ENTRAR EM CONTATO"
+  },
+  "seo": {
+    "title": "Zen Eyer | DJ e Produtor de Zouk Brasileiro",
+    "description": "Zen Eyer, DJ e produtor musical focado no Zouk Brasileiro.",
+    "keywords": "Zen Eyer, Brazilian Zouk DJ, Zouk Brasileiro, Best DJ Performance, Best Remix, Brazilian Zouk music, dance festival DJ, Zouk producer",
+    "lead_answer": "Zen Eyer é DJ e produtor musical especializado em Zouk Brasileiro, vencedor de Best DJ Performance e Best Remix no Campeonato Mundial de DJs de Zouk Brasileiro de 2022."
+  },
+  "festivals": {
+    "presence": "Presença Internacional",
+    "many_more": "muitos outros"
+  },
+  "shows": {
+    "title": "Próximos Shows",
+    "cta": "Agenda completa",
+    "bandsintown_aria": "Seguir Zen Eyer no Bandsintown"
+  },
+  "press": {
+    "title": "Imprensa & Mídia",
+    "desc": "Acesse fotos, bio e assets.",
+    "cta": "BAIXAR PRESS KIT"
+  }
+}

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -216,7 +216,8 @@
     "title_part1": "Agenda de",
     "title_part2": "Eventos",
     "press_kit": "Kit de Imprensa",
-    "featured": "Evento em Destaque"
+    "featured": "Evento em Destaque",
+    "press_title": "Imprensa & Mídia"
   },
   "gamification": {
     "zenTribe": "Zen Tribe",
@@ -393,89 +394,6 @@
   "explore_music_button": "Explorar Músicas",
   "play_featured_mix": "Ouvir no SoundCloud",
   "upcoming_events": "Próximos Eventos",
-  "home": {
-    "site_desc": "Site oficial de Zen Eyer, DJ e produtor musical de Zouk Brasileiro, também conhecido como DJ Zen Eyer.",
-    "page_title": "Zen Eyer | DJ e Produtor de Zouk Brasileiro",
-    "page_meta_desc": "Zen Eyer, vencedor de Melhor Remix e Melhor Performance DJ no Campeonato Mundial de DJs de Zouk Brasileiro de 2022. Contrate para eventos internacionais.",
-    "headline": "Experiencie o <1>Zen</1> no Zouk Brasileiro",
-    "subheadline": "A pressa é inimiga da cremosidade. Mergulhe no som de Zen Eyer.",
-    "welcome": "Bem-vindo ao Zen Eyer",
-    "tagline": "DJ e Produtor de Zouk Brasileiro",
-    "cta": "Explorar Músicas",
-    "features_title": "Por Que Entrar na Zen Tribe?",
-    "features_subtitle": "Desbloqueie benefícios exclusivos e faça parte de uma comunidade engajada",
-    "feat_exclusive_title": "Música Exclusiva",
-    "feat_exclusive_desc": "Acesso antecipado a lançamentos e remixes exclusivos",
-    "feat_achievements_title": "Conquistas & Recompensas",
-    "feat_achievements_desc": "Ganhe XP, desbloqueie badges e suba de nível",
-    "feat_community_title": "Comunidade Ativa",
-    "feat_community_desc": "Conecte-se com amantes de música e Zen Eyer",
-    "cta_title": "Pronto para Entrar na <1>Zen Tribe</1>?",
-    "cta_subtitle": "Junte-se a milhares de membros e transforme sua experiência com o Zouk.",
-    "hero_badge": "Best DJ Performance + Best Remix - Campeonato Mundial de DJs de Zouk Brasileiro de 2022",
-    "hero_title": "Zen Eyer",
-    "hero_subtitle": "DJ e Produtor de Zouk Brasileiro",
-    "introduction_aria": "Introdução de Zen Eyer",
-    "pronunciation_summary": " (Fonética: /zɛn ˈaɪər/. Eyer soa como Buyer sem o B, ou 'Eye' seguido de 'er').",
-    "hero_slogan": "A pressa é inimiga da cremosidade",
-    "hero_cta_text": "Sets completos e remixes. Para mais opções de streaming e downloads, vá em <0>Músicas</0>.",
-    "stat_champion": "Prêmios no Campeonato",
-    "stat_countries": "Países",
-    "stat_events": "Eventos",
-    "stat_years": "Experiência",
-    "bio_p1": "é um DJ e produtor brasileiro focado em Brazilian Zouk. Em 2022, tive a honra de vencer Best Remix e Best DJ Performance no Campeonato Mundial de DJs de Zouk Brasileiro, consolidando uma jornada que começou cedo na pista e hoje me leva a tocar em 14 países.",
-    "bio_p2": "Conhecido por um som focado no 'flow' puro da dança — a vibe que a nossa comunidade chama de 'cremosidade' —, priorizo sets onde a energia cresce gradualmente, dando ao dançarino tempo e espaço para se conectar sem pressa.",
-    "bio_p3": "Seja na reZENha, no Rio Zouk Congress da Renata Peçanha (onde tenho a honra de tocar anualmente) ou em festivais pelo mundo, a missão é a mesma: criar o clima perfeito para quem ama o Zouk Brasileiro.",
-    "festivals_title": "Festivais & Eventos",
-    "festivals_subtitle": "Muito feliz de ter levado o Zouk para esses lugares",
-    "festivals_more": "e outras cidades incríveis",
-    "press_title": "Imprensa & Mídia",
-    "press_desc": "Fotos para divulgação, infos e rider técnico.",
-    "press_cta": "ACESSAR PRESS KIT",
-    "booking_title": "Bookings",
-    "booking_desc": "Quer levar o som da Tribo Zen para a sua cidade? Mande uma mensagem.",
-    "booking_cta": "ENTRAR EM CONTATO",
-    "authority_title": "Perfis Verificados",
-    "tribe": {
-      "title": "Junte-se à <0>Zen Tribe</0>",
-      "subtitle": "Sem pressa aqui. Apenas derretimento prolongado.",
-      "desc": "Não é só sobre música. É sobre vibração. Entre para a lista VIP.",
-      "cta": "Entrar na Tribo"
-    },
-    "cta_soundcloud": "Ouvir no SoundCloud",
-    "cta_booking": "Booking / Press Kit",
-    "cta_music": "Explorar Músicas",
-    "bio_title": "Quem é Zen Eyer?",
-    "bio_intro": "<strong>Zen Eyer</strong> (Marcelo Eyer Fernandes) é <strong>DJ de Brazilian Zouk</strong> e produtor musical. Em 2022, conquistou os prêmios de Melhor Remix e Melhor Performance DJ no Campeonato Mundial de DJs de Zouk Brasileiro, sendo reconhecido pela precisão técnica e sensibilidade musical.",
-    "bio_style": "Conhecido pelo estilo \"cremoso\" e envolvente, Zen prioriza a conexão. Sem pressa. Seu drop assinatura <em>\"Zen… Zen… Zen… Eyer… Eyer…\"</em> já é um clássico nos festivais.",
-    "bio_mensa": "Membro da <strong>Mensa International</strong>, ele cria jornadas emocionais perfeitas para o \"flow\" na dança. Frequenta palcos de peso como o Rio Zouk Congress.",
-    "verified": "Perfis Verificados",
-    "bookers": {
-      "title": "Bookings",
-      "desc": "Quer levar o som da Tribo Zen para a sua cidade? Mande uma mensagem.",
-      "cta": "ENTRAR EM CONTATO"
-    },
-    "seo": {
-      "title": "Zen Eyer | DJ e Produtor de Zouk Brasileiro",
-      "description": "Zen Eyer, DJ e produtor musical focado no Zouk Brasileiro.",
-      "keywords": "Zen Eyer, Brazilian Zouk DJ, Zouk Brasileiro, Best DJ Performance, Best Remix, Brazilian Zouk music, dance festival DJ, Zouk producer",
-      "lead_answer": "Zen Eyer é DJ e produtor musical especializado em Zouk Brasileiro, vencedor de Best DJ Performance e Best Remix no Campeonato Mundial de DJs de Zouk Brasileiro de 2022."
-    },
-    "festivals": {
-      "presence": "Presença Internacional",
-      "many_more": "muitos outros"
-    },
-    "shows": {
-      "title": "Próximos Shows",
-      "cta": "Agenda completa",
-      "bandsintown_aria": "Seguir Zen Eyer no Bandsintown"
-    },
-    "press": {
-      "title": "Imprensa & Mídia",
-      "desc": "Acesse fotos, bio e assets.",
-      "cta": "BAIXAR PRESS KIT"
-    }
-  },
   "music_catalog_title": "Catálogo Musical",
   "music_catalog_description": "Faixas, edits e lançamentos do Zen Eyer com metadados para DJs.",
   "track": {

--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -388,7 +388,7 @@ const EventsPage: React.FC = () => {
 
         <section className="mt-16 p-6 md:p-10 text-center bg-surface border border-border/5 rounded-3xl relative overflow-hidden group max-w-4xl mx-auto">
           <Music className="absolute -right-8 -bottom-8 text-text/5 w-48 h-48 rotate-12 z-10" />
-          <h2 className="text-2xl md:text-3xl font-black mb-4 uppercase tracking-tighter relative z-20">{t('home.press_title')}</h2>
+          <h2 className="text-2xl md:text-3xl font-black mb-4 uppercase tracking-tighter relative z-20">{t('events.press_title')}</h2>
           <div className="flex flex-col sm:flex-row justify-center gap-4 relative z-20">
             <Link to={getLocalizedRoute('booking', lang as Language)} className="btn btn-primary px-10 py-3 min-h-[44px] rounded-xl font-bold uppercase text-sm">{t('contact')}</Link>
             <a href={safeUrl(pressKitUrl, '/')} className="btn btn-outline border-border/10 px-10 py-3 min-h-[44px] rounded-xl font-bold text-sm">{t('events.press_kit', { defaultValue: 'Press Kit' })}</a>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -48,12 +48,12 @@ interface FestivalBadgeProps {
 // ============================================================================
 
 const FEATURES_DATA = [
-  { id: 'music', icon: Music as React.ElementType, titleKey: 'home.feat_exclusive_title', descKey: 'home.feat_exclusive_desc' },
-  { id: 'achievements', icon: Award as React.ElementType, titleKey: 'home.feat_achievements_title', descKey: 'home.feat_achievements_desc' },
-  { id: 'community', icon: Users as React.ElementType, titleKey: 'home.feat_community_title', descKey: 'home.feat_community_desc' },
+  { id: 'music', icon: Music as React.ElementType, titleKey: 'feat_exclusive_title', descKey: 'feat_exclusive_desc' },
+  { id: 'achievements', icon: Award as React.ElementType, titleKey: 'feat_achievements_title', descKey: 'feat_achievements_desc' },
+  { id: 'community', icon: Users as React.ElementType, titleKey: 'feat_community_title', descKey: 'feat_community_desc' },
 ] as const;
 
-const STATS_BASE = [{ value: '2×', labelKey: 'home.stat_champion', icon: Trophy }] as const;
+const STATS_BASE = [{ value: '2×', labelKey: 'stat_champion', icon: Trophy }] as const;
 
 const LazyEventsList = React.lazy(() =>
   import('../components/EventsList').then((module) => ({ default: module.EventsList }))
@@ -114,7 +114,8 @@ const FestivalBadge = React.memo(({ name, flag }: FestivalBadgeProps) => (
 // ============================================================================
 
 const HomePage: React.FC = () => {
-  const { t, i18n } = useTranslation();
+  const { t: th, i18n } = useTranslation('home');
+  const { t } = useTranslation();
   const { data: seoSettings } = useZenSeoSettings();
   const { artist } = useBranding();
   const currentTheme = useCurrentTheme();
@@ -124,16 +125,16 @@ const HomePage: React.FC = () => {
   const baseUrl = artist?.site?.baseUrl || ARTIST.site.baseUrl;
   const currentUrl = `${baseUrl}${currentPath}`;
   const heroImages = HOME_HERO_IMAGES[currentTheme];
-  const translatedHeroTitle = t('home.hero_title');
-  const heroTitle = translatedHeroTitle === 'home.hero_title' ? ARTIST.identity.shortName : translatedHeroTitle;
+  const translatedHeroTitle = th('hero_title');
+  const heroTitle = translatedHeroTitle === 'hero_title' ? ARTIST.identity.shortName : translatedHeroTitle;
   const [heroTitleLead, ...heroTitleRestParts] = heroTitle.split(' ');
   const heroTitleRest = heroTitleRestParts.join(' ');
 
   const festivalsHighlight = useMemo(() => (artist?.festivals || ARTIST.festivals).slice(0, 6), [artist?.festivals]);
   const stats = useMemo(() => ([
     ...STATS_BASE,
-    { value: `${artist?.stats?.countriesPlayed || ARTIST.stats.countriesPlayed}+`, labelKey: 'home.stat_countries', icon: Globe },
-    { value: `${new Date().getFullYear() - (artist?.stats?.startingYear || ARTIST.stats.startingYear)}+`, labelKey: 'home.stat_years', icon: Sparkles },
+    { value: `${artist?.stats?.countriesPlayed || ARTIST.stats.countriesPlayed}+`, labelKey: 'stat_countries', icon: Globe },
+    { value: `${new Date().getFullYear() - (artist?.stats?.startingYear || ARTIST.stats.startingYear)}+`, labelKey: 'stat_years', icon: Sparkles },
   ]), [artist?.stats?.countriesPlayed, artist?.stats?.startingYear]);
 
   // ⚡ Bolt: Memoize localized routes to avoid O(N) recalculations on every render
@@ -154,7 +155,7 @@ const HomePage: React.FC = () => {
         "@id": `${baseUrl}/#website`,
         "url": baseUrl,
         "name": "Zen Eyer",
-        "description": t('home.site_desc'),
+        "description": th('site_desc'),
         "publisher": { "@id": `${baseUrl}/#artist` },
         "inLanguage": ["en", "pt-BR"],
         "potentialAction": {
@@ -172,8 +173,8 @@ const HomePage: React.FC = () => {
         "@type": "WebPage",
         "@id": `${currentUrl}#webpage`,
         "url": currentUrl,
-        "name": t('home.page_title'),
-        "description": t('home.page_meta_desc'),
+        "name": th('page_title'),
+        "description": th('page_meta_desc'),
         "isPartOf": { "@id": `${baseUrl}/#website` },
         "speakable": {
           "@type": "SpeakableSpecification",
@@ -191,20 +192,20 @@ const HomePage: React.FC = () => {
         }
       }
     ],
-  }), [seoSettings, t, currentUrl, routes.news, baseUrl]);
+  }), [seoSettings, th, currentUrl, routes.news, baseUrl]);
 
   return (
     <>
       <HeadlessSEO
-        title={t('home.page_title')}
-        description={t('home.page_meta_desc')}
+        title={th('page_title')}
+        description={th('page_meta_desc')}
         url={currentUrl}
         image={seoSettings?.default_og_image || `${baseUrl}/images/og/zen-eyer-home-og.jpg`}
         imageAlt={t('og.image_alt.home')}
         isHomepage={true}
         schema={schemaData}
-        keywords={t('home.seo.keywords')}
-        leadAnswer={t('home.seo.lead_answer')}
+        keywords={th('seo.keywords')}
+        leadAnswer={th('seo.lead_answer')}
         preload={[
           {
             href: heroImages.mobileSrc,
@@ -224,7 +225,7 @@ const HomePage: React.FC = () => {
       />
 
       {/* HERO SECTION */}
-      <section className="relative min-h-screen flex items-center overflow-hidden pt-20 pb-12 text-center md:text-left" aria-label={t('home.introduction_aria')}>
+      <section className="relative min-h-screen flex items-center overflow-hidden pt-20 pb-12 text-center md:text-left" aria-label={th('introduction_aria')}>
         <div className="absolute inset-0 z-0 bg-background">
             <div className="w-full h-full">
               <picture>
@@ -271,12 +272,12 @@ const HomePage: React.FC = () => {
 
           <div>
             <p id="artist-voice-bio" className="text-base sm:text-xl md:text-2xl text-text mb-1 font-light" data-speakable>
-              {t('home.hero_subtitle')}
-              <span id="pronunciation-faq-summary" className="sr-only">{t('home.pronunciation_summary')}</span>
+              {th('hero_subtitle')}
+              <span id="pronunciation-faq-summary" className="sr-only">{th('pronunciation_summary')}</span>
             </p>
 
             <p className="text-lg md:text-xl italic text-primary/90 mb-5">
-              &ldquo;{t('home.hero_slogan')}&rdquo;
+              &ldquo;{th('hero_slogan')}&rdquo;
             </p>
 
             <div className="mb-8">
@@ -286,7 +287,7 @@ const HomePage: React.FC = () => {
                   : 'px-4 py-2 bg-primary/10 border border-primary/20 text-primary font-bold tracking-widest uppercase'
               }`}>
                 <Trophy size={16} />
-                <span>{t('home.hero_badge')}</span>
+                <span>{th('hero_badge')}</span>
               </div>
             </div>
 
@@ -295,7 +296,7 @@ const HomePage: React.FC = () => {
                 <StatCard
                   key={stat.labelKey}
                   value={stat.value}
-                  label={t(stat.labelKey as unknown as Parameters<typeof t>[0])}
+                  label={th(stat.labelKey)}
                   icon={stat.icon}
                   iconClass={currentTheme === 'mediterranean-dusk' ? 'text-secondary' : 'text-primary'}
                   cardClass={currentTheme === 'mediterranean-dusk' ? 'bg-surface/60 border border-border/20 rounded-xl backdrop-blur-sm' : ''}
@@ -310,24 +311,25 @@ const HomePage: React.FC = () => {
                 target="_blank"
                 rel="noopener noreferrer"
                 className="btn btn-primary btn-lg flex items-center gap-2 min-h-[44px] shadow-lg shadow-primary/25 hover:shadow-primary/40 transition-shadow"
-                aria-label={t('home.cta_soundcloud')}
+                aria-label={th('cta_soundcloud')}
               >
                 <PlayCircle size={22} />
-                <span>{t('home.cta_soundcloud')}</span>
+                <span>{th('cta_soundcloud')}</span>
               </a>
               <Link
                 to={routes.booking}
                 className="btn btn-outline btn-lg flex items-center gap-2 min-h-[44px] backdrop-blur-sm"
-                aria-label={t('home.cta_booking')}
+                aria-label={th('cta_booking')}
               >
                 <Mail size={22} />
-                <span>{t('home.cta_booking')}</span>
+                <span>{th('cta_booking')}</span>
               </Link>
             </div>
 
             <p className="text-sm md:text-base text-text/60 max-w-2xl mx-auto md:mx-0 leading-relaxed">
               <Trans
-                i18nKey="home.hero_cta_text"
+                i18nKey="hero_cta_text"
+                ns="home"
                 components={[
                   <Link
                     key="music-link"
@@ -353,12 +355,12 @@ const HomePage: React.FC = () => {
         <div className="container mx-auto px-4">
           <div className="max-w-4xl mx-auto">
             <article className="prose prose-invert prose-lg max-w-none safe-html-contrast">
-              <h2 className="text-3xl font-bold mb-6 text-text font-display">{t('home.bio_title')}</h2>
+              <h2 className="text-3xl font-bold mb-6 text-text font-display">{th('bio_title')}</h2>
               <div className="text-xl leading-relaxed mb-6 text-text/90">
-                <p dangerouslySetInnerHTML={{ __html: sanitizeHtml(t('home.bio_intro')) }} />
+                <p dangerouslySetInnerHTML={{ __html: sanitizeHtml(th('bio_intro')) }} />
               </div>
-              <p className="text-lg leading-relaxed text-text/80 mb-6" dangerouslySetInnerHTML={{ __html: sanitizeHtml(t('home.bio_style')) }} />
-              <p className="text-lg leading-relaxed text-text/80" dangerouslySetInnerHTML={{ __html: sanitizeHtml(t('home.bio_mensa')) }} />
+              <p className="text-lg leading-relaxed text-text/80 mb-6" dangerouslySetInnerHTML={{ __html: sanitizeHtml(th('bio_style')) }} />
+              <p className="text-lg leading-relaxed text-text/80" dangerouslySetInnerHTML={{ __html: sanitizeHtml(th('bio_mensa')) }} />
             </article>
           </div>
         </div>
@@ -369,7 +371,7 @@ const HomePage: React.FC = () => {
         <div className="container mx-auto px-4">
           <div className="max-w-4xl mx-auto text-center">
             <h2 className="text-2xl md:text-3xl font-bold mb-3 font-display">
-              {t('home.shows.title')}
+              {th('shows.title')}
             </h2>
 
             <div className="mb-8">
@@ -389,10 +391,10 @@ const HomePage: React.FC = () => {
             <div className="flex flex-wrap justify-center gap-4">
               <Link to={routes.events} className="btn btn-primary btn-lg flex items-center gap-2">
                 <Calendar size={20} />
-                <span>{t('home.shows.cta')}</span>
+                <span>{th('shows.cta')}</span>
               </Link>
               {ARTIST.social.bandsintown?.url && (
-                <a href={safeUrl(ARTIST.social.bandsintown.url, '/')} target="_blank" rel="noopener noreferrer" className="btn btn-outline btn-lg flex items-center gap-2" aria-label={t('home.shows.bandsintown_aria')}>
+                <a href={safeUrl(ARTIST.social.bandsintown.url, '/')} target="_blank" rel="noopener noreferrer" className="btn btn-outline btn-lg flex items-center gap-2" aria-label={th('shows.bandsintown_aria')}>
                   <ExternalLink size={18} />
                   <span>{t('social.bandsintown')}</span>
                 </a>
@@ -407,7 +409,7 @@ const HomePage: React.FC = () => {
         <div className="container mx-auto px-4">
           <ul className="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-5xl mx-auto">
             {FEATURES_DATA.map(feature => (
-              <FeatureCard key={feature.id} icon={feature.icon} title={t(feature.titleKey as unknown as Parameters<typeof t>[0])} description={t(feature.descKey as unknown as Parameters<typeof t>[0])} />
+              <FeatureCard key={feature.id} icon={feature.icon} title={th(feature.titleKey)} description={th(feature.descKey)} />
             ))}
           </ul>
         </div>
@@ -418,12 +420,12 @@ const HomePage: React.FC = () => {
         <div className="container mx-auto px-4">
           <div className="text-center">
             <h2 className="text-2xl md:text-3xl font-bold mb-2 font-display">
-              {t('home.festivals.presence')}
+              {th('festivals.presence')}
             </h2>
             <div className="flex flex-wrap justify-center gap-3 mt-8">
               {festivalsHighlight.map(festival => (<FestivalBadge key={festival.name} name={festival.name} flag={festival.flag} />))}
               <span className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-primary/10 border border-primary/30 rounded-full text-sm text-primary">
-                <span>+{t('home.festivals.many_more')}</span>
+                <span>+{th('festivals.many_more')}</span>
               </span>
             </div>
           </div>
@@ -436,20 +438,20 @@ const HomePage: React.FC = () => {
           <div className="grid md:grid-cols-2 gap-6 max-w-4xl mx-auto">
             <div className="p-4 sm:p-8 bg-surface border-l-4 border-primary rounded-r-lg shadow-lg hover:bg-surface/80 transition-colors" role="group" aria-labelledby="press-card-title">
               <h3 id="press-card-title" className="text-xl font-bold mb-3 flex items-center gap-2 font-display">
-                <Download size={20} className="text-primary" /> {t('home.press.title')}
+                <Download size={20} className="text-primary" /> {th('press.title')}
               </h3>
-              <p className="text-text/70 mb-4 text-sm">{t('home.press.desc')}</p>
+              <p className="text-text/70 mb-4 text-sm">{th('press.desc')}</p>
               <Link to={routes.booking} className="inline-flex items-center gap-2 text-primary hover:text-primary/80 font-semibold transition-colors">
-                {t('home.press.cta')} →
+                {th('press.cta')} →
               </Link>
             </div>
             <div className="p-4 sm:p-8 bg-surface border-l-4 border-success rounded-r-lg shadow-lg hover:bg-surface/80 transition-colors" role="group" aria-labelledby="bookers-card-title">
               <h3 id="bookers-card-title" className="text-xl font-bold mb-3 flex items-center gap-2 font-display">
-                <Calendar size={20} className="text-success" /> {t('home.bookers.title')}
+                <Calendar size={20} className="text-success" /> {th('bookers.title')}
               </h3>
-              <p className="text-text/70 mb-4 text-sm">{t('home.bookers.desc')}</p>
+              <p className="text-text/70 mb-4 text-sm">{th('bookers.desc')}</p>
               <Link to={routes.booking} className="inline-flex items-center gap-2 text-success hover:text-success/80 font-semibold transition-colors">
-                {t('home.bookers.cta')} →
+                {th('bookers.cta')} →
               </Link>
             </div>
           </div>
@@ -460,7 +462,7 @@ const HomePage: React.FC = () => {
       <section className="py-12 bg-background border-t border-border/5">
         <div className="container mx-auto px-4 text-center">
           <div>
-            <p className="text-xs font-semibold text-text/55 mb-4 uppercase tracking-widest">{t('home.verified')}</p>
+            <p className="text-xs font-semibold text-text/55 mb-4 uppercase tracking-widest">{th('verified')}</p>
             <div className="flex flex-wrap justify-center gap-6 text-sm">
               <a href={safeUrl(`https://musicbrainz.org/artist/${ARTIST.identifiers.musicbrainz}`, '/')} target="_blank" rel="noopener noreferrer" className="text-text/65 hover:text-primary transition-colors flex items-center gap-1">{t('social.musicbrainz')} <ExternalLink size={10} /></a>
               <a href={safeUrl(`https://www.wikidata.org/wiki/${ARTIST.identifiers.wikidata}`, '/')} target="_blank" rel="noopener noreferrer" className="text-text/65 hover:text-primary transition-colors flex items-center gap-1">{t('social.wikidata')} <ExternalLink size={10} /></a>
@@ -476,10 +478,10 @@ const HomePage: React.FC = () => {
 
         <div className="container mx-auto px-4 text-center relative z-10">
           <h2 className="text-2xl sm:text-4xl md:text-6xl font-bold mb-6 font-display">
-            <Trans i18nKey="home.tribe.title" components={[<span className="text-primary" />]} />
+            <Trans i18nKey="tribe.title" ns="home" components={[<span className="text-primary" />]} />
           </h2>
           <p className="text-xl text-text/70 mb-10 max-w-2xl mx-auto">
-            {t('home.tribe.subtitle')}
+            {th('tribe.subtitle')}
           </p>
           <div className="flex flex-wrap justify-center gap-4">
             <Link to={routes.zentribe} className="btn btn-primary btn-lg min-w-[200px]">

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -330,6 +330,7 @@ const HomePage: React.FC = () => {
               <Trans
                 i18nKey="hero_cta_text"
                 ns="home"
+                t={th}
                 components={[
                   <Link
                     key="music-link"
@@ -478,7 +479,7 @@ const HomePage: React.FC = () => {
 
         <div className="container mx-auto px-4 text-center relative z-10">
           <h2 className="text-2xl sm:text-4xl md:text-6xl font-bold mb-6 font-display">
-            <Trans i18nKey="tribe.title" ns="home" components={[<span className="text-primary" />]} />
+            <Trans i18nKey="tribe.title" ns="home" t={th} components={[<span className="text-primary" />]} />
           </h2>
           <p className="text-xl text-text/70 mb-10 max-w-2xl mx-auto">
             {th('tribe.subtitle')}

--- a/src/pages/NewsletterStatusPage.tsx
+++ b/src/pages/NewsletterStatusPage.tsx
@@ -1,5 +1,4 @@
 import React, { useMemo } from 'react';
-import { motion } from 'framer-motion';
 import { Link, useLocation } from 'react-router-dom';
 import { CheckCircle2, HeartHandshake, MailCheck, MailQuestion, Settings2, ShieldCheck, Sparkles } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -13,9 +12,6 @@ type NewsletterLang = 'en' | 'pt';
 interface NewsletterStatusPageProps {
   mode?: NewsletterPageMode;
 }
-
-const FADE_IN_UP_INITIAL = { opacity: 0, y: 20 };
-const FADE_IN_UP_ANIMATE = { opacity: 1, y: 0 };
 
 const getCurrentLangFromPath = (pathname: string): NewsletterLang => (
   pathname === '/pt' || pathname.startsWith('/pt/') ? 'pt' : 'en'
@@ -47,12 +43,7 @@ const NewsletterStatusPage: React.FC<NewsletterStatusPageProps> = ({ mode = 'con
 
       <main className="min-h-screen bg-background text-text pt-24 pb-20">
         <div className="container mx-auto px-4 max-w-5xl">
-          <motion.section
-            initial={FADE_IN_UP_INITIAL}
-            animate={FADE_IN_UP_ANIMATE}
-            transition={{ duration: 0.6 }}
-            className="relative overflow-hidden rounded-[2rem] border border-border/10 bg-gradient-to-br from-primary/20 via-surface/80 to-background p-6 md:p-12 shadow-2xl"
-          >
+          <section className="relative overflow-hidden rounded-[2rem] border border-border/10 bg-gradient-to-br from-primary/20 via-surface/80 to-background p-6 md:p-12 shadow-2xl motion-safe:animate-fade-up">
             <div className="absolute -right-24 -top-24 h-64 w-64 rounded-full bg-primary/20 blur-3xl" aria-hidden="true" />
             <div className="absolute -bottom-32 -left-20 h-72 w-72 rounded-full bg-text/5 blur-3xl" aria-hidden="true" />
 
@@ -97,13 +88,11 @@ const NewsletterStatusPage: React.FC<NewsletterStatusPageProps> = ({ mode = 'con
                 </ol>
               </div>
             </div>
-          </motion.section>
+          </section>
 
-          <motion.section
-            initial={FADE_IN_UP_INITIAL}
-            animate={FADE_IN_UP_ANIMATE}
-            transition={{ duration: 0.6, delay: 0.12 }}
-            className="mt-8 grid gap-6 lg:grid-cols-[1fr_0.85fr]"
+          <section
+            className="mt-8 grid gap-6 lg:grid-cols-[1fr_0.85fr] motion-safe:animate-fade-up"
+            style={{ animationDelay: '120ms' }}
           >
             <div className="card p-6 md:p-8">
               <div className="mb-5 flex items-center gap-3">
@@ -133,20 +122,18 @@ const NewsletterStatusPage: React.FC<NewsletterStatusPageProps> = ({ mode = 'con
                 {t(`${mode}.note`)}
               </div>
             </aside>
-          </motion.section>
+          </section>
 
           {mode === 'preferences' && (
-            <motion.div
-              initial={FADE_IN_UP_INITIAL}
-              animate={FADE_IN_UP_ANIMATE}
-              transition={{ duration: 0.6, delay: 0.18 }}
-              className="mt-6 flex items-center gap-3 rounded-2xl border border-border/10 bg-surface/50 p-5 text-text/70"
+            <div
+              className="mt-6 flex items-center gap-3 rounded-2xl border border-border/10 bg-surface/50 p-5 text-text/70 motion-safe:animate-fade-up"
+              style={{ animationDelay: '180ms' }}
             >
               <CheckCircle2 className="flex-shrink-0 text-primary" size={24} />
               <p className="leading-relaxed">
                 {t('preferences.recommended_standard')}
               </p>
-            </motion.div>
+            </div>
           )}
         </div>
       </main>

--- a/src/pages/PhilosophyPage.tsx
+++ b/src/pages/PhilosophyPage.tsx
@@ -73,7 +73,7 @@ const PhilosophyPage: React.FC = () => {
         breadcrumb: {
           '@type': 'BreadcrumbList',
           itemListElement: [
-            { '@type': 'ListItem', position: 1, name: t('home'), item: `${ARTIST.site.baseUrl}${getLocalizedRoute('home', currentLang)}` },
+            { '@type': 'ListItem', position: 1, name: t('nav.home'), item: `${ARTIST.site.baseUrl}${getLocalizedRoute('home', currentLang)}` },
             { '@type': 'ListItem', position: 2, name: t('philosophy.page_title'), item: pageUrl },
           ],
         },

--- a/src/pages/PrivacyPolicyPage.tsx
+++ b/src/pages/PrivacyPolicyPage.tsx
@@ -1,14 +1,8 @@
 import React, { useMemo } from 'react';
-import { motion } from 'framer-motion';
 import { Shield, Lock, Eye, Database, Mail } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { HeadlessSEO } from '../components/HeadlessSEO';
 import { getLocalizedRoute, normalizeLanguage } from '../config/routes';
-
-
-// ⚡ Bolt: Module-scoped constants to prevent unnecessary object reallocation on every render cycle.
-const FADE_IN_UP_INITIAL = { opacity: 0, y: 20 };
-const FADE_IN_UP_ANIMATE = { opacity: 1, y: 0 };
 
 const PrivacyPolicyPage: React.FC = () => {
   const { t, i18n } = useTranslation(['translation', 'privacy']);
@@ -59,12 +53,7 @@ const PrivacyPolicyPage: React.FC = () => {
       <div className="min-h-screen pt-24 pb-16">
         <div className="container mx-auto px-4 max-w-4xl">
           {/* Header */}
-          <motion.div
-            initial={FADE_IN_UP_INITIAL}
-            animate={FADE_IN_UP_ANIMATE}
-            transition={{ duration: 0.6 }}
-            className="text-center mb-12"
-          >
+          <div className="text-center mb-12 motion-safe:animate-fade-up">
             <div className="inline-flex items-center justify-center w-20 h-20 rounded-full bg-primary/20 mb-6">
               <Shield size={40} className="text-primary" />
             </div>
@@ -74,32 +63,21 @@ const PrivacyPolicyPage: React.FC = () => {
             <p className="text-text/70">
               {t('privacy_page.last_updated')}: <span className="text-primary font-semibold">{t('privacy_page.last_updated_date')}</span>
             </p>
-          </motion.div>
+          </div>
 
           {/* Introduction */}
-          <motion.div
-            initial={FADE_IN_UP_INITIAL}
-            animate={FADE_IN_UP_ANIMATE}
-            transition={{ duration: 0.6, delay: 0.1 }}
-            className="card p-8 mb-8"
-          >
+          <div className="card p-8 mb-8 motion-safe:animate-fade-up">
             <p className="text-lg text-text/80 leading-relaxed mb-4">
               {t('privacy_page.intro_p1')}
             </p>
             <p className="text-text/70 leading-relaxed">
               {t('privacy_page.intro_p2')}
             </p>
-          </motion.div>
+          </div>
 
           {/* Sections */}
           {sections.map((section, index) => (
-            <motion.div
-              key={index}
-              initial={FADE_IN_UP_INITIAL}
-              animate={FADE_IN_UP_ANIMATE}
-              transition={{ duration: 0.6, delay: 0.2 + index * 0.1 }}
-              className="card p-8 mb-6"
-            >
+            <div key={index} className="card p-8 mb-6 motion-safe:animate-fade-up">
               <div className="flex items-start gap-4 mb-4">
                 <div className="flex-shrink-0 w-12 h-12 rounded-lg bg-primary/20 flex items-center justify-center">
                   <section.icon size={24} className="text-primary" />
@@ -114,16 +92,11 @@ const PrivacyPolicyPage: React.FC = () => {
                   </li>
                 ))}
               </ul>
-            </motion.div>
+            </div>
           ))}
 
           {/* Cookies */}
-          <motion.div
-            initial={FADE_IN_UP_INITIAL}
-            animate={FADE_IN_UP_ANIMATE}
-            transition={{ duration: 0.6, delay: 0.7 }}
-            className="card p-8 mb-6"
-          >
+          <div className="card p-8 mb-6 motion-safe:animate-fade-up">
             <h2 className="text-2xl font-display font-bold mb-4">{t('privacy_page.cookies_title')}</h2>
             <p className="text-text/70 leading-relaxed mb-4">
               {t('privacy_page.cookies_p1')}
@@ -131,15 +104,10 @@ const PrivacyPolicyPage: React.FC = () => {
             <p className="text-text/70 leading-relaxed">
               {t('privacy_page.cookies_p2')}
             </p>
-          </motion.div>
+          </div>
 
           {/* Third-Party Services */}
-          <motion.div
-            initial={FADE_IN_UP_INITIAL}
-            animate={FADE_IN_UP_ANIMATE}
-            transition={{ duration: 0.6, delay: 0.8 }}
-            className="card p-8 mb-6"
-          >
+          <div className="card p-8 mb-6 motion-safe:animate-fade-up">
             <h2 className="text-2xl font-display font-bold mb-4">{t('privacy_page.third_party_title')}</h2>
             <p className="text-text/70 leading-relaxed mb-4">
               {t('privacy_page.third_party_p1')}
@@ -149,15 +117,10 @@ const PrivacyPolicyPage: React.FC = () => {
               <p className="text-text/80"><strong>{t('privacy_page.third_party_payments').split(':')[0]}:</strong>{t('privacy_page.third_party_payments').split(':')[1]}</p>
               <p className="text-text/80"><strong>{t('privacy_page.third_party_email').split(':')[0]}:</strong>{t('privacy_page.third_party_email').split(':')[1]}</p>
             </div>
-          </motion.div>
+          </div>
 
           {/* LGPD Compliance */}
-          <motion.div
-            initial={FADE_IN_UP_INITIAL}
-            animate={FADE_IN_UP_ANIMATE}
-            transition={{ duration: 0.6, delay: 0.9 }}
-            className="card p-8 mb-6 border-l-4 border-primary"
-          >
+          <div className="card p-8 mb-6 border-l-4 border-primary motion-safe:animate-fade-up">
             <h2 className="text-2xl font-display font-bold mb-4">{t('privacy_page.lgpd_title')}</h2>
             <p className="text-text/70 leading-relaxed mb-4">
               {t('privacy_page.lgpd_p1')}
@@ -170,28 +133,18 @@ const PrivacyPolicyPage: React.FC = () => {
                 </li>
               ))}
             </ul>
-          </motion.div>
+          </div>
 
           {/* Changes to Policy */}
-          <motion.div
-            initial={FADE_IN_UP_INITIAL}
-            animate={FADE_IN_UP_ANIMATE}
-            transition={{ duration: 0.6, delay: 1.0 }}
-            className="card p-8 mb-6"
-          >
+          <div className="card p-8 mb-6 motion-safe:animate-fade-up">
             <h2 className="text-2xl font-display font-bold mb-4">{t('privacy_page.changes_title')}</h2>
             <p className="text-text/70 leading-relaxed">
               {t('privacy_page.changes_p1')}
             </p>
-          </motion.div>
+          </div>
 
           {/* Contact */}
-          <motion.div
-            initial={FADE_IN_UP_INITIAL}
-            animate={FADE_IN_UP_ANIMATE}
-            transition={{ duration: 0.6, delay: 1.1 }}
-            className="card p-8 text-center bg-gradient-to-br from-primary/10 to-transparent"
-          >
+          <div className="card p-8 text-center bg-gradient-to-br from-primary/10 to-transparent motion-safe:animate-fade-up">
             <h2 className="text-2xl font-display font-bold mb-4">{t('privacy_page.contact_title')}</h2>
             <p className="text-text/70 mb-6">
               {t('privacy_page.contact_p1')}
@@ -208,7 +161,7 @@ const PrivacyPolicyPage: React.FC = () => {
                 contact@djzeneyer.com
               </a>
             </div>
-          </motion.div>
+          </div>
         </div>
       </div>
     </>

--- a/src/pages/ReturnPolicyPage.tsx
+++ b/src/pages/ReturnPolicyPage.tsx
@@ -1,5 +1,4 @@
 import React, { useMemo } from 'react';
-import { motion } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
 import { HeadlessSEO } from '../components/HeadlessSEO';
 import { ARTIST } from '../data/artistData';
@@ -20,11 +19,7 @@ const ReturnPolicyPage: React.FC = () => {
 
       <div className="min-h-screen pt-24 pb-20 bg-background text-text">
         <div className="container mx-auto px-4 max-w-4xl">
-          <motion.article
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            className="prose prose-invert prose-lg max-w-none"
-          >
+          <article className="prose prose-invert prose-lg max-w-none motion-safe:animate-fade-up">
             <h1 className="font-display text-4xl md:text-5xl mb-8">
               {t('legal.return_policy.h1')}
             </h1>
@@ -68,7 +63,7 @@ const ReturnPolicyPage: React.FC = () => {
             <div className="mt-12 pt-8 border-t border-border/10 text-sm text-text/50">
               <p>{t('legal.return_policy.last_updated')}: <span className="text-primary font-semibold">{t('legal.return_policy.last_updated_date')}</span></p>
             </div>
-          </motion.article>
+          </article>
         </div>
       </div>
     </>

--- a/src/pages/TermsPage.tsx
+++ b/src/pages/TermsPage.tsx
@@ -1,14 +1,10 @@
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { motion } from 'framer-motion';
 import { FileText, AlertCircle, Scale, Ban, CheckCircle } from 'lucide-react';
 import { HeadlessSEO } from '../components/HeadlessSEO';
 import { getLocalizedRoute, normalizeLanguage } from '../config/routes';
 
 
-// ⚡ Bolt: Extract static framer-motion variants to preserve object references and prevent unnecessary reallocations
-const FADE_IN_UP_INITIAL = { opacity: 0, y: 20 };
-const FADE_IN_UP_ANIMATE = { opacity: 1, y: 0 };
 
 const TermsPage: React.FC = () => {
   const { t, i18n } = useTranslation(['translation', 'legal']);
@@ -108,12 +104,7 @@ const TermsPage: React.FC = () => {
       <div className="min-h-screen pt-24 pb-16">
         <div className="container mx-auto px-4 max-w-4xl">
           {/* Header */}
-          <motion.div
-            initial={FADE_IN_UP_INITIAL}
-            animate={FADE_IN_UP_ANIMATE}
-            transition={{ duration: 0.6 }}
-            className="text-center mb-12"
-          >
+          <div className="text-center mb-12 motion-safe:animate-fade-up">
             <div className="inline-flex items-center justify-center w-20 h-20 rounded-full bg-primary/20 mb-6">
               <FileText size={40} className="text-primary" />
             </div>
@@ -123,32 +114,21 @@ const TermsPage: React.FC = () => {
             <p className="text-text/70">
               {t('legal.terms_page.last_updated')}: <span className="text-primary font-semibold">{t('legal.terms_page.last_updated_date')}</span>
             </p>
-          </motion.div>
+          </div>
 
           {/* Introduction */}
-          <motion.div
-            initial={FADE_IN_UP_INITIAL}
-            animate={FADE_IN_UP_ANIMATE}
-            transition={{ duration: 0.6, delay: 0.1 }}
-            className="card p-8 mb-8 border-l-4 border-primary"
-          >
+          <div className="card p-8 mb-8 border-l-4 border-primary motion-safe:animate-fade-up">
             <p className="text-lg text-text/80 leading-relaxed mb-4">
               {t('legal.terms_page.introduction')}
             </p>
             <p className="text-text/70 leading-relaxed">
               {t('legal.terms_page.introduction_agreement')}
             </p>
-          </motion.div>
+          </div>
 
           {/* Main Sections */}
           {sections.map((section, index) => (
-            <motion.div
-              key={index}
-              initial={FADE_IN_UP_INITIAL}
-              animate={FADE_IN_UP_ANIMATE}
-              transition={{ duration: 0.6, delay: 0.2 + index * 0.1 }}
-              className="card p-8 mb-6"
-            >
+            <div key={index} className="card p-8 mb-6 motion-safe:animate-fade-up">
               <div className="flex items-start gap-4 mb-4">
                 <div className="flex-shrink-0 w-12 h-12 rounded-lg bg-primary/20 flex items-center justify-center">
                   <section.icon size={24} className="text-primary" />
@@ -156,18 +136,12 @@ const TermsPage: React.FC = () => {
                 <h2 className="text-2xl font-display font-bold mt-1">{`${index + 1}. ${section.title}`}</h2>
               </div>
               <p className="text-text/70 leading-relaxed ml-16">{section.content}</p>
-            </motion.div>
+            </div>
           ))}
 
           {/* Additional Terms */}
           {additionalTerms.map((term, index) => (
-            <motion.div
-              key={index}
-              initial={FADE_IN_UP_INITIAL}
-              animate={FADE_IN_UP_ANIMATE}
-              transition={{ duration: 0.6, delay: 0.6 + index * 0.1 }}
-              className="card p-8 mb-6"
-            >
+            <div key={index} className="card p-8 mb-6 motion-safe:animate-fade-up">
               <h2 className="text-2xl font-display font-bold mb-4">{`${index + 5}. ${term.title}`}</h2>
               <ul className="space-y-3">
                 {term.points.map((point, i) => (
@@ -177,16 +151,11 @@ const TermsPage: React.FC = () => {
                   </li>
                 ))}
               </ul>
-            </motion.div>
+            </div>
           ))}
 
           {/* Governing Law */}
-          <motion.div
-            initial={FADE_IN_UP_INITIAL}
-            animate={FADE_IN_UP_ANIMATE}
-            transition={{ duration: 0.6, delay: 1.1 }}
-            className="card p-8 mb-6"
-          >
+          <div className="card p-8 mb-6 motion-safe:animate-fade-up">
             <h2 className="text-2xl font-display font-bold mb-4">10. {t('legal.terms_page.governing_law')}</h2>
             <p className="text-text/70 leading-relaxed mb-4">
               {t('legal.terms_page.law_brazil')}
@@ -194,28 +163,18 @@ const TermsPage: React.FC = () => {
             <p className="text-text/70 leading-relaxed">
               {t('legal.terms_page.law_consent')}
             </p>
-          </motion.div>
+          </div>
 
           {/* Modifications */}
-          <motion.div
-            initial={FADE_IN_UP_INITIAL}
-            animate={FADE_IN_UP_ANIMATE}
-            transition={{ duration: 0.6, delay: 1.2 }}
-            className="card p-8 mb-6"
-          >
+          <div className="card p-8 mb-6 motion-safe:animate-fade-up">
             <h2 className="text-2xl font-display font-bold mb-4">11. {t('legal.terms_page.modifications')}</h2>
             <p className="text-text/70 leading-relaxed">
               {t('legal.terms_page.modifications_desc')}
             </p>
-          </motion.div>
+          </div>
 
           {/* Contact */}
-          <motion.div
-            initial={FADE_IN_UP_INITIAL}
-            animate={FADE_IN_UP_ANIMATE}
-            transition={{ duration: 0.6, delay: 1.3 }}
-            className="card p-8 text-center bg-gradient-to-br from-primary/10 to-transparent"
-          >
+          <div className="card p-8 text-center bg-gradient-to-br from-primary/10 to-transparent motion-safe:animate-fade-up">
             <h2 className="text-2xl font-display font-bold mb-4">{t('legal.terms_page.questions')}</h2>
             <p className="text-text/70 mb-6">
               {t('legal.terms_page.questions_desc')}
@@ -232,17 +191,12 @@ const TermsPage: React.FC = () => {
                 contact@djzeneyer.com
               </a>
             </div>
-          </motion.div>
+          </div>
 
           {/* Acceptance */}
-          <motion.div
-            initial={FADE_IN_UP_INITIAL}
-            animate={FADE_IN_UP_ANIMATE}
-            transition={{ duration: 0.6, delay: 1.4 }}
-            className="text-center text-text/50 text-sm mt-8"
-          >
+          <div className="text-center text-text/50 text-sm mt-8 motion-safe:animate-fade-up">
             <p>{t('legal.terms_page.acceptance_footer')}</p>
-          </motion.div>
+          </div>
         </div>
       </div>
     </>

--- a/src/services/newsletterService.ts
+++ b/src/services/newsletterService.ts
@@ -1,0 +1,20 @@
+import { buildApiUrl } from '../config/api';
+
+interface SubscribeResponse {
+  message?: string;
+}
+
+export const subscribeToNewsletter = async (email: string): Promise<SubscribeResponse> => {
+  const res = await fetch(buildApiUrl('djzeneyer/v1/subscribe'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email }),
+  });
+
+  const data = (await res.json().catch(() => ({}))) as SubscribeResponse;
+  if (!res.ok) {
+    throw new Error(data.message || 'Subscription failed');
+  }
+
+  return data;
+};


### PR DESCRIPTION
## Summary
- move Home-specific EN/PT copy from the global translation namespace into dedicated home namespaces
- load the home namespace in HomePage while keeping global labels on the default namespace
- move the Events press title to events.press_title and fix an ambiguous Philosophy breadcrumb key

## Validation
- npm run i18n:check
- npm run type-check
- npm run build
- npm run perf:budget

## Performance notes
- global translation chunks are smaller for non-Home pages
- Home still loads its own copy on first visit, so initial Home JS remains effectively unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Novos Recursos**
  * A página inicial ganhou conteúdo completo em português e inglês, incluindo SEO, hero, benefícios, biografia, imprensa, festivais e booking.
  * A área de newsletter agora envia inscrições diretamente e mostra feedback de sucesso ou erro para o usuário.

* **Melhorias**
  * Foram adicionadas animações leves com suporte a redução de movimento para várias páginas e componentes.
  * Textos de navegação e títulos de imprensa foram ajustados para refletir melhor as seções exibidas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->