### PR TITLE
Adiciona locks atômicos em streak e rate-limit

### DIFF
--- a/plugins/zeneyer-auth/includes/Core/class-rate-limiter.php
+++ b/plugins/zeneyer-auth/includes/Core/class-rate-limiter.php
@@ -64,6 +64,13 @@ class Rate_Limiter {
         $ip = self::get_client_ip();
         $key = self::get_transient_key($ip, $action);
 
+        // Sem lock, requisições paralelas do mesmo IP (ex: brute force automatizado)
+        // poderiam ler a mesma contagem antiga e a tentativa acabaria não sendo contada
+        // para todas. GET_LOCK é atômico no MySQL e não exige Redis.
+        global $wpdb;
+        $lock_name = 'zeneyer_rl_' . \md5($ip . $action);
+        $lock_acquired = (bool) $wpdb->get_var($wpdb->prepare('SELECT GET_LOCK(%s, 3)', $lock_name));
+
         $attempts = (int) get_transient($key);
         $attempts++;
 
@@ -72,6 +79,10 @@ class Rate_Limiter {
         $duration = apply_filters('zeneyer_auth_lockout_duration', $duration, $action);
 
         set_transient($key, $attempts, $duration);
+
+        if ($lock_acquired) {
+            $wpdb->query($wpdb->prepare('SELECT RELEASE_LOCK(%s)', $lock_name));
+        }
 
         do_action('zeneyer_auth_rate_limit_incremented', $ip, $action, $attempts);
 

--- a/plugins/zeneyer-auth/includes/Core/class-rate-limiter.php
+++ b/plugins/zeneyer-auth/includes/Core/class-rate-limiter.php
@@ -64,23 +64,36 @@ class Rate_Limiter {
         $ip = self::get_client_ip();
         $key = self::get_transient_key($ip, $action);
 
+        $options = get_option('zeneyer_auth_settings', []);
+        $max_attempts = isset($options['rate_limit_attempts']) ? (int) $options['rate_limit_attempts'] : self::MAX_ATTEMPTS;
+        $max_attempts = apply_filters('zeneyer_auth_max_attempts', $max_attempts, $action);
+        $duration = isset($options['rate_limit_duration']) ? (int) $options['rate_limit_duration'] : self::LOCKOUT_DURATION;
+        $duration = apply_filters('zeneyer_auth_lockout_duration', $duration, $action);
+
         // Sem lock, requisições paralelas do mesmo IP (ex: brute force automatizado)
         // poderiam ler a mesma contagem antiga e a tentativa acabaria não sendo contada
         // para todas. GET_LOCK é atômico no MySQL e não exige Redis.
         global $wpdb;
         $lock_name = 'zeneyer_rl_' . \md5($ip . $action);
-        $lock_acquired = (bool) $wpdb->get_var($wpdb->prepare('SELECT GET_LOCK(%s, 3)', $lock_name));
+        $lock_acquired = (bool) $wpdb->get_var($wpdb->prepare('SELECT GET_LOCK(%s, 1)', $lock_name));
 
-        $attempts = (int) get_transient($key);
-        $attempts++;
+        if (!$lock_acquired) {
+            \wp_cache_delete('_transient_' . $key, 'options');
+            \wp_cache_delete('_transient_timeout_' . $key, 'options');
+            set_transient($key, $max_attempts, $duration);
+            self::log_audit_event('rate_limit_lock_timeout', 0, $ip, ['action' => $action]);
+            return;
+        }
 
-        $options = get_option('zeneyer_auth_settings', []);
-        $duration = isset($options['rate_limit_duration']) ? (int) $options['rate_limit_duration'] : self::LOCKOUT_DURATION;
-        $duration = apply_filters('zeneyer_auth_lockout_duration', $duration, $action);
+        try {
+            \wp_cache_delete('_transient_' . $key, 'options');
+            \wp_cache_delete('_transient_timeout_' . $key, 'options');
 
-        set_transient($key, $attempts, $duration);
+            $attempts = (int) get_transient($key);
+            $attempts++;
 
-        if ($lock_acquired) {
+            set_transient($key, $attempts, $duration);
+        } finally {
             $wpdb->query($wpdb->prepare('SELECT RELEASE_LOCK(%s)', $lock_name));
         }
 

--- a/plugins/zengame/includes/API/class-rest-handler.php
+++ b/plugins/zengame/includes/API/class-rest-handler.php
@@ -123,16 +123,23 @@ final class REST_Handler
     }
 
     /**
-     * Global Leaderboard Endpoint
+     * Global Leaderboard Endpoint.
+     *
+     * Site pequeno (DJ), sem tráfego de e-commerce em escala — top 5 cobre o uso real
+     * (única chamada no frontend é `useLeaderboardQuery(5)`). Fixar o limite simplifica
+     * a chave de cache (uma só, em vez de uma por variante de limit) e reduz o custo
+     * do UNION ALL sobre wp_usermeta a cada cache-miss.
      */
+    private const LEADERBOARD_LIMIT = 5;
+
     public static function get_leaderboard($request)
     {
         if (!\defined('GAMIPRESS_VER')) {
             return new WP_Error('engine_off', 'GamiPress not found', ['status' => 503]);
         }
 
-        $limit = \max(1, \min(50, (int) ($request->get_param('limit') ?: 10)));
-        $cache_key = 'djz_gamipress_leaderboard_' . \ZenEyer\Game\ZenGame::CACHE_VERSION . '_' . $limit;
+        $limit = self::LEADERBOARD_LIMIT;
+        $cache_key = 'djz_gamipress_leaderboard_' . \ZenEyer\Game\ZenGame::CACHE_VERSION;
         $cached = \get_transient($cache_key);
         if (false !== $cached) {
             return \rest_ensure_response($cached);

--- a/plugins/zengame/includes/API/class-rest-handler.php
+++ b/plugins/zengame/includes/API/class-rest-handler.php
@@ -123,23 +123,16 @@ final class REST_Handler
     }
 
     /**
-     * Global Leaderboard Endpoint.
-     *
-     * Site pequeno (DJ), sem tráfego de e-commerce em escala — top 5 cobre o uso real
-     * (única chamada no frontend é `useLeaderboardQuery(5)`). Fixar o limite simplifica
-     * a chave de cache (uma só, em vez de uma por variante de limit) e reduz o custo
-     * do UNION ALL sobre wp_usermeta a cada cache-miss.
+     * Global Leaderboard Endpoint
      */
-    private const LEADERBOARD_LIMIT = 5;
-
     public static function get_leaderboard($request)
     {
         if (!\defined('GAMIPRESS_VER')) {
             return new WP_Error('engine_off', 'GamiPress not found', ['status' => 503]);
         }
 
-        $limit = self::LEADERBOARD_LIMIT;
-        $cache_key = 'djz_gamipress_leaderboard_' . \ZenEyer\Game\ZenGame::CACHE_VERSION;
+        $limit = \max(1, \min(50, (int) ($request->get_param('limit') ?: 10)));
+        $cache_key = 'djz_gamipress_leaderboard_' . \ZenEyer\Game\ZenGame::CACHE_VERSION . '_' . $limit;
         $cached = \get_transient($cache_key);
         if (false !== $cached) {
             return \rest_ensure_response($cached);

--- a/plugins/zengame/includes/Core/class-zengame-engine.php
+++ b/plugins/zengame/includes/Core/class-zengame-engine.php
@@ -225,6 +225,10 @@ final class Engine
         $user_id = $user->ID;
         $today = \current_time('Y-m-d');
 
+        if ((string) \get_user_meta($user_id, 'zen_last_login', true) === $today) {
+            return;
+        }
+
         // wp_login (login normal) e rest_pre_dispatch (retorno via JWT) podem disparar
         // quase ao mesmo tempo em requisições paralelas (ex: várias abas abrindo juntas).
         // Sem lock, ambas leriam o mesmo streak antigo e a contagem ficaria errada
@@ -239,7 +243,11 @@ final class Engine
             return;
         }
 
+        $updated = false;
+
         try {
+            \wp_cache_delete($user_id, 'user_meta');
+
             $last = (string) \get_user_meta($user_id, 'zen_last_login', true);
             if ($last === $today) return;
 
@@ -252,9 +260,13 @@ final class Engine
 
             \update_user_meta($user_id, 'zen_last_login', $today);
             \update_user_meta($user_id, 'zen_login_streak', $streak);
-            $this->clear_user_cache($user_id);
+            $updated = true;
         } finally {
             $wpdb->query($wpdb->prepare('SELECT RELEASE_LOCK(%s)', $lock_name));
+        }
+
+        if ($updated) {
+            $this->clear_user_cache($user_id);
         }
     }
 
@@ -277,8 +289,11 @@ final class Engine
         \delete_transient('djz_stats_events_' . $user_id);
         \delete_transient('djz_stats_tracks_' . $user_id);
 
-        // Leaderboard (top 5) muda sempre que os pontos de qualquer usuário mudam.
-        \delete_transient('djz_gamipress_leaderboard_' . \ZenEyer\Game\ZenGame::CACHE_VERSION);
+        // Leaderboard rankings change whenever any user's points change.
+        // Clear the most common limit variants so the next request fetches fresh data.
+        foreach ([5, 10, 25, 50] as $limit) {
+            \delete_transient('djz_gamipress_leaderboard_' . \ZenEyer\Game\ZenGame::CACHE_VERSION . '_' . $limit);
+        }
     }
 
     /**

--- a/plugins/zengame/includes/Core/class-zengame-engine.php
+++ b/plugins/zengame/includes/Core/class-zengame-engine.php
@@ -224,19 +224,38 @@ final class Engine
     {
         $user_id = $user->ID;
         $today = \current_time('Y-m-d');
-        $last = (string) \get_user_meta($user_id, 'zen_last_login', true);
-        $streak = (int) \get_user_meta($user_id, 'zen_login_streak', true);
 
-        if ($last === $today) return;
+        // wp_login (login normal) e rest_pre_dispatch (retorno via JWT) podem disparar
+        // quase ao mesmo tempo em requisições paralelas (ex: várias abas abrindo juntas).
+        // Sem lock, ambas leriam o mesmo streak antigo e a contagem ficaria errada
+        // (double count ou update perdido). GET_LOCK é atômico no MySQL e não exige Redis.
+        global $wpdb;
+        $lock_name = 'zengame_streak_' . $user_id;
+        $lock_acquired = (bool) $wpdb->get_var($wpdb->prepare('SELECT GET_LOCK(%s, 5)', $lock_name));
 
-        // Calcular "ontem" a partir de $today (já no timezone do WP) para evitar
-        // discrepância entre date() (PHP/UTC) e current_time() (WP timezone).
-        $yesterday = \date('Y-m-d', \strtotime($today . ' -1 day'));
-        $streak = ($last === $yesterday) ? $streak + 1 : 1;
+        if (!$lock_acquired) {
+            // Outra requisição já está atualizando o streak deste usuário agora;
+            // preferimos pular a atualizar do que arriscar uma contagem incorreta.
+            return;
+        }
 
-        \update_user_meta($user_id, 'zen_last_login', $today);
-        \update_user_meta($user_id, 'zen_login_streak', $streak);
-        $this->clear_user_cache($user_id);
+        try {
+            $last = (string) \get_user_meta($user_id, 'zen_last_login', true);
+            if ($last === $today) return;
+
+            $streak = (int) \get_user_meta($user_id, 'zen_login_streak', true);
+
+            // Calcular "ontem" a partir de $today (já no timezone do WP) para evitar
+            // discrepância entre date() (PHP/UTC) e current_time() (WP timezone).
+            $yesterday = \date('Y-m-d', \strtotime($today . ' -1 day'));
+            $streak = ($last === $yesterday) ? $streak + 1 : 1;
+
+            \update_user_meta($user_id, 'zen_last_login', $today);
+            \update_user_meta($user_id, 'zen_login_streak', $streak);
+            $this->clear_user_cache($user_id);
+        } finally {
+            $wpdb->query($wpdb->prepare('SELECT RELEASE_LOCK(%s)', $lock_name));
+        }
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -258,11 +277,8 @@ final class Engine
         \delete_transient('djz_stats_events_' . $user_id);
         \delete_transient('djz_stats_tracks_' . $user_id);
 
-        // Leaderboard rankings change whenever any user's points change.
-        // Clear the most common limit variants so the next request fetches fresh data.
-        foreach ([5, 10, 25, 50] as $limit) {
-            \delete_transient('djz_gamipress_leaderboard_' . \ZenEyer\Game\ZenGame::CACHE_VERSION . '_' . $limit);
-        }
+        // Leaderboard (top 5) muda sempre que os pontos de qualquer usuário mudam.
+        \delete_transient('djz_gamipress_leaderboard_' . \ZenEyer\Game\ZenGame::CACHE_VERSION);
     }
 
     /**


### PR DESCRIPTION
## Description

Corrige duas races reais de read-after-write em contadores compartilhados sem adicionar Redis/Memcached:

- `Rate_Limiter::increment()` agora serializa o read/modify/write do transient com `GET_LOCK()`, invalida o cache runtime de transients antes de reler e falha fechado quando não consegue adquirir o lock.
- `Engine::update_login_streak()` mantém o fast path barato quando o streak já foi atualizado hoje, mas relê `user_meta` após adquirir o lock para evitar cache stale em requisições paralelas.
- A invalidação de cache do usuário foi movida para fora da seção crítica do lock.
- A mudança anterior que fixava `/zengame/v1/leaderboard` em top 5 foi revertida para preservar o contrato público `?limit=` e as chaves de cache por limite.

## Type of Change
- [x] Backend (WordPress PHP)
- [x] Bug fix
- [x] Security hardening

## Testing
- [x] `php -l plugins/zeneyer-auth/includes/Core/class-rate-limiter.php`
- [x] `php -l plugins/zengame/includes/Core/class-zengame-engine.php`
- [x] `php -l plugins/zengame/includes/API/class-rest-handler.php`
- [x] `git diff --check`
- [ ] Local WordPress/MySQL concurrency test not run; no local WP/MySQL stack is available in this worktree.
- [ ] `npm run lint` / `npm run test` not run; isolated worktree has no `node_modules` (`eslint`/`vitest` unavailable). CI should cover these gates.

## Review Notes

This update addresses the blocking review feedback around fail-open rate-limit behavior and stale WordPress runtime cache after waiting on MySQL advisory locks. It also removes the leaderboard contract change to keep this PR focused on concurrency.