### PR TITLE
style: refine Mediterranean visuals and responsive Home hero

### DIFF
--- a/src/__tests__/pages/HomePage.test.tsx
+++ b/src/__tests__/pages/HomePage.test.tsx
@@ -145,6 +145,20 @@ describe('HomePage — render', () => {
     renderPage();
     expect(screen.getByText('2×')).toBeDefined();
   });
+
+  it('uses portrait and landscape hero sources for responsive windows', () => {
+    const { container } = renderPage();
+    const sources = container.querySelectorAll('picture source');
+    const image = container.querySelector('picture img');
+
+    expect(sources).toHaveLength(2);
+    expect(sources[0].getAttribute('media')).toBe('(max-width: 768px), (orientation: portrait)');
+    expect(sources[0].getAttribute('srcset')).toBe('/images/hero-background-mediterranean-mobile.webp');
+    expect(sources[1].getAttribute('media')).toBe('(min-width: 769px) and (orientation: landscape)');
+    expect(sources[1].getAttribute('srcset')).toContain('/images/hero-background-mediterranean-1440.webp 1440w');
+    expect(sources[1].getAttribute('srcset')).toContain('/images/hero-background-mediterranean.webp?v=2 1920w');
+    expect(image?.getAttribute('src')).toBe('/images/hero-background-mediterranean-1440.webp');
+  });
 });
 
 // ── SEO / schema tests ────────────────────────────────────────────────────────

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useMemo } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { Music, Music2, MessageCircle, SendHorizontal, Heart } from 'lucide-react';
+import { Music2, MessageCircle, SendHorizontal, Heart } from 'lucide-react';
 import { FacebookIcon, InstagramIcon, YouTubeIcon } from '../icons/BrandIcons';
 import { ARTIST, CURRENT_YEAR } from '../../data/artistData';
 import { getLocalizedRoute, normalizeLanguage } from '../../config/routes';
@@ -74,10 +74,7 @@ const Footer: React.FC = () => {
 
           {/* 1. Logo, Bio & Social Icons */}
           <div className="lg:col-span-1">
-            <Link to={routes.home} className="flex items-center space-x-2 mb-4 hover:opacity-80 transition-opacity" aria-label={`DJ Zen Eyer - ${t('footer_home')}`}>
-              <div className="h-10 w-10 flex items-center justify-center rounded-full bg-primary/20">
-                <Music size={20} className="text-primary" />
-              </div>
+            <Link to={routes.home} className="inline-flex items-center mb-4 hover:opacity-80 transition-opacity" aria-label={`DJ Zen Eyer - ${t('footer_home')}`}>
               <span className="text-xl font-display font-bold tracking-wide">
                 <span className="text-primary">DJ</span> Zen Eyer
               </span>

--- a/src/index.css
+++ b/src/index.css
@@ -186,6 +186,31 @@
   .badge-error {
     @apply bg-error/20 text-[rgb(var(--color-error-light))] border border-error/30;
   }
+  .badge-mediterranean {
+    @apply inline-flex items-center justify-center gap-2 rounded-full border px-4 py-2 text-xs font-bold uppercase tracking-widest shadow-sm;
+    background: rgba(243, 235, 221, 0.78);
+    border-color: rgba(177, 164, 126, 0.7);
+    color: #6f8f4e;
+    box-shadow: 0 1px 8px rgba(177, 164, 126, 0.15);
+  }
+  .icon-chip-mediterranean {
+    @apply inline-flex items-center justify-center border shadow-sm;
+    background: rgba(243, 235, 221, 0.82);
+    border-color: rgba(177, 164, 126, 0.55);
+    color: #2d728f;
+    box-shadow: 0 1px 8px rgba(177, 164, 126, 0.12);
+  }
+  .btn-mediterranean-soft {
+    @apply inline-flex items-center justify-center gap-2 rounded-xl border px-5 py-2.5 text-sm font-bold shadow-sm transition-all;
+    background: rgba(243, 235, 221, 0.82);
+    border-color: rgba(177, 164, 126, 0.6);
+    color: #2d728f;
+    box-shadow: 0 1px 8px rgba(177, 164, 126, 0.15);
+  }
+  .btn-mediterranean-soft:hover {
+    background: #efe3cc;
+    color: #b85c38;
+  }
 
   /* ========== INPUTS ========== */
   .input {

--- a/src/pages/CodeOfConductPage.tsx
+++ b/src/pages/CodeOfConductPage.tsx
@@ -114,7 +114,7 @@ const CodeOfConductPage: React.FC = () => {
         {/* Background Decorations - Premium Glows */}
         <div className="absolute top-0 left-0 w-full h-full overflow-hidden pointer-events-none -z-0">
           <div className="absolute top-[15%] left-[-10%] w-[40%] h-[40%] bg-primary/10 blur-[120px] rounded-full animate-pulse" />
-          <div className="absolute top-[10%] right-[10%] w-[30%] h-[30%] bg-blue-500/5 blur-[100px] rounded-full" />
+          <div className="absolute top-[10%] right-[10%] w-[30%] h-[30%] bg-[#D9A66A]/10 blur-[100px] rounded-full" />
           <div className="absolute bottom-[25%] right-[-5%] w-[35%] h-[35%] bg-secondary/10 blur-[110px] rounded-full" />
           <div className="absolute bottom-[10%] left-[5%] w-[25%] h-[25%] bg-primary/5 blur-[90px] rounded-full" />
         </div>
@@ -126,8 +126,8 @@ const CodeOfConductPage: React.FC = () => {
             transition={{ duration: 0.6 }}
             className="text-center mb-12"
           >
-            <div className="inline-flex items-center justify-center w-20 h-20 rounded-full bg-primary/20 mb-6">
-              <Heart size={40} className="text-primary" />
+            <div className="icon-chip-mediterranean mb-6 h-20 w-20 rounded-full">
+              <Heart size={40} />
             </div>
             <h1 className="text-4xl md:text-6xl font-black font-display mb-6 text-text leading-tight">
               <Trans i18nKey="conduct_page.title_rich" ns="conduct" components={{ 1: <span className="text-primary" /> }} />
@@ -170,8 +170,8 @@ const CodeOfConductPage: React.FC = () => {
                   transition={{ duration: 0.6, delay: 0.3 + index * 0.1 }}
                   className="card p-6 text-center"
                 >
-                  <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-primary/20 mb-4">
-                    <principle.icon size={32} className="text-primary" />
+                  <div className="icon-chip-mediterranean mb-4 h-16 w-16 rounded-full">
+                    <principle.icon size={32} />
                   </div>
                   <h3 className="text-xl font-bold mb-3">{principle.title}</h3>
                   <p className="text-text/70 mb-4 leading-relaxed">{principle.description}</p>
@@ -232,11 +232,11 @@ const CodeOfConductPage: React.FC = () => {
             initial={FADE_UP_INITIAL}
             animate={FADE_UP_ANIMATE}
             transition={{ duration: 0.6, delay: 1.0 }}
-            className="card p-8 mb-8 bg-gradient-to-br from-primary/10 to-transparent"
+            className="card mb-8 bg-gradient-to-br from-[#F3EBDD]/45 to-transparent p-8"
           >
             <div className="flex items-center gap-3 mb-4">
-              <div className="w-12 h-12 rounded-lg bg-primary/20 flex items-center justify-center">
-                <AlertTriangle size={24} className="text-primary" />
+              <div className="icon-chip-mediterranean h-12 w-12 rounded-lg">
+                <AlertTriangle size={24} />
               </div>
               <h2 className="text-2xl font-display font-bold">{t('conduct_page.reporting')}</h2>
             </div>
@@ -305,7 +305,7 @@ const CodeOfConductPage: React.FC = () => {
                   transition={{ duration: 0.6, delay: 1.2 + index * 0.1 }}
                   className="card p-6 flex items-start gap-4"
                 >
-                  <div className="flex-shrink-0 w-10 h-10 rounded-full bg-primary/20 flex items-center justify-center text-primary font-bold">
+                  <div className="icon-chip-mediterranean h-10 w-10 flex-shrink-0 rounded-full font-bold">
                     {index + 1}
                   </div>
                   <div className="flex-1">
@@ -360,8 +360,8 @@ const CodeOfConductPage: React.FC = () => {
             transition={{ duration: 0.6, delay: 1.6 }}
             className="card p-8 text-center"
           >
-            <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-primary/20 mb-4">
-              <Mail size={32} className="text-primary" />
+            <div className="icon-chip-mediterranean mb-4 h-16 w-16 rounded-full">
+              <Mail size={32} />
             </div>
             <h2 className="text-2xl font-display font-bold mb-4">{t('conduct_page.contact')}</h2>
             <p className="text-text/70 mb-6">

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -69,7 +69,7 @@ const HOME_HERO_IMAGES: Record<SiteTheme, {
   'mediterranean-dusk': {
     defaultSrc: '/images/hero-background-mediterranean-1440.webp',
     mobileSrc: '/images/hero-background-mediterranean-mobile.webp',
-    desktopSrcSet: '/images/hero-background-mediterranean-1440.webp 1440w',
+    desktopSrcSet: '/images/hero-background-mediterranean-1440.webp 1440w, /images/hero-background-mediterranean.webp?v=2 1920w',
     preloadDesktop: '/images/hero-background-mediterranean-1440.webp',
     imageClassName: 'opacity-90',
   },
@@ -210,13 +210,13 @@ const HomePage: React.FC = () => {
           {
             href: heroImages.mobileSrc,
             as: 'image',
-            media: '(max-width: 768px)',
+            media: '(max-width: 768px), (orientation: portrait)',
             fetchPriority: 'high',
           },
           {
             href: heroImages.preloadDesktop,
             as: 'image',
-            media: '(min-width: 769px)',
+            media: '(min-width: 769px) and (orientation: landscape)',
             imageSrcSet: heroImages.desktopSrcSet,
             imageSizes: '100vw',
             fetchPriority: 'high',
@@ -230,12 +230,12 @@ const HomePage: React.FC = () => {
             <div className="w-full h-full">
               <picture>
                 <source
-                  media="(max-width: 768px)"
+                  media="(max-width: 768px), (orientation: portrait)"
                   srcSet={heroImages.mobileSrc}
                   sizes="100vw"
                 />
                 <source
-                  media="(min-width: 769px)"
+                  media="(min-width: 769px) and (orientation: landscape)"
                   srcSet={heroImages.desktopSrcSet}
                   sizes="100vw"
               />

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -67,9 +67,9 @@ const HOME_HERO_IMAGES: Record<SiteTheme, {
   imageClassName: string;
 }> = {
   'mediterranean-dusk': {
-    defaultSrc: '/images/hero-background-mediterranean.webp',
+    defaultSrc: '/images/hero-background-mediterranean-1440.webp',
     mobileSrc: '/images/hero-background-mediterranean-mobile.webp',
-    desktopSrcSet: '/images/hero-background-mediterranean-1440.webp 1440w, /images/hero-background-mediterranean.webp 1920w',
+    desktopSrcSet: '/images/hero-background-mediterranean-1440.webp 1440w',
     preloadDesktop: '/images/hero-background-mediterranean-1440.webp',
     imageClassName: 'opacity-90',
   },

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -463,7 +463,7 @@ const HomePage: React.FC = () => {
       <section className="py-12 bg-background border-t border-border/5">
         <div className="container mx-auto px-4 text-center">
           <div>
-            <p className="text-xs font-semibold text-text/55 mb-4 uppercase tracking-widest">{th('verified')}</p>
+            <p className="text-xs font-semibold text-text/75 mb-4 uppercase tracking-widest">{th('verified')}</p>
             <div className="flex flex-wrap justify-center gap-6 text-sm">
               <a href={safeUrl(`https://musicbrainz.org/artist/${ARTIST.identifiers.musicbrainz}`, '/')} target="_blank" rel="noopener noreferrer" className="text-text/65 hover:text-primary transition-colors flex items-center gap-1">{t('social.musicbrainz')} <ExternalLink size={10} /></a>
               <a href={safeUrl(`https://www.wikidata.org/wiki/${ARTIST.identifiers.wikidata}`, '/')} target="_blank" rel="noopener noreferrer" className="text-text/65 hover:text-primary transition-colors flex items-center gap-1">{t('social.wikidata')} <ExternalLink size={10} /></a>

--- a/src/pages/PressKitPage.tsx
+++ b/src/pages/PressKitPage.tsx
@@ -235,7 +235,7 @@ const PressKitPage: React.FC = () => {
               <div className="flex justify-center">
                 <Breadcrumb items={[{ label: t('nav.presskit') }]} className="mb-6" />
               </div>
-              <div className="inline-flex items-center rounded-full border border-primary/30 bg-primary/10 px-5 py-2 text-xs font-bold uppercase tracking-[0.28em] text-primary">
+              <div className="inline-flex items-center rounded-full border border-[#B1A47E]/70 bg-[#F3EBDD]/75 px-5 py-2 text-xs font-bold uppercase tracking-[0.28em] text-[#6F8F4E] shadow-sm shadow-[#B1A47E]/15">
                 {t('presskit.tag')}
               </div>
               <h1 className="mt-6 text-2xl sm:text-4xl font-black uppercase tracking-tight text-text md:text-6xl">
@@ -340,7 +340,7 @@ const PressKitPage: React.FC = () => {
                   </div>
                   <button
                     onClick={handleCopyBio}
-                    className="flex items-center gap-2 rounded-xl bg-primary/20 px-5 py-2.5 text-sm font-bold text-primary transition-all hover:bg-primary/30 min-h-[44px]"
+                    className="flex min-h-[44px] items-center gap-2 rounded-xl border border-[#B1A47E]/60 bg-[#F3EBDD]/80 px-5 py-2.5 text-sm font-bold text-[#2D728F] shadow-sm shadow-[#B1A47E]/15 transition-all hover:bg-[#EFE3CC] hover:text-[#B85C38]"
                   >
                     {isCopied ? <Check size={16} /> : <Copy size={16} />}
                     {isCopied ? t('presskit.canonical_bio.copied') : t('presskit.canonical_bio.copy_button')}

--- a/src/pages/PressKitPage.tsx
+++ b/src/pages/PressKitPage.tsx
@@ -62,11 +62,11 @@ const MediaKitCard = memo<{
     href={path}
     target="_blank"
     rel="noopener noreferrer"
-    className="group flex h-full flex-col rounded-2xl border border-border/10 bg-surface/50 p-8 backdrop-blur-sm transition-all hover:border-primary hover:bg-surface/80"
+    className="group flex h-full flex-col rounded-2xl border border-border/10 bg-surface/50 p-8 backdrop-blur-sm transition-all hover:border-[#B1A47E]/70 hover:bg-surface/80"
     whileHover={MEDIA_CARD_HOVER}
     transition={{ type: 'spring', stiffness: 300 }}
   >
-    <div className="mx-auto mb-4 inline-block rounded-full bg-primary/10 p-4 text-primary transition-transform group-hover:scale-110">
+    <div className="icon-chip-mediterranean mx-auto mb-4 rounded-full p-4 transition-transform group-hover:scale-110">
       {icon}
     </div>
     <h3 className="mb-2 text-xl font-bold text-text">{title}</h3>
@@ -129,7 +129,7 @@ const PressKitPage: React.FC = () => {
         number: artist.stats.countriesPlayed.toString(),
         label: t('presskit.stats.countries'),
         icon: <Globe size={32} />,
-        color: 'bg-gradient-to-br from-primary/65 to-primary/40'
+        color: 'bg-gradient-to-br from-[#6F8F4E]/65 to-[#B1A47E]/45'
       },
       {
         number: `${new Date().getFullYear() - artist.stats.startingYear}+`,
@@ -158,7 +158,7 @@ const PressKitPage: React.FC = () => {
       {
         title: t('presskit.bio.quickStats.cremosidade'),
         desc: t('presskit.bio.quickStats.cremosidade_desc'),
-        icon: <Star size={20} className="text-primary" />
+        icon: <Star size={20} className="text-[#6F8F4E]" />
       },
       {
         title: t('presskit.bio.quickStats.repertoire'),
@@ -235,7 +235,7 @@ const PressKitPage: React.FC = () => {
               <div className="flex justify-center">
                 <Breadcrumb items={[{ label: t('nav.presskit') }]} className="mb-6" />
               </div>
-              <div className="inline-flex items-center rounded-full border border-[#B1A47E]/70 bg-[#F3EBDD]/75 px-5 py-2 text-xs font-bold uppercase tracking-[0.28em] text-[#6F8F4E] shadow-sm shadow-[#B1A47E]/15">
+              <div className="badge-mediterranean px-5 tracking-[0.28em]">
                 {t('presskit.tag')}
               </div>
               <h1 className="mt-6 text-2xl sm:text-4xl font-black uppercase tracking-tight text-text md:text-6xl">
@@ -287,7 +287,7 @@ const PressKitPage: React.FC = () => {
                     />
                     <div className="absolute inset-x-0 bottom-0 h-1/3 bg-gradient-to-t from-black to-transparent" />
                     <div className="absolute bottom-6 left-6 right-6">
-                      <span className="text-xs font-bold uppercase tracking-widest text-primary">{t('presskit.bio.photo_label', { year: ARTIST.titles.year })}</span>
+                      <span className="text-xs font-bold uppercase tracking-widest text-[#6F8F4E]">{t('presskit.bio.photo_label', { year: ARTIST.titles.year })}</span>
                       <h3 className="text-2xl font-bold">{t('presskit.bio.role')}</h3>
                     </div>
                   </motion.div>
@@ -295,7 +295,7 @@ const PressKitPage: React.FC = () => {
 
                 <div>
                   <h2 className="mb-6 sm:mb-8 flex items-center gap-3 sm:gap-4 text-3xl sm:text-5xl font-black">
-                    <Music2 className="text-primary w-8 h-8 sm:w-12 sm:h-12" />
+                    <Music2 className="h-8 w-8 text-[#6F8F4E] sm:h-12 sm:w-12" />
                     {t('presskit.bio.title')}
                   </h2>
 
@@ -308,7 +308,7 @@ const PressKitPage: React.FC = () => {
                   <div className="mt-12 grid grid-cols-2 gap-6 rounded-3xl border border-border/5 bg-surface/50 p-4 sm:p-8">
                     {quickStatsItems.map((item, index) => (
                       <div key={index} className="flex items-start gap-3">
-                        <div className="rounded-xl bg-primary/10 p-3">{item.icon}</div>
+                        <div className="icon-chip-mediterranean rounded-xl p-3">{item.icon}</div>
                         <div>
                           <div className="text-base font-bold leading-tight text-text">{item.title}</div>
                           <div className="text-sm text-text/50">{item.desc}</div>
@@ -340,7 +340,7 @@ const PressKitPage: React.FC = () => {
                   </div>
                   <button
                     onClick={handleCopyBio}
-                    className="flex min-h-[44px] items-center gap-2 rounded-xl border border-[#B1A47E]/60 bg-[#F3EBDD]/80 px-5 py-2.5 text-sm font-bold text-[#2D728F] shadow-sm shadow-[#B1A47E]/15 transition-all hover:bg-[#EFE3CC] hover:text-[#B85C38]"
+                    className="btn-mediterranean-soft min-h-[44px]"
                   >
                     {isCopied ? <Check size={16} /> : <Copy size={16} />}
                     {isCopied ? t('presskit.canonical_bio.copied') : t('presskit.canonical_bio.copy_button')}
@@ -467,7 +467,7 @@ const PressKitPage: React.FC = () => {
               viewport={{ once: true }}
               className="mx-auto max-w-4xl text-center"
             >
-              <div className="rounded-[2rem] sm:rounded-[3rem] border border-border/10 bg-gradient-to-br from-primary/10 via-surface/50 to-accent/10 p-6 sm:p-16 shadow-3xl">
+              <div className="rounded-[2rem] border border-[#B1A47E]/30 bg-gradient-to-br from-[#F3EBDD]/70 via-surface/50 to-accent/10 p-6 shadow-3xl sm:rounded-[3rem] sm:p-16">
                 <h2 className="mb-6 sm:mb-8 text-3xl sm:text-5xl font-black uppercase tracking-tighter md:text-6xl">{t('presskit.contact.title')}</h2>
                 <p className="mx-auto mb-8 sm:mb-12 max-w-2xl text-base sm:text-xl leading-relaxed text-text/60">{t('presskit.contact.subtitle')}</p>
 
@@ -488,8 +488,8 @@ const PressKitPage: React.FC = () => {
                 <div className="mt-8 sm:mt-16 border-t border-border/10 pt-6 sm:pt-10">
                   <div className="mb-12 grid gap-10 text-left md:grid-cols-3">
                     <div className="flex items-start gap-4">
-                      <div className="rounded-lg bg-primary/20 p-2">
-                        <MapPin className="text-primary" size={24} />
+                      <div className="icon-chip-mediterranean rounded-lg p-2">
+                        <MapPin size={24} />
                       </div>
                       <div>
                         <div className="mb-1 text-xs font-bold uppercase tracking-wider text-text">{t('presskit.contact.base')}</div>
@@ -497,8 +497,8 @@ const PressKitPage: React.FC = () => {
                       </div>
                     </div>
                     <div className="flex items-start gap-4">
-                      <div className="rounded-lg bg-primary/20 p-2">
-                        <Calendar className="text-primary" size={24} />
+                      <div className="icon-chip-mediterranean rounded-lg p-2">
+                        <Calendar size={24} />
                       </div>
                       <div>
                         <div className="mb-1 text-xs font-bold uppercase tracking-wider text-text">{t('presskit.contact.availability')}</div>
@@ -506,8 +506,8 @@ const PressKitPage: React.FC = () => {
                       </div>
                     </div>
                     <div className="flex items-start gap-4">
-                      <div className="rounded-lg bg-primary/20 p-2">
-                        <Globe className="text-primary" size={24} />
+                      <div className="icon-chip-mediterranean rounded-lg p-2">
+                        <Globe size={24} />
                       </div>
                       <div>
                         <div className="mb-1 text-xs font-bold uppercase tracking-wider text-text">{t('presskit.contact.booking_label')}</div>

--- a/src/pages/ShopPage.tsx
+++ b/src/pages/ShopPage.tsx
@@ -603,17 +603,17 @@ const ShopPage: React.FC = () => {
       <section className="px-6 md:px-12 lg:px-20 py-20 bg-background border-t border-border/5">
         <div className="grid grid-cols-2 lg:grid-cols-4 gap-8 md:gap-12">
           {[
-            { icon: Truck, title: t('shop.benefits.instant_delivery'), desc: t('shop.benefits.instant_delivery_desc') },
-            { icon: Shield, title: t('shop.benefits.secure_payment'), desc: t('shop.benefits.secure_payment_desc') },
-            { icon: Gift, title: t('shop.benefits.tribe_perks'), desc: t('shop.benefits.tribe_perks_desc') },
-            { icon: Zap, title: t('shop.benefits.vip_support'), desc: t('shop.benefits.vip_support_desc') },
+            { icon: Truck, title: t('shop.benefits.instant_delivery'), desc: t('shop.benefits.instant_delivery_desc'), color: 'text-[#2D728F]', bg: 'bg-[#2D728F]/12', border: 'border-[#2D728F]/25' },
+            { icon: Shield, title: t('shop.benefits.secure_payment'), desc: t('shop.benefits.secure_payment_desc'), color: 'text-[#6F8F4E]', bg: 'bg-[#6F8F4E]/12', border: 'border-[#6F8F4E]/25' },
+            { icon: Gift, title: t('shop.benefits.tribe_perks'), desc: t('shop.benefits.tribe_perks_desc'), color: 'text-[#C4863A]', bg: 'bg-[#C4863A]/14', border: 'border-[#C4863A]/25' },
+            { icon: Zap, title: t('shop.benefits.vip_support'), desc: t('shop.benefits.vip_support_desc'), color: 'text-[#B85C38]', bg: 'bg-[#B85C38]/12', border: 'border-[#B85C38]/25' },
           ].map((item, idx) => (
-            <div key={idx} className="flex flex-col space-y-3 group cursor-default">
-              <div className="text-primary group-hover:scale-110 transition-transform duration-300 w-fit">
+            <div key={idx} className="group cursor-default rounded-2xl border border-border/10 bg-surface/45 p-5 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-border/25 hover:bg-surface/70 hover:shadow-xl">
+              <div className={`mb-5 flex h-14 w-14 items-center justify-center rounded-2xl border ${item.border} ${item.bg} ${item.color} shadow-sm transition-transform duration-300 group-hover:scale-105`}>
                 <item.icon size={32} />
               </div>
-              <h3 className="font-bold text-lg md:text-xl text-text group-hover:text-primary transition-colors">{item.title}</h3>
-              <p className="text-sm text-text/40 leading-relaxed">{item.desc}</p>
+              <h3 className="font-bold text-lg md:text-xl text-text transition-colors group-hover:text-primary">{item.title}</h3>
+              <p className="mt-3 text-sm leading-relaxed text-text/60">{item.desc}</p>
             </div>
           ))}
         </div>

--- a/src/pages/ShopPage.tsx
+++ b/src/pages/ShopPage.tsx
@@ -91,7 +91,7 @@ const ShopHero = memo(({ product, onAddToCart, isAddingToCart, getProductPath }:
           className="max-w-3xl space-y-4 md:space-y-6"
         >
           <div className="flex items-center gap-3">
-            <div className="h-6 w-1 bg-primary rounded-full shadow-[0_0_10px_rgba(13,150,255,0.5)]" />
+            <div className="h-6 w-1 rounded-full bg-[#6F8F4E] shadow-[0_0_10px_rgba(111,143,78,0.35)]" />
             <span className="text-text font-black text-xs md:text-sm uppercase flex items-center gap-2 bg-background/35 border border-border/20 rounded-full px-3 py-1 backdrop-blur-sm">
               {t('shop.artist_badge')} <span className="text-text/60">{t('badge_featured')}</span>
             </span>

--- a/src/pages/SupportArtistPage.tsx
+++ b/src/pages/SupportArtistPage.tsx
@@ -40,7 +40,7 @@ const CurrencyAccordion = memo(({
       aria-expanded={isOpen}
     >
       <div className="flex items-center gap-4">
-        <div className={`p-3 rounded-xl bg-gradient-to-br from-primary/20 to-accent/20 text-primary group-hover:scale-110 transition-transform`}>
+        <div className="icon-chip-mediterranean rounded-xl p-3 transition-transform group-hover:scale-110">
           <Icon size={28} />
         </div>
         <h3 className="text-xl md:text-2xl font-black text-text group-hover:text-primary transition-colors font-display uppercase tracking-tighter">
@@ -52,7 +52,7 @@ const CurrencyAccordion = memo(({
         transition={{ duration: 0.3 }}
         className="flex-shrink-0"
       >
-        <ChevronDown className="text-primary/70" size={24} />
+        <ChevronDown className="text-[#6F8F4E]" size={24} />
       </motion.div>
     </button>
 
@@ -135,7 +135,7 @@ const SupportArtistPage: React.FC = () => {
 
       <div className="container mx-auto px-4 max-w-5xl">
         <motion.div initial={{ opacity: 0, y: -20 }} animate={{ opacity: 1, y: 0 }} className="text-center mb-10 sm:mb-16">
-          <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-primary/10 text-primary border border-primary/20 mb-8 text-sm font-bold tracking-widest uppercase">
+          <div className="badge-mediterranean mb-8 text-sm">
             <Heart size={16} /> {t('common.footer_support_artist')}
           </div>
           <h1 className="text-3xl sm:text-5xl md:text-7xl font-black font-display mb-6 sm:mb-8 text-text tracking-tighter uppercase leading-[0.9]">
@@ -152,7 +152,7 @@ const SupportArtistPage: React.FC = () => {
           <div className="space-y-5">
             {supportActions.map((action) => (
               <div key={action.title} className="flex gap-4 rounded-xl border border-border/5 bg-background/15 p-4">
-                <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-2xl" aria-hidden="true">
+                <div className="icon-chip-mediterranean flex h-11 w-11 shrink-0 rounded-xl text-2xl" aria-hidden="true">
                   {action.emoji}
                 </div>
                 <div className="min-w-0">
@@ -214,8 +214,8 @@ const SupportArtistPage: React.FC = () => {
               onToggle={() => handleToggle('BRL')}
             >
               <div className="space-y-6">
-                <div className="p-6 bg-primary/5 rounded-2xl border border-primary/20 shadow-inner">
-                  <h4 className="flex items-center gap-2 font-bold mb-4 text-primary uppercase text-sm tracking-widest">
+                <div className="rounded-2xl border border-[#B1A47E]/35 bg-[#F3EBDD]/30 p-6 shadow-inner">
+                  <h4 className="mb-4 flex items-center gap-2 text-sm font-bold uppercase tracking-widest text-[#6F8F4E]">
                     <Building2 size={18} /> {t('support.inter.brazil')}
                   </h4>
                   <div className="grid md:grid-cols-2 gap-4">
@@ -288,8 +288,8 @@ const SupportArtistPage: React.FC = () => {
                   </a>
                 </div>
 
-                <div className="p-6 bg-primary/5 rounded-2xl border border-primary/20">
-                  <h4 className="flex items-center gap-2 font-bold mb-4 text-primary uppercase text-sm tracking-widest">
+                <div className="rounded-2xl border border-[#B1A47E]/35 bg-[#F3EBDD]/30 p-6">
+                  <h4 className="mb-4 flex items-center gap-2 text-sm font-bold uppercase tracking-widest text-[#6F8F4E]">
                     <CreditCard size={18} /> {t('support.payment.paypal_title')}
                   </h4>
                   <div className="grid gap-4 sm:grid-cols-2">
@@ -317,7 +317,7 @@ const SupportArtistPage: React.FC = () => {
         </div>
 
         <motion.div initial={{ opacity: 0 }} whileInView={{ opacity: 1 }} transition={{ delay: 0.5 }} className="mt-20 text-center">
-          <Sparkles className="mx-auto mb-4 text-primary" size={24} />
+          <Sparkles className="mx-auto mb-4 text-[#6F8F4E]" size={24} />
           <p className="mx-auto max-w-3xl text-lg leading-relaxed text-text/70 sm:text-2xl">
             {t('support.thankYou')}
           </p>

--- a/src/pages/TermsPage.tsx
+++ b/src/pages/TermsPage.tsx
@@ -105,8 +105,8 @@ const TermsPage: React.FC = () => {
         <div className="container mx-auto px-4 max-w-4xl">
           {/* Header */}
           <div className="text-center mb-12 motion-safe:animate-fade-up">
-            <div className="inline-flex items-center justify-center w-20 h-20 rounded-full bg-primary/20 mb-6">
-              <FileText size={40} className="text-primary" />
+            <div className="icon-chip-mediterranean mb-6 h-20 w-20 rounded-full">
+              <FileText size={40} />
             </div>
             <h1 className="text-4xl md:text-5xl font-display font-bold mb-4">
               {t('legal.terms_page.title').split(' ')[0]} <span className="text-primary">{t('legal.terms_page.title').split(' ').slice(1).join(' ')}</span>
@@ -130,8 +130,8 @@ const TermsPage: React.FC = () => {
           {sections.map((section, index) => (
             <div key={index} className="card p-8 mb-6 motion-safe:animate-fade-up">
               <div className="flex items-start gap-4 mb-4">
-                <div className="flex-shrink-0 w-12 h-12 rounded-lg bg-primary/20 flex items-center justify-center">
-                  <section.icon size={24} className="text-primary" />
+                <div className="icon-chip-mediterranean h-12 w-12 flex-shrink-0 rounded-lg">
+                  <section.icon size={24} />
                 </div>
                 <h2 className="text-2xl font-display font-bold mt-1">{`${index + 1}. ${section.title}`}</h2>
               </div>
@@ -174,7 +174,7 @@ const TermsPage: React.FC = () => {
           </div>
 
           {/* Contact */}
-          <div className="card p-8 text-center bg-gradient-to-br from-primary/10 to-transparent motion-safe:animate-fade-up">
+          <div className="card bg-gradient-to-br from-[#F3EBDD]/45 to-transparent p-8 text-center motion-safe:animate-fade-up">
             <h2 className="text-2xl font-display font-bold mb-4">{t('legal.terms_page.questions')}</h2>
             <p className="text-text/70 mb-6">
               {t('legal.terms_page.questions_desc')}

--- a/src/pages/VerifiedFactsPage.tsx
+++ b/src/pages/VerifiedFactsPage.tsx
@@ -82,7 +82,7 @@ const VerifiedFactsPage: React.FC = () => {
           <Breadcrumb items={[{ label: t('verified_facts.nav_label') }]} className="mb-10" />
 
           <header className="mb-12 text-center">
-            <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-4 py-2 text-xs font-bold uppercase tracking-widest text-primary">
+            <div className="badge-mediterranean mb-6">
               <ShieldCheck size={14} />
               {t('verified_facts.badge')}
             </div>

--- a/src/pages/ZenTribePage.tsx
+++ b/src/pages/ZenTribePage.tsx
@@ -346,7 +346,7 @@ const ZenTribePage: React.FC = () => {
               viewport={{ once: true }}
               transition={{ duration: 0.5 }}
             >
-              <div className="mb-6 inline-flex items-center rounded-full border border-primary/30 bg-primary/10 px-4 py-2 text-xs font-bold uppercase tracking-[0.22em] text-primary">
+              <div className="mb-6 inline-flex items-center rounded-full border border-[#B1A47E]/70 bg-[#F3EBDD]/75 px-4 py-2 text-xs font-bold uppercase tracking-[0.22em] text-[#6F8F4E] shadow-sm shadow-[#B1A47E]/15">
                 {t('zenTribe.philosophy.badge')}
               </div>
               <h2 className="mb-6 text-2xl sm:text-4xl font-black font-display text-text">

--- a/src/pages/ZenTribePage.tsx
+++ b/src/pages/ZenTribePage.tsx
@@ -303,7 +303,7 @@ const ZenTribePage: React.FC = () => {
                 <Breadcrumb items={[{ label: t('nav.tribe') }]} className="mb-6" />
               </div>
               <div className="inline-block mb-4">
-                <div className="bg-primary/20 border border-primary/50 rounded-full px-6 py-2 text-primary font-bold uppercase tracking-wider text-sm">
+                <div className="rounded-full border border-[#B1A47E]/70 bg-[#F3EBDD]/75 px-6 py-2 text-sm font-bold uppercase tracking-wider text-[#6F8F4E] shadow-sm shadow-[#B1A47E]/15">
                   {t('zenTribe.badge')}
                 </div>
               </div>

--- a/src/pages/ZoukFestivalsPage.tsx
+++ b/src/pages/ZoukFestivalsPage.tsx
@@ -114,7 +114,7 @@ const ZoukFestivalsPage: React.FC = () => {
             animate={prefersReducedMotion ? undefined : 'visible'}
             className="mb-14"
           >
-            <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-4 py-2 text-xs font-bold uppercase tracking-widest text-primary">
+            <div className="badge-mediterranean mb-4">
               <Globe size={14} />
               {t('hub_pages.zouk_festivals.breadcrumb')}
             </div>


### PR DESCRIPTION
## Summary
- improve the Home verified-profiles contrast
- remove the decorative music-note icon from the footer brand
- strengthen Shop benefit cards with Mediterranean accent colors
- align badges, icon chips, support panels, legal pages, Zen Tribe, and Press Kit with the Mediterranean visual language
- restore the Home hero image and select portrait/landscape sources by viewport orientation
- keep 1440px as a reliable fallback and use a versioned 1920px source for wide screens
- add a Home hero source regression test

## Type of Change
- [x] Bug fix
- [x] Accessibility improvement
- [x] Visual refinement
- [x] Responsive behavior
- [ ] Breaking change

## Impact Area
- Home hero and authority links
- Footer
- Shop
- Press Kit
- Zen Tribe and public information/legal/support pages
- Shared Mediterranean UI classes

## Testing
- [x] `npm run build`
- [x] `npx vitest run src/__tests__/pages/HomePage.test.tsx` (17/17)
- [x] UTF-8 content check
- [x] GitHub Contract Tests
- [x] GitHub Quality Gate
- [x] GitHub test workflow

## Review Status
- no unresolved review threads
- CodeRabbit approved
- Gemini and Charlie reported no actionable feedback
- PR is mergeable and up to date with `main`

## Notes for Reviewers
The visual changes preserve existing behavior and reuse three shared Mediterranean classes. Functional/action colors remain unchanged where they communicate state or primary actions.

## Final Checklist
- [x] No secrets or environment files
- [x] No route/auth/schema contract changes
- [x] No generated lockfile or plan artifact
- [x] Scope matches the final PR title and description
