### PR TITLE
docs: add WordPress plugin review skill

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -40,6 +40,7 @@ O objetivo e reduzir dispersao sem apagar especializacao util.
 | `wp-project-triage` | Inspecao deterministica de estrutura WP | Manter, usar quando estrutura mudar |
 | `wp-headless` | Arquitetura WordPress headless + SPA | Manter |
 | `wp-plugin-development` | Desenvolvimento de plugins | Manter |
+| `wp-plugin-code-reviewer` | Review de PHP em plugins WordPress com WPCS/security | Manter como skill fina de review |
 | `wp-rest-api` | Endpoints REST | Manter |
 | `wp-performance` | Performance backend/WordPress | Manter |
 | `wp-wpcli-and-ops` | Operacoes WP-CLI/SSH/cache | Manter com cuidado em producao |

--- a/.agents/skills/backend-security-coder/SKILL.md
+++ b/.agents/skills/backend-security-coder/SKILL.md
@@ -21,6 +21,8 @@ Apply secure backend coding practices to the real project stack:
 
 This skill is for secure implementation and review. For CodeQL-specific findings, use `codeql-security` first. For REST endpoint design, use `wp-rest-api`. For auth architecture, use `auth-implementation-patterns` + `wp-headless`.
 
+For WordPress plugin code review, use `wp-plugin-code-reviewer` first and this skill as its security checklist. WordPress Coding Standards are the primary style authority for plugin PHP in this project.
+
 ## Project-specific security posture
 
 Do not treat intentional public product surfaces as leaks:
@@ -80,6 +82,7 @@ Use this skill when:
 - Always use `$wpdb->prepare()`.
 - Prefer WordPress APIs over raw SQL.
 - For WooCommerce HPOS, use `wc_get_orders()`, not SQL over `wp_posts`.
+- GamiPress helpers such as `gamipress_get_rank_types()` return associative arrays. Use `array_values()` or `reset()` for the first element, never `$array[0]`.
 
 ### REST API
 

--- a/.agents/skills/wordpress-router/SKILL.md
+++ b/.agents/skills/wordpress-router/SKILL.md
@@ -50,6 +50,7 @@ Read the detailed tree when necessary at `.agents/skills/wordpress-router/refere
 | If the task involves... | Use skill/context |
 |---|---|
 | Plugins (`zen-bit`, `zengame`, `zeneyer-auth`, `zen-seo-lite`, `zen-mailer`) | `wp-plugin-development` + `backend-security-coder` |
+| Review of WordPress plugin PHP, PRs, diffs or snippets | `wp-plugin-code-reviewer` |
 | REST API routes (`zen-bit/v2`, `zengame/v1`, `zeneyer-auth/v1`, `zen-seo/v1`, `djzeneyer/v1`) | `wp-rest-api` |
 | Headless architecture, CORS, JWT, React SPA integration | `wp-headless` |
 | Performance issues, N+1, transients, APCu, LiteSpeed cache | `wp-performance` |
@@ -71,6 +72,7 @@ Ask: where is the change happening?
 
 ```text
 plugin PHP code?        -> wp-plugin-development
+plugin PHP review?      -> wp-plugin-code-reviewer
 REST endpoint PHP?      -> wp-rest-api
 React/TS frontend?      -> react-best-practices / typescript-pro
 headless arch decision? -> wp-headless

--- a/.agents/skills/wordpress-router/references/decision-tree.md
+++ b/.agents/skills/wordpress-router/references/decision-tree.md
@@ -18,6 +18,7 @@ Não é:
 | Intent keywords | Skill |
 |-----------------|-------|
 | Plugin bug, plugin feature, hooks, `add_action`, `add_filter` | `wp-plugin-development` |
+| Plugin code review, PR review, PHPCS/WPCS, PHP snippet review | `wp-plugin-code-reviewer` |
 | REST route, `register_rest_route`, `permission_callback`, 401/403/404 | `wp-rest-api` |
 | Slow endpoint, N+1, transient, cache, TTFB | `wp-performance` |
 | `wp` command, SSH, cache flush, DB export, rewrite | `wp-wpcli-and-ops` |

--- a/.agents/skills/wp-plugin-code-reviewer/SKILL.md
+++ b/.agents/skills/wp-plugin-code-reviewer/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: wp-plugin-code-reviewer
+description: "Review WordPress plugin PHP code for djzeneyer.com. Use when asked to review PRs, diffs, files or snippets touching plugins/, WordPress PHP, hooks, REST routes, settings, admin screens, SQL, sanitization, escaping, capabilities, nonces, PHPCS/WPCS, PHPStan or plugin security."
+risk: safe
+source: "project-local"
+date_added: "2026-06-30"
+compatibility: "WordPress-first review for custom plugins on PHP 8.3+."
+---
+
+# WP Plugin Code Reviewer
+
+## Purpose
+
+Review custom WordPress plugin PHP with WordPress Coding Standards as the primary style authority. PSR-1/PSR-12 are secondary references only where they do not conflict with WordPress conventions.
+
+Use alongside:
+
+- `wp-plugin-development` for plugin ownership, lifecycle and architecture.
+- `backend-security-coder` for sanitization, escaping, SQL, capabilities and public/private boundaries.
+- `wp-rest-api` when `register_rest_route`, REST args or permissions are touched.
+- `codeql-security` before changing sanitization, HTML stripping or risky sink/source patterns.
+- `wp-phpstan` when static analysis config or PHPStan findings are involved.
+
+## Review Stance
+
+Lead with actionable findings, ordered by severity. Do not summarize first. Each finding should include file/line, risk, and a concrete fix direction.
+
+Severity guide:
+
+- **P0**: exploitable security issue, fatal error, data loss, broken auth/permissions.
+- **P1**: likely production regression, missing REST permission, unsafe SQL, persistent XSS, broken plugin activation.
+- **P2**: correctness, maintainability, WPCS violations with real impact, missing escaping on low-risk output.
+- **P3**: style/naming/documentation issues that are worth fixing but not blockers.
+
+## WordPress-First Checklist
+
+### Plugin structure
+
+- Main plugin file has a valid plugin header and no accidental output.
+- Direct access is blocked where appropriate: `defined('ABSPATH') || exit;`.
+- Functions, hooks, options, transients, nonces and cache keys are project-prefixed.
+- Activation/deactivation hooks are registered at top level and do not depend on late hooks.
+- Existing plugin ownership is respected:
+  - `zen-bit`: events, event cache, MusicEvent schema.
+  - `zengame`: gamification, points, ranks, achievements.
+  - `zeneyer-auth`: JWT, Google OAuth, profile, newsletter, orders.
+  - `zen-seo-lite`: metadata, schema, sitemap, release metadata.
+  - `zen-mailer`: mail support/health.
+
+### WordPress Coding Standards
+
+- Prefer WPCS over PSR-12 when indentation or naming conflicts: tabs for indentation, spaces for alignment.
+- Use Yoda conditions where project style expects them.
+- Use snake_case for WordPress-style functions and methods when matching existing plugin style; do not force camelCase into WordPress plugin code.
+- Use class/file naming consistent with the existing plugin rather than introducing a parallel convention.
+- Keep text domains aligned with the plugin.
+
+### Security and data handling
+
+- Validate/sanitize input early; escape output late.
+- Use `wp_unslash()` before sanitizing superglobals.
+- Use context-specific escaping: `esc_html`, `esc_attr`, `esc_url`, `esc_textarea`, `wp_kses`.
+- Admin actions need capability checks and nonces; nonce-only is not authorization.
+- REST routes need explicit `permission_callback`.
+- Public REST endpoints using `__return_true` must expose intentionally public data only.
+- Do not mark artist-owned payment/support data as a leak; it is public by product design.
+- Never expose secrets, tokens, SMTP/API keys, reset tokens, private customer/order data or third-party payment data.
+
+### SQL and WordPress APIs
+
+- Prefer WordPress, WooCommerce and GamiPress APIs over SQL.
+- Raw SQL must use `$wpdb->prepare()` unless there are no placeholders.
+- WooCommerce orders must use `wc_get_orders()` and CRUD APIs, not SQL over `wp_posts`.
+- GamiPress type helpers return associative arrays keyed by slug. Use `array_values($array)[0]` or `reset($array)`, never `$array[0]`.
+- For post/user meta loops, prefer cache priming APIs before considering custom SQL.
+
+### REST and headless behavior
+
+- REST callbacks should return arrays/objects, `WP_REST_Response`, or `WP_Error` with explicit status.
+- Use route `args` schemas for validation/sanitization where practical.
+- Keep authenticated endpoints aligned with `zeneyer-auth` JWT/user patterns.
+- Do not make intentional public AI/search resources private without explicit human request.
+
+## Output Format
+
+```text
+Findings
+- [P1] Title - file:line
+  Why it matters:
+  Suggested fix:
+
+Open questions
+- ...
+
+Validation
+- Ran:
+- Still needed:
+```
+
+If there are no findings, say so clearly and list residual risks or checks not run.
+
+## Verification Commands
+
+Use what exists in the repo; do not invent mandatory tooling.
+
+```powershell
+# PHP syntax check with bundled PHP if available.
+& "$env:USERPROFILE\.codex\tools\php-8.4.21\php.exe" -l path\to\file.php
+
+# Project checks when relevant.
+npm run utf8:check
+```
+
+When PHPCS/PHPStan are configured for the touched plugin, run the local configured command. If not configured, report that limitation instead of pretending compliance was machine-verified.

--- a/.agents/skills/wp-plugin-code-reviewer/SKILL.md
+++ b/.agents/skills/wp-plugin-code-reviewer/SKILL.md
@@ -25,6 +25,8 @@ Use alongside:
 
 Lead with actionable findings, ordered by severity. Do not summarize first. Each finding should include file/line, risk, and a concrete fix direction.
 
+Verify every automated or checklist finding against the actual runtime semantics before recommending a change. Do not manufacture a code change merely to satisfy a scanner or style rule; a defensive-looking rewrite can still introduce a regression.
+
 Severity guide:
 
 - **P0**: exploitable security issue, fatal error, data loss, broken auth/permissions.
@@ -58,7 +60,10 @@ Severity guide:
 ### Security and data handling
 
 - Validate/sanitize input early; escape output late.
-- Use `wp_unslash()` before sanitizing superglobals.
+- Use `wp_unslash()` before sanitizing values read from request superglobals.
+- Presence checks such as `isset($_POST['submit'])` do not read the value and do not require unslashing or sanitization. Preserve presence semantics for valueless submit buttons.
+- Validate input shape before sanitizing. Functions such as `sanitize_text_field()` can throw a `TypeError` when given arrays on PHP 8+.
+- Do not sanitize PHP-generated `$_FILES['tmp_name']` paths. Check the upload error and validate with `is_uploaded_file()` before reading, or use the appropriate WordPress upload API.
 - Use context-specific escaping: `esc_html`, `esc_attr`, `esc_url`, `esc_textarea`, `wp_kses`.
 - Admin actions need capability checks and nonces; nonce-only is not authorization.
 - REST routes need explicit `permission_callback`.
@@ -103,12 +108,12 @@ If there are no findings, say so clearly and list residual risks or checks not r
 
 Use what exists in the repo; do not invent mandatory tooling.
 
-```powershell
-# PHP syntax check with bundled PHP if available.
-& "$env:USERPROFILE\.codex\tools\php-8.4.21\php.exe" -l path\to\file.php
+```shell
+# Use PHP from PATH or the PHP executable configured by the project toolchain.
+php -l path/to/file.php
 
 # Project checks when relevant.
 npm run utf8:check
 ```
 
-When PHPCS/PHPStan are configured for the touched plugin, run the local configured command. If not configured, report that limitation instead of pretending compliance was machine-verified.
+If `php` is not on PATH, use the PHP executable exposed by the existing project or workspace toolchain without hardcoding a user-specific path in the skill. When PHPCS/PHPStan are configured for the touched plugin, run the local configured command. If tooling or dependencies are unavailable, report that limitation instead of pretending compliance was machine-verified.

--- a/.agents/skills/wp-plugin-development/SKILL.md
+++ b/.agents/skills/wp-plugin-development/SKILL.md
@@ -70,6 +70,16 @@ Guidelines:
 - Do not introduce a new architecture style into an existing plugin without need.
 - Preserve plugin headers and activation hooks.
 
+### 1.5) WordPress coding standards priority
+
+For plugin PHP, WordPress Coding Standards are the primary style authority for this project. PSR-1/PSR-12 can inform readability, but do not override WordPress conventions when they conflict.
+
+- Prefer tabs for indentation and spaces for alignment, matching WPCS.
+- Preserve existing plugin naming style instead of forcing generic PSR naming.
+- Use WordPress-style prefixes for functions, hooks, options, transients, nonces and cache keys.
+- Use translation functions with the correct plugin text domain for visible strings.
+- Treat PHPCS/WPCS findings as actionable when tooling is configured or the violation is clear from the diff.
+
 ### 2) Project-specific ownership
 
 | Domain | Preferred owner |
@@ -145,6 +155,16 @@ echo esc_attr($value);
 echo esc_url($url);
 echo wp_kses_post($html);
 ```
+
+### 5.5) Plugin review mode
+
+When the user asks for review of WordPress plugin PHP, use `wp-plugin-code-reviewer` first. In that mode:
+
+- Lead with findings by severity and file/line.
+- Check WPCS before PSR style preferences.
+- Check capabilities, nonces, REST permissions, sanitization, escaping and SQL safety.
+- Apply project laws: GamiPress arrays are associative; WooCommerce orders use CRUD APIs; artist-owned support/payment data can be public by design.
+- Include validation commands run and commands still needed.
 
 ### 6) Data storage and cache
 


### PR DESCRIPTION
## Summary
- add `wp-plugin-code-reviewer` as a focused WordPress-first PHP plugin review skill
- update WP plugin/security/router skills to route plugin review through WPCS-first checks
- document the new review skill in `.agents/skills/README.md`

## Validation
- local skill frontmatter validation passed
- `npm run utf8:check`
- `git diff --check`

## Notes
- WPCS/WordPress standards are treated as primary for plugin PHP; PSR-1/PSR-12 are secondary where they do not conflict.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Novidades**
  * Adicionamos uma nova opção para revisão de código PHP de plugins WordPress, com orientações mais claras para análises de segurança, estilo e boas práticas.
  * O roteamento de solicitações foi refinado para direcionar melhor casos de revisão de plugins WordPress.
* **Documentação**
  * Atualizamos as diretrizes de governança e manutenção para incluir um passo extra ao registrar mudanças relevantes.
  * Reforçamos referências e padrões recomendados para revisão, incluindo priorização de padrões do WordPress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->