### PR TITLE
fix: address WordPress plugin audit findings

### DIFF
--- a/plugins/zen-seo-lite/admin/class-zen-seo-admin.php
+++ b/plugins/zen-seo-lite/admin/class-zen-seo-admin.php
@@ -566,7 +566,10 @@ class Zen_SEO_Admin
         }
 
         // Handle cache clear action
-        if (isset($_POST['zen_seo_clear_cache']) && \check_admin_referer('zen_seo_clear_cache')) {
+        $clear_cache_requested = isset($_POST['zen_seo_clear_cache'])
+            ? (bool) \sanitize_text_field(\wp_unslash($_POST['zen_seo_clear_cache']))
+            : false;
+        if ($clear_cache_requested && \check_admin_referer('zen_seo_clear_cache')) {
             $cleared = Zen_SEO_Cache::clear_all();
             echo '<div class="notice notice-success"><p>'
                 . \sprintf(__('Cleared %d cache entries.', 'zen-seo'), $cleared)
@@ -681,12 +684,16 @@ class Zen_SEO_Admin
      */
     public function handle_export_import()
     {
-        if (!isset($_GET['page']) || $_GET['page'] !== 'zen-seo-tools') {
+        $page = isset($_GET['page']) ? \sanitize_key(\wp_unslash($_GET['page'])) : '';
+        if ('zen-seo-tools' !== $page) {
             return;
         }
 
         // 1. Handle Export
-        if (isset($_POST['zen_seo_export']) && \check_admin_referer('zen_seo_export_action')) {
+        $export_requested = isset($_POST['zen_seo_export'])
+            ? (bool) \sanitize_text_field(\wp_unslash($_POST['zen_seo_export']))
+            : false;
+        if ($export_requested && \check_admin_referer('zen_seo_export_action')) {
             $settings = Zen_SEO_Helpers::get_global_settings();
             $filename = 'zen-seo-backup-' . \date('Y-m-d') . '.json';
             
@@ -700,13 +707,19 @@ class Zen_SEO_Admin
         }
 
         // 2. Handle Import
-        if (isset($_POST['zen_seo_import']) && \check_admin_referer('zen_seo_import_action')) {
-            if (empty($_FILES['import_file']['tmp_name'])) {
+        $import_requested = isset($_POST['zen_seo_import'])
+            ? (bool) \sanitize_text_field(\wp_unslash($_POST['zen_seo_import']))
+            : false;
+        if ($import_requested && \check_admin_referer('zen_seo_import_action')) {
+            $import_file = isset($_FILES['import_file']['tmp_name'])
+                ? \sanitize_text_field(\wp_unslash($_FILES['import_file']['tmp_name']))
+                : '';
+            if (empty($import_file)) {
                 \add_settings_error('zen_seo_tools', 'no_file', __('Please select a file to import.', 'zen-seo'), 'error');
                 return;
             }
 
-            $file_content = \file_get_contents($_FILES['import_file']['tmp_name']);
+            $file_content = \file_get_contents($import_file);
             $data = \json_decode($file_content, true);
 
             if (!$data || !\is_array($data)) {

--- a/plugins/zen-seo-lite/admin/class-zen-seo-admin.php
+++ b/plugins/zen-seo-lite/admin/class-zen-seo-admin.php
@@ -687,6 +687,10 @@ class Zen_SEO_Admin
             return;
         }
 
+        if (!\current_user_can('manage_options')) {
+            return;
+        }
+
         // 1. Handle Export
         $export_requested = isset($_POST['zen_seo_export']);
         if ($export_requested && \check_admin_referer('zen_seo_export_action')) {

--- a/plugins/zen-seo-lite/admin/class-zen-seo-admin.php
+++ b/plugins/zen-seo-lite/admin/class-zen-seo-admin.php
@@ -566,9 +566,7 @@ class Zen_SEO_Admin
         }
 
         // Handle cache clear action
-        $clear_cache_requested = isset($_POST['zen_seo_clear_cache'])
-            ? (bool) \sanitize_text_field(\wp_unslash($_POST['zen_seo_clear_cache']))
-            : false;
+        $clear_cache_requested = isset($_POST['zen_seo_clear_cache']);
         if ($clear_cache_requested && \check_admin_referer('zen_seo_clear_cache')) {
             $cleared = Zen_SEO_Cache::clear_all();
             echo '<div class="notice notice-success"><p>'
@@ -690,9 +688,7 @@ class Zen_SEO_Admin
         }
 
         // 1. Handle Export
-        $export_requested = isset($_POST['zen_seo_export'])
-            ? (bool) \sanitize_text_field(\wp_unslash($_POST['zen_seo_export']))
-            : false;
+        $export_requested = isset($_POST['zen_seo_export']);
         if ($export_requested && \check_admin_referer('zen_seo_export_action')) {
             $settings = Zen_SEO_Helpers::get_global_settings();
             $filename = 'zen-seo-backup-' . \date('Y-m-d') . '.json';
@@ -707,19 +703,26 @@ class Zen_SEO_Admin
         }
 
         // 2. Handle Import
-        $import_requested = isset($_POST['zen_seo_import'])
-            ? (bool) \sanitize_text_field(\wp_unslash($_POST['zen_seo_import']))
-            : false;
+        $import_requested = isset($_POST['zen_seo_import']);
         if ($import_requested && \check_admin_referer('zen_seo_import_action')) {
-            $import_file = isset($_FILES['import_file']['tmp_name'])
-                ? \sanitize_text_field(\wp_unslash($_FILES['import_file']['tmp_name']))
+            $import_file = isset($_FILES['import_file']) && \is_array($_FILES['import_file'])
+                ? $_FILES['import_file']
+                : [];
+            $import_file_path = isset($import_file['tmp_name']) && \is_string($import_file['tmp_name'])
+                ? $import_file['tmp_name']
                 : '';
-            if (empty($import_file)) {
+            $upload_error = isset($import_file['error']) ? (int) $import_file['error'] : \UPLOAD_ERR_NO_FILE;
+
+            if (\UPLOAD_ERR_OK !== $upload_error || '' === $import_file_path || !\is_uploaded_file($import_file_path)) {
                 \add_settings_error('zen_seo_tools', 'no_file', __('Please select a file to import.', 'zen-seo'), 'error');
                 return;
             }
 
-            $file_content = \file_get_contents($import_file);
+            $file_content = \file_get_contents($import_file_path);
+            if (false === $file_content) {
+                \add_settings_error('zen_seo_tools', 'invalid_file', __('Unable to read the backup file.', 'zen-seo'), 'error');
+                return;
+            }
             $data = \json_decode($file_content, true);
 
             if (!$data || !\is_array($data)) {

--- a/plugins/zen-seo-lite/admin/class-zen-seo-meta-box.php
+++ b/plugins/zen-seo-lite/admin/class-zen-seo-meta-box.php
@@ -343,7 +343,8 @@ class Zen_SEO_Meta_Box
     public function save_meta_data($post_id, $post)
     {
         // Security checks
-        if (!isset($_POST['zen_seo_nonce']) || !\wp_verify_nonce($_POST['zen_seo_nonce'], 'zen_seo_meta_box')) {
+        $nonce = isset($_POST['zen_seo_nonce']) ? \sanitize_text_field(\wp_unslash($_POST['zen_seo_nonce'])) : '';
+        if (!$nonce || !\wp_verify_nonce($nonce, 'zen_seo_meta_box')) {
             return;
         }
 
@@ -361,10 +362,12 @@ class Zen_SEO_Meta_Box
         }
 
         // Sanitize and save data
-        if (isset($_POST['zen_seo'])) {
+        $zen_seo_data = isset($_POST['zen_seo']) ? \wp_unslash($_POST['zen_seo']) : [];
+        if (\is_array($zen_seo_data)) {
             $sanitized = [];
 
-            foreach ($_POST['zen_seo'] as $key => $value) {
+            foreach ($zen_seo_data as $key => $value) {
+                $key = \sanitize_key($key);
                 switch ($key) {
                     case 'noindex':
                         $sanitized[$key] = !empty($value) ? 1 : 0;

--- a/plugins/zen-seo-lite/admin/class-zen-seo-meta-box.php
+++ b/plugins/zen-seo-lite/admin/class-zen-seo-meta-box.php
@@ -368,6 +368,10 @@ class Zen_SEO_Meta_Box
 
             foreach ($zen_seo_data as $key => $value) {
                 $key = \sanitize_key($key);
+                if (!\is_scalar($value)) {
+                    continue;
+                }
+
                 switch ($key) {
                     case 'noindex':
                         $sanitized[$key] = !empty($value) ? 1 : 0;

--- a/plugins/zeneyer-auth/uninstall.php
+++ b/plugins/zeneyer-auth/uninstall.php
@@ -10,8 +10,23 @@ delete_option('zeneyer_auth_audit_log');
 
 // Delete user meta
 global $wpdb;
-$wpdb->query("DELETE FROM {$wpdb->usermeta} WHERE meta_key LIKE 'zeneyer_%'");
+$wpdb->query(
+    $wpdb->prepare(
+        "DELETE FROM {$wpdb->usermeta} WHERE meta_key LIKE %s",
+        'zeneyer_%'
+    )
+);
 
 // Delete transients
-$wpdb->query("DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_zeneyer_%'");
-$wpdb->query("DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_timeout_zeneyer_%'");
+$wpdb->query(
+    $wpdb->prepare(
+        "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
+        '_transient_zeneyer_%'
+    )
+);
+$wpdb->query(
+    $wpdb->prepare(
+        "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
+        '_transient_timeout_zeneyer_%'
+    )
+);


### PR DESCRIPTION
## Summary
- sanitize and unslash Zen SEO admin/meta-box superglobal reads before use
- prepare ZenEyer Auth uninstall cleanup queries for WPCS consistency
- leave zengame uninstall unchanged because it already prepares its cleanup query

## Validation
- php -l plugins/zen-seo-lite/admin/class-zen-seo-meta-box.php
- php -l plugins/zen-seo-lite/admin/class-zen-seo-admin.php
- php -l plugins/zeneyer-auth/uninstall.php
- npm run utf8:check
- git diff --check

## Notes
PHPCS/PHPStan are not available in this checkout, so this PR keeps the fix narrow and focused on the audit findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Melhorada a confiabilidade das ações no painel admin, com validações mais seguras para limpar cache, exportar e importar configurações.
  * O fluxo de importação agora lida melhor com arquivos ausentes ou inválidos, reduzindo falhas no processamento.
  * Ajustes na edição de metadados tornam o salvamento mais consistente e protegido contra entradas inválidas.
* **Chores**
  * A remoção do plugin foi refinada para limpar dados de forma mais segura no banco.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->