### PR TITLE
chore: tighten automated review guardrails

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,16 +6,21 @@ language: 'pt-BR'
 
 tone_instructions: |
   Responda sempre em Português Brasileiro.
-  Seja direto e conciso. Priorize bugs reais, riscos de segurança e violações das
-  regras do projeto. Evite elogios genéricos ou comentários sobre style sem impacto.
+  Seja direto e conciso. Comente somente quando houver bug funcional, risco de
+  segurança, regressão, quebra de contrato ou violação explícita das regras do
+  projeto. Não comente estilo, preferências, renomeações, micro-otimizações,
+  elogios genéricos ou oportunidades hipotéticas. Antes de reportar N+1 em
+  WordPress, verifique se update_meta_cache() ou _prime_post_caches() já aquece
+  o cache. Antes de sugerir Promise.all(), confirme que a execução sequencial
+  não implementa failover, rate limit, bounded concurrency ou early return.
 
 reviews:
-  profile: 'assertive'
+  profile: 'chill'
   request_changes_workflow: true
   auto_review:
     enabled: true
     auto_incremental_review: true
-  high_level_summary: true
+  high_level_summary: false
   high_level_summary_placeholder: '@coderabbitai resumo'
   poem: false
   collapse_walkthrough: true
@@ -119,4 +124,4 @@ reviews:
         - Puppeteer: .puppeteerrc.cjs tem skipDownload:true — Chrome só é instalado no CI via `npx puppeteer browsers install chrome`.
 
 chat:
-  auto_reply: true
+  auto_reply: false

--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -8,7 +8,9 @@ memory_config:
   disabled: false
 
 code_review:
-  disable: false
+  # CodeRabbit is the automatic reviewer. Keep Gemini available for explicit
+  # prompts outside the automatic PR review loop to avoid duplicate summaries.
+  disable: true
   # Postar apenas problemas de severidade MEDIUM ou superior.
   # LOW = style nit; MEDIUM = bug potencial; HIGH = bug confirmado; CRITICAL = segurança/dados
   comment_severity_threshold: MEDIUM
@@ -16,24 +18,23 @@ code_review:
   max_review_comments: 25
   pull_request_opened:
     help: false
-    # Resumo automático do PR — útil para PRs criados por bots (Jules, Bolt)
-    summary: true
-    code_review: true
+    summary: false
+    code_review: false
     # Não revisar drafts — aguardar o PR estar pronto
     include_drafts: false
 
 # Ignorar arquivos que não são código do projeto
 ignore_patterns:
-  - "dist/**"
-  - "dist-debug/**"
-  - ".claude/**"
-  - ".agents/**"
-  - ".bolt/**"
-  - ".gemini/**"
-  - ".jules/**"
-  - ".devcontainer/**"
-  - "plugins/gamipress/**"
-  - "**/*.lock"
-  - "public/sitemap*.xml"
-  - "pr_comments_utf8.json"
-  - "PressKitPage_beautiful.tsx"
+  - 'dist/**'
+  - 'dist-debug/**'
+  - '.claude/**'
+  - '.agents/**'
+  - '.bolt/**'
+  - '.gemini/**'
+  - '.jules/**'
+  - '.devcontainer/**'
+  - 'plugins/gamipress/**'
+  - '**/*.lock'
+  - 'public/sitemap*.xml'
+  - 'pr_comments_utf8.json'
+  - 'PressKitPage_beautiful.tsx'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,11 @@ updates:
       dependencies:
         patterns:
           - "*"
+        # Routine automation must never hide a major toolchain migration inside
+        # a patch/minor bundle. Major updates remain isolated PRs for review.
+        update-types:
+          - "patch"
+          - "minor"
 
   - package-ecosystem: "composer"
     directory: "/plugins/zeneyer-auth"

--- a/.github/workflows/trigger-bot-reviews.yml
+++ b/.github/workflows/trigger-bot-reviews.yml
@@ -2,12 +2,12 @@ name: Trigger Bot Reviews
 
 # CodeRabbit needs an explicit prompt on bot-created PRs, but repeated prompts
 # create noisy review loops. This workflow posts at most one CodeRabbit trigger
-# comment per PR. Codex is intentionally not auto-triggered here until the
-# GitHub connector is configured; otherwise it only replies with setup noise.
+# comment per PR. Codex remains an on-demand deep reviewer until its GitHub
+# connector is configured; otherwise automatic mentions only create setup noise.
 
 on:
   pull_request_target:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review, labeled]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -26,7 +26,18 @@ concurrency:
 jobs:
   trigger-reviews:
     name: Trigger CodeRabbit
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]' && contains(github.event.pull_request.labels.*.name, 'needs-ai-review')) }}
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.actor != 'github-actions[bot]' &&
+          (
+            contains(github.event.pull_request.labels.*.name, 'needs-ai-review') ||
+            github.actor == 'dependabot[bot]' ||
+            github.actor == 'google-labs-jules[bot]'
+          )
+        )
+      }}
     runs-on: ubuntu-latest
     steps:
       - name: Trigger CodeRabbit review once
@@ -65,6 +76,6 @@ jobs:
                 marker,
                 '@coderabbitai review',
                 '',
-                'Revisar bugs, regressoes, performance, SEO e aderencia as regras do projeto.',
+                'Revisar somente bugs funcionais, regressoes, seguranca, quebra de contrato, SEO e violacoes explicitas das regras do projeto. Ignorar estilo, elogios, renomeacoes, micro-otimizacoes e oportunidades hipoteticas.',
               ].join('\n'),
             });

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,7 @@
+# Qodo remains available through explicit slash commands, but must not post
+# automatic reviews, summaries, suggestions, or CI feedback on every PR.
+[github_app]
+pr_commands = []
+
+[checks]
+enable_auto_checks_feedback = false


### PR DESCRIPTION
## Summary
- keep major npm upgrades out of routine Dependabot groups
- trigger one CodeRabbit review for Dependabot and Jules PRs
- reduce CodeRabbit style, summary, chat, micro-optimization, false N+1, and unsafe Promise.all noise

## Validation
- Prettier check passed for edited CodeRabbit/workflow YAML
- git diff --check passed
- original worktree was not modified