### PR TITLE
fix(security): nonce WordPress SSG bootstrap

### DIFF
--- a/index.php
+++ b/index.php
@@ -161,7 +161,18 @@ if ($serve_file) {
             'userId'   => get_current_user_id(),
             'themeUrl' => get_template_directory_uri(),
         ];
-        $wp_data_script = '<script>window.wpData=' . wp_json_encode($wp_data, JSON_UNESCAPED_SLASHES) . ';</script>';
+        // The SSG shell has a hash-based meta CSP, while this bridge is generated
+        // per request. Authorize it with the same nonce used by inc/csp.php.
+        $csp_nonce = djz_csp_nonce();
+        $wp_data_script = '<script nonce="' . esc_attr($csp_nonce) . '">window.wpData=' . wp_json_encode($wp_data, JSON_UNESCAPED_SLASHES) . ';</script>';
+
+        // A meta CSP is enforced in addition to the HTTP header, so both policies
+        // must authorize the request-scoped bootstrap script.
+        $html_content = str_replace(
+            "script-src 'self'",
+            "script-src 'self' 'nonce-" . esc_attr($csp_nonce) . "'",
+            $html_content
+        );
 
         if (strpos($html_content, 'window.wpData') === false) {
             $html_content = str_replace('</body>', $wp_data_script . "\n</body>", $html_content);

--- a/scripts/check-security-invariants.mjs
+++ b/scripts/check-security-invariants.mjs
@@ -5,6 +5,7 @@ import {
 } from './cloudflare-cache-rule.mjs';
 
 const html = readFileSync(new URL('../index.html', import.meta.url), 'utf8');
+const wordpressIndex = readFileSync(new URL('../index.php', import.meta.url), 'utf8');
 const failures = [];
 
 const cspMatch = html.match(
@@ -38,6 +39,15 @@ try {
   assertCacheRuleSafety(buildPublicHtmlCacheRule());
 } catch (error) {
   failures.push(error.message);
+}
+
+for (const requiredNonceFragment of [
+  `$wp_data_script = '<script nonce="' . esc_attr($csp_nonce)`,
+  `"script-src 'self' 'nonce-" . esc_attr($csp_nonce)`,
+]) {
+  if (!wordpressIndex.includes(requiredNonceFragment)) {
+    failures.push('WordPress SSG bridge must share the request CSP nonce');
+  }
 }
 
 if (failures.length) {


### PR DESCRIPTION
## Summary
- nonce the request-scoped WordPress wpData bootstrap
- inject the same nonce into the SSG meta CSP
- enforce the shared nonce bridge in security invariants

## Why
Lighthouse confirmed the static SSG hashes work, but WordPress adds wpData after build with request-varying content. A shared CSP nonce authorizes only that generated script without restoring unsafe-inline.

## Validation
- security invariants pass
- ESLint passes
- PHP syntax check passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correções de segurança**
  * Adicionado um nonce CSP exclusivo por requisição aos scripts inline do WordPress.
  * O nonce também é incluído na diretiva `script-src`, reforçando a proteção contra execução de scripts não autorizados.

* **Testes**
  * Ampliadas as verificações automatizadas para validar a aplicação correta do nonce CSP.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->