### PR TITLE
Remove unused global hero preload

### DIFF
--- a/header.php
+++ b/header.php
@@ -20,11 +20,6 @@
     
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <link rel="icon" type="image/png" sizes="96x96" href="/favicon-96x96.png">
-    
-    <link rel="preload" as="image"
-      imagesrcset="/images/hero-background-mediterranean-mobile.webp 900w, /images/hero-background-mediterranean-1440.webp 1440w, /images/hero-background-mediterranean.webp 1920w"
-      imagesizes="100vw"
-      fetchpriority="high">
     <!-- Preconnect para Google Fonts — carregamento async gerenciado pelo LiteSpeed Cache (optm-ggfonts_async) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -63,21 +63,18 @@ const HOME_HERO_IMAGES: Record<SiteTheme, {
   defaultSrc: string;
   mobileSrc: string;
   desktopSrcSet: string;
-  preloadDesktop: string;
   imageClassName: string;
 }> = {
   'mediterranean-dusk': {
     defaultSrc: '/images/hero-background-mediterranean-1440.webp',
     mobileSrc: '/images/hero-background-mediterranean-mobile.webp',
     desktopSrcSet: '/images/hero-background-mediterranean-1440.webp 1440w, /images/hero-background-mediterranean.webp?v=2 1920w',
-    preloadDesktop: '/images/hero-background-mediterranean-1440.webp',
     imageClassName: 'opacity-90',
   },
   'zen-night': {
     defaultSrc: '/images/hero-background.webp',
     mobileSrc: '/images/hero-background-mobile.webp',
     desktopSrcSet: '/images/hero-background-1440.webp 1440w, /images/hero-background.webp 1920w',
-    preloadDesktop: '/images/hero-background-1440.webp',
     imageClassName: 'opacity-65',
   },
 };
@@ -211,14 +208,6 @@ const HomePage: React.FC = () => {
             href: heroImages.mobileSrc,
             as: 'image',
             media: '(max-width: 768px), (orientation: portrait)',
-            fetchPriority: 'high',
-          },
-          {
-            href: heroImages.preloadDesktop,
-            as: 'image',
-            media: '(min-width: 769px) and (orientation: landscape)',
-            imageSrcSet: heroImages.desktopSrcSet,
-            imageSizes: '100vw',
             fetchPriority: 'high',
           },
         ]}


### PR DESCRIPTION
## Summary
- remove the global hero image preload from the WordPress header template
- stop preloading the desktop hero candidate from React SEO metadata
- keep eager loading and fetchPriority on the home hero image itself

## Why
The global preload made non-home routes preload the home hero image, producing browser warnings such as “preloaded but not used”. The desktop-specific preload could also mismatch the actual srcset candidate selected by the browser.

## Validation
- git diff --check
- CI pending