### PR TITLE
ci: automate focused AI reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,14 +5,9 @@
 language: 'pt-BR'
 
 tone_instructions: |
-  Responda sempre em Português Brasileiro.
-  Seja direto e conciso. Comente somente quando houver bug funcional, risco de
-  segurança, regressão, quebra de contrato ou violação explícita das regras do
-  projeto. Não comente estilo, preferências, renomeações, micro-otimizações,
-  elogios genéricos ou oportunidades hipotéticas. Antes de reportar N+1 em
-  WordPress, verifique se update_meta_cache() ou _prime_post_caches() já aquece
-  o cache. Antes de sugerir Promise.all(), confirme que a execução sequencial
-  não implementa failover, rate limit, bounded concurrency ou early return.
+  Responda em português brasileiro. Comente apenas bugs, regressões, segurança,
+  contratos ou regras explícitas do projeto. Ignore estilo, elogios, renomeações,
+  micro-otimizações e hipóteses sem evidência.
 
 reviews:
   profile: 'chill'

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -20,7 +20,7 @@ reviews:
   auto_review:
     enabled: true
     auto_incremental_review: true
-  high_level_summary: false
+  high_level_summary: true
   high_level_summary_placeholder: '@coderabbitai resumo'
   poem: false
   collapse_walkthrough: true
@@ -28,9 +28,6 @@ reviews:
   path_filters:
     - '!dist/**'
     - '!dist-debug/**'
-    - '!.claude/**'
-    - '!.bolt/**'
-    - '!.gemini/**'
     - '!plugins/gamipress/**'
     - '!**/*.lock'
     - '!public/sitemap*.xml'

--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -18,7 +18,7 @@ code_review:
   max_review_comments: 25
   pull_request_opened:
     help: false
-    summary: true
+    summary: false
     code_review: true
     # Não revisar drafts — aguardar o PR estar pronto
     include_drafts: false

--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -8,9 +8,9 @@ memory_config:
   disabled: false
 
 code_review:
-  # CodeRabbit is the automatic reviewer. Keep Gemini available for explicit
-  # prompts outside the automatic PR review loop to avoid duplicate summaries.
-  disable: true
+  # Automatic second opinion for every ready PR. MEDIUM threshold keeps the
+  # feedback actionable while CodeRabbit supplies the broader summary.
+  disable: false
   # Postar apenas problemas de severidade MEDIUM ou superior.
   # LOW = style nit; MEDIUM = bug potencial; HIGH = bug confirmado; CRITICAL = segurança/dados
   comment_severity_threshold: MEDIUM
@@ -18,8 +18,8 @@ code_review:
   max_review_comments: 25
   pull_request_opened:
     help: false
-    summary: false
-    code_review: false
+    summary: true
+    code_review: true
     # Não revisar drafts — aguardar o PR estar pronto
     include_drafts: false
 
@@ -27,12 +27,6 @@ code_review:
 ignore_patterns:
   - 'dist/**'
   - 'dist-debug/**'
-  - '.claude/**'
-  - '.agents/**'
-  - '.bolt/**'
-  - '.gemini/**'
-  - '.jules/**'
-  - '.devcontainer/**'
   - 'plugins/gamipress/**'
   - '**/*.lock'
   - 'public/sitemap*.xml'

--- a/.github/workflows/trigger-bot-reviews.yml
+++ b/.github/workflows/trigger-bot-reviews.yml
@@ -1,13 +1,12 @@
 name: Trigger Bot Reviews
 
-# CodeRabbit needs an explicit prompt on bot-created PRs, but repeated prompts
-# create noisy review loops. This workflow posts at most one CodeRabbit trigger
-# comment per PR. Codex remains an on-demand deep reviewer until its GitHub
-# connector is configured; otherwise automatic mentions only create setup noise.
+# CodeRabbit auto-reviews ordinary PRs through .coderabbit.yaml. Bot-authored
+# PRs can require an explicit prompt, so this workflow posts one prompt per PR
+# without requiring a label or human action.
 
 on:
   pull_request_target:
-    types: [opened, reopened, synchronize, ready_for_review, labeled]
+    types: [opened, reopened, synchronize, ready_for_review]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -20,24 +19,13 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: bot-review-trigger-${{ github.event.pull_request.base.ref || format('manual-pr-{0}', inputs.pr_number) }}
+  group: bot-review-trigger-${{ github.event.pull_request.number || inputs.pr_number }}
   cancel-in-progress: false
 
 jobs:
   trigger-reviews:
     name: Trigger CodeRabbit
-    if: >-
-      ${{
-        github.event_name == 'workflow_dispatch' ||
-        (
-          github.actor != 'github-actions[bot]' &&
-          (
-            contains(github.event.pull_request.labels.*.name, 'needs-ai-review') ||
-            github.actor == 'dependabot[bot]' ||
-            github.actor == 'google-labs-jules[bot]'
-          )
-        )
-      }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.pull_request.draft == false && github.event.pull_request.user.type == 'Bot') }}
     runs-on: ubuntu-latest
     steps:
       - name: Trigger CodeRabbit review once

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,7 +1,24 @@
-# Qodo remains available through explicit slash commands, but must not post
-# automatic reviews, summaries, suggestions, or CI feedback on every PR.
-[github_app]
-pr_commands = []
+# Repository-level review guidance for Qodo Code Review.
 
-[checks]
-enable_auto_checks_feedback = false
+[github_app]
+pr_commands = [
+  "/agentic_describe",
+  "/agentic_review",
+]
+
+[review_agent]
+comments_location_policy = "both"
+inline_comments_severity_threshold = 2
+issues_user_guidelines = """
+Prioritize correctness, security, regressions, performance problems with measurable impact,
+SEO/schema failures, authentication boundaries, WordPress/PHP safety, and broken tests.
+Read AGENTS.md and the relevant repository context before reporting a finding. Do not report
+public artist payment/support fields or AI-training content signals as leaks: both are explicit
+product decisions. Avoid cosmetic style findings and speculative micro-optimizations.
+"""
+compliance_user_guidelines = """
+Enforce AGENTS.md and .agents/GUIDELINES.md. In particular, verify safeUrl fallbacks,
+loadingInitial route guards, bilingual i18n parity, MusicEvent required fields, WooCommerce CRUD
+instead of direct order SQL, GamiPress associative-array access, and the repository restrictions
+on tool major upgrades and generated artifacts.
+"""


### PR DESCRIPTION
## What changed

- restores automatic Gemini reviews at MEDIUM+ severity
- enables automatic Qodo agentic descriptions and reviews with project-specific guidance
- keeps CodeRabbit as the primary automatic reviewer with summaries
- triggers CodeRabbit once for any bot-authored ready PR without requiring labels
- reviews agent/context configuration files instead of silently excluding them
- scopes workflow concurrency per PR to avoid cross-PR contention

## Why

Reduce human review setup work while keeping automated feedback focused on actionable bugs, regressions, security, contracts, SEO, and explicit repository rules.

## Validation

- git diff --check
- workflow name validation
- GitHub Actions will validate the repository configuration on this PR